### PR TITLE
Eq-based PshIsoⱽ, refactor TerminalPshⱽ→ᴰ proofs for consistent style

### DIFF
--- a/Cubical/Categories/Displayed/Functor/More.agda
+++ b/Cubical/Categories/Displayed/Functor/More.agda
@@ -6,6 +6,7 @@ open import Cubical.Foundations.Prelude
 open import Cubical.Categories.Category.Base
 open import Cubical.Categories.Functor
 import      Cubical.Data.Equality as Eq
+import      Cubical.Data.Equality.More as Eq
 
 open import Cubical.Categories.Displayed.Base
 open import Cubical.Categories.Displayed.Functor
@@ -15,9 +16,6 @@ import      Cubical.Categories.Displayed.Reasoning as HomᴰReasoning
 private
   variable
     ℓ ℓB ℓB' ℓC ℓC' ℓCᴰ ℓCᴰ' ℓD ℓD' ℓDᴰ ℓDᴰ' ℓE ℓE' ℓEᴰ ℓEᴰ' : Level
-
-mixedHEq : {A0 A1 : Type ℓ} (Aeq : A0 Eq.≡ A1) (a0 : A0)(a1 : A1) → Type _
-mixedHEq Aeq a0 a1 = Eq.transport (λ A → A) Aeq a0 ≡ a1
 
 module _
   {C : Category ℓC ℓC'}{D : Category ℓD ℓD'}
@@ -100,7 +98,7 @@ module _
   reindF'' : (G : Functor C D)
              (GF-ob≡FF-ob : F .F-ob Eq.≡ G .F-ob)
              (GF-hom≡FF-hom :
-              mixedHEq (Eq.ap (λ F-ob₁ → ∀ {x} {y}
+              Eq.mixedHEq (Eq.ap (λ F-ob₁ → ∀ {x} {y}
                          → C [ x , y ] → D [ F-ob₁ x , F-ob₁ y ])
                          GF-ob≡FF-ob)
                 (F .F-hom)
@@ -153,3 +151,23 @@ module _ {C : Category ℓC ℓC'}
   open Functorᴰ
   _^opFⱽ : Functorⱽ (Cᴰ ^opᴰ) (Dᴰ ^opᴰ)
   _^opFⱽ = reindF' _ Eq.refl Eq.refl (Fⱽ ^opFᴰ)
+
+module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} {F : Functor C D}
+  {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'} {Dᴰ : Categoryᴰ D ℓDᴰ ℓDᴰ'}
+  (Fᴰ Gᴰ : Functorᴰ F Cᴰ Dᴰ)
+  where
+  private
+    module Cᴰ = Categoryᴰ Cᴰ
+    module Dᴰ = Categoryᴰ Dᴰ
+  open Functorᴰ
+  FunctorᴰEq : Type _
+  FunctorᴰEq =
+    Σ[ obᴰEq ∈ (Eq._≡_ {A = ∀ {x} → Cᴰ.ob[ x ] → Dᴰ.ob[ F ⟅ x ⟆ ]} (Fᴰ .F-obᴰ) (Gᴰ .F-obᴰ) ) ]
+    Eq.HEq
+      (Eq.ap (λ F-obᴰ → (∀ {x y} {f : C [ x , y ]} {xᴰ : Cᴰ.ob[ x ]} {yᴰ : Cᴰ.ob[ y ]}
+      → Cᴰ [ f ][ xᴰ , yᴰ ]
+      → Dᴰ [ F ⟪ f ⟫ ][ F-obᴰ xᴰ , F-obᴰ yᴰ ]))
+        obᴰEq)
+      (Fᴰ .F-homᴰ)
+      (Gᴰ .F-homᴰ)
+

--- a/Cubical/Categories/Displayed/Limits/BinProduct/Properties.agda
+++ b/Cubical/Categories/Displayed/Limits/BinProduct/Properties.agda
@@ -98,7 +98,7 @@ module _ {C : Category ℓC ℓC'} {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
     ⋆PshIsoᴰⱽ invPshIsoⱽ (PshProdⱽ≅ᴰ Pᴰ Qᴰ))
 
   ×ⱽRepr+π*→×ᴰRepr : UniversalElementᴰ Cᴰ p×q (Pᴰ ×ᴰPsh Qᴰ)
-  ×ⱽRepr+π*→×ᴰRepr = π₁*×ⱽπ₂* ◃PshIsoⱽᴰ ×ᴰ≅π₁*×ⱽπ₂*
+  ×ⱽRepr+π*→×ᴰRepr = π₁*×ⱽπ₂* ◁PshIsoⱽᴰ ×ᴰ≅π₁*×ⱽπ₂*
 
 module _ {C : Category ℓC ℓC'} {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
   {P : Presheaf C ℓP}{Q : Presheaf C ℓQ}
@@ -118,38 +118,39 @@ module _ {C : Category ℓC ℓC'} {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
     module P×Q = UniversalElementNotation P×Q
     module Cᴰ = Fibers Cᴰ
 
-  BinProductⱽ→PshProdReprᴰ : UniversalElementᴰ Cᴰ P×Q (Pᴰ ×ᴰPsh Qᴰ)
-  BinProductⱽ→PshProdReprᴰ .vertexᴰ = bpⱽ.vert
-  BinProductⱽ→PshProdReprᴰ .elementᴰ .fst = bpⱽ.π₁ Pᴰ.⋆ⱽᴰ π₁*P.π
-  BinProductⱽ→PshProdReprᴰ .elementᴰ .snd = bpⱽ.π₂ Qᴰ.⋆ⱽᴰ π₂*Q.π
-  BinProductⱽ→PshProdReprᴰ .universalᴰ .inv (f₁ , f₂) (fᴰ₁ , fᴰ₂) =
-    π₁*P.intro (Pᴰ.reind (sym $ cong fst $ P×Q.β) fᴰ₁) bpⱽ.,ⱽ π₂*Q.intro (Qᴰ.reind (sym $ cong snd $ P×Q.β) fᴰ₂)
-  BinProductⱽ→PshProdReprᴰ .universalᴰ .rightInv (f₁ , f₂) (fᴰ₁ , fᴰ₂) = ΣPathP
-    ( (Pᴰ.rectify $ Pᴰ.≡out $
-      (sym $ Pᴰ.⋆Assocᴰⱽᴰ _ _ _)
-      ∙ Pᴰ.⟨ bpⱽ.∫×βⱽ₁ ⟩⋆⟨ refl ⟩
-      ∙ π₁*P.β
-      ∙ (sym $ Pᴰ.reind-filler _ _)
-      )
-    , (Qᴰ.rectify $ Qᴰ.≡out $
-      (sym $ Qᴰ.⋆Assocᴰⱽᴰ _ _ _)
-      ∙ Qᴰ.⟨ bpⱽ.∫×βⱽ₂ ⟩⋆⟨ refl ⟩
-      ∙ π₂*Q.β
-      ∙ (sym $ Qᴰ.reind-filler _ _)))
-  BinProductⱽ→PshProdReprᴰ .universalᴰ .leftInv f fᴰ = Cᴰ.rectify $ Cᴰ.≡out $
-    bpⱽ.,ⱽ≡
-      (π₁*P.intro≡
-        ((sym $ Pᴰ.reind-filler _ _)
-        ∙ Pᴰ.⟨ refl ⟩⋆⟨ sym $ Pᴰ.reind-filler _ _ ⟩
-        ∙ (sym $ Pᴰ.⋆Assoc _ _ _)
-        ∙ Pᴰ.⟨ Cᴰ.reind-filler _ _ ∙ Cᴰ.reind-filler _ _ ⟩⋆⟨ refl ⟩)
-        ∙ (sym $ Cᴰ.reind-filler P×Q.η _))
-      (π₂*Q.intro≡
-        ((sym $ Qᴰ.reind-filler _ _)
-        ∙ Qᴰ.⟨ refl ⟩⋆⟨ sym $ Qᴰ.reind-filler _ _ ⟩
-        ∙ (sym $ Qᴰ.⋆Assoc _ _ _)
-        ∙ Qᴰ.⟨ Cᴰ.reind-filler _ _ ∙ Cᴰ.reind-filler _ _ ⟩⋆⟨ refl ⟩)
-        ∙ (sym $ Cᴰ.reind-filler P×Q.η _))
+    -- Old manual proof preserved in a private module for future reference
+    BinProductⱽ→PshProdReprᴰ : UniversalElementᴰ Cᴰ P×Q (Pᴰ ×ᴰPsh Qᴰ)
+    BinProductⱽ→PshProdReprᴰ .vertexᴰ = bpⱽ.vert
+    BinProductⱽ→PshProdReprᴰ .elementᴰ .fst = bpⱽ.π₁ Pᴰ.⋆ⱽᴰ π₁*P.π
+    BinProductⱽ→PshProdReprᴰ .elementᴰ .snd = bpⱽ.π₂ Qᴰ.⋆ⱽᴰ π₂*Q.π
+    BinProductⱽ→PshProdReprᴰ .universalᴰ .inv (f₁ , f₂) (fᴰ₁ , fᴰ₂) =
+      π₁*P.intro (Pᴰ.reind (sym $ cong fst $ P×Q.β) fᴰ₁) bpⱽ.,ⱽ π₂*Q.intro (Qᴰ.reind (sym $ cong snd $ P×Q.β) fᴰ₂)
+    BinProductⱽ→PshProdReprᴰ .universalᴰ .rightInv (f₁ , f₂) (fᴰ₁ , fᴰ₂) = ΣPathP
+      ( (Pᴰ.rectify $ Pᴰ.≡out $
+        (sym $ Pᴰ.⋆Assocᴰⱽᴰ _ _ _)
+        ∙ Pᴰ.⟨ bpⱽ.∫×βⱽ₁ ⟩⋆⟨ refl ⟩
+        ∙ π₁*P.β
+        ∙ (sym $ Pᴰ.reind-filler _ _)
+        )
+      , (Qᴰ.rectify $ Qᴰ.≡out $
+        (sym $ Qᴰ.⋆Assocᴰⱽᴰ _ _ _)
+        ∙ Qᴰ.⟨ bpⱽ.∫×βⱽ₂ ⟩⋆⟨ refl ⟩
+        ∙ π₂*Q.β
+        ∙ (sym $ Qᴰ.reind-filler _ _)))
+    BinProductⱽ→PshProdReprᴰ .universalᴰ .leftInv f fᴰ = Cᴰ.rectify $ Cᴰ.≡out $
+      bpⱽ.,ⱽ≡
+        (π₁*P.intro≡
+          ((sym $ Pᴰ.reind-filler _ _)
+          ∙ Pᴰ.⟨ refl ⟩⋆⟨ sym $ Pᴰ.reind-filler _ _ ⟩
+          ∙ (sym $ Pᴰ.⋆Assoc _ _ _)
+          ∙ Pᴰ.⟨ Cᴰ.reind-filler _ _ ∙ Cᴰ.reind-filler _ _ ⟩⋆⟨ refl ⟩)
+          ∙ (sym $ Cᴰ.reind-filler P×Q.η _))
+        (π₂*Q.intro≡
+          ((sym $ Qᴰ.reind-filler _ _)
+          ∙ Qᴰ.⟨ refl ⟩⋆⟨ sym $ Qᴰ.reind-filler _ _ ⟩
+          ∙ (sym $ Qᴰ.⋆Assoc _ _ _)
+          ∙ Qᴰ.⟨ Cᴰ.reind-filler _ _ ∙ Cᴰ.reind-filler _ _ ⟩⋆⟨ refl ⟩)
+          ∙ (sym $ Cᴰ.reind-filler P×Q.η _))
 
 module _ {C : Category ℓC ℓC'}{x₁ x₂ : C .ob}
   (prod : BinProduct C (x₁ , x₂))
@@ -169,7 +170,9 @@ module _ {C : Category ℓC ℓC'}{x₁ x₂ : C .ob}
     where
     BinProductⱽ→BinProductᴰ : BinProductᴰ Cᴰ prod (xᴰ₁ , xᴰ₂)
     BinProductⱽ→BinProductᴰ =
-      ×ⱽRepr+π*→×ᴰRepr prod
+      vbp
+      ◁PshIsoⱽᴰ ×ᴰ≅π₁*×ⱽπ₂*
+        prod
         (CartesianLift→CartesianLift' _ _ (CatLift→YoLift lift-π₁))
         (CartesianLift→CartesianLift' _ _ (CatLift→YoLift lift-π₂))
         vbp

--- a/Cubical/Categories/Displayed/Limits/Cartesian.agda
+++ b/Cubical/Categories/Displayed/Limits/Cartesian.agda
@@ -5,6 +5,7 @@ open import Cubical.Foundations.Prelude
 open import Cubical.Data.Sigma
 
 open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Limits.BinProduct.More
 open import Cubical.Categories.Limits.Cartesian.Base
 open import Cubical.Categories.Limits.Terminal.More
 open import Cubical.Categories.Instances.Sets
@@ -12,6 +13,7 @@ open import Cubical.Categories.Presheaf.Constructions
 open import Cubical.Categories.Presheaf.More
 
 open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Functor
 open import Cubical.Categories.Displayed.Limits.BinProduct.Base
 open import Cubical.Categories.Displayed.Limits.BinProduct.Properties
 open import Cubical.Categories.Displayed.Limits.Terminal
@@ -64,9 +66,13 @@ module _ {CC : CartesianCategory ℓC ℓC'}
   open TerminalNotation term
   open CartesianCategoryⱽ CCᴰ
   open CartesianCategoryᴰ hiding (Cᴰ)
+  open isFibrationNotation Cᴰ cartesianLifts
+  private
+    module bp = BinProductsNotation bp
   CartesianCategoryⱽ→CartesianCategoryᴰ : CartesianCategoryᴰ CC ℓCᴰ ℓCᴰ'
   CartesianCategoryⱽ→CartesianCategoryᴰ .CartesianCategoryᴰ.Cᴰ = Cᴰ
-  CartesianCategoryⱽ→CartesianCategoryᴰ .termᴰ = Terminalⱽ→Terminalᴰ Cᴰ (termⱽ 𝟙)
+  CartesianCategoryⱽ→CartesianCategoryᴰ .termᴰ =
+    termⱽ 𝟙ue.vertex ◁PshIsoⱽᴰ UnitPshᴰ≅UnitPshᴰ
   CartesianCategoryⱽ→CartesianCategoryᴰ .bpᴰ =
     BinProductsⱽ→BinProductsᴰ Cᴰ cartesianLifts bpⱽ bp
 
@@ -75,8 +81,8 @@ record CartesianCategoryReprᴰ (CC : CartesianCategoryRepr ℓC ℓC') (ℓCᴰ
   no-eta-equality
   open CartesianCategoryRepr CC
   field
-    Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'
-    termᴰ : Representationᵁᴰ Cᴰ (TerminalPresheafᴰ* Cᴰ ℓCᴰ' (TerminalPresheaf* ℓC')) term
+    Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ' -- (TerminalPresheafᴰ* Cᴰ ℓCᴰ' (TerminalPresheaf* ℓC'))
+    termᴰ : Representationᵁᴰ Cᴰ (LiftPshᴰ UnitPshᴰ ℓCᴰ') term
     bpᴰ   : ∀ {c} {d} cᴰ dᴰ
       → Representationᵁᴰ Cᴰ ((Cᴰ [-][-, cᴰ ]) ×ᴰPsh (Cᴰ [-][-, dᴰ ])) (bp c d)
 
@@ -89,11 +95,11 @@ record CartesianCategoryReprⱽ (C : Category ℓC ℓC') (ℓCᴰ ℓCᴰ' : Le
     Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'
   module Cᴰ = Categoryᴰ Cᴰ
   field
-    termⱽ : ∀ {c} → Representationᵁⱽ Cᴰ (TerminalPresheafᴰ* Cᴰ ℓCᴰ' (C [-, c ]))
-    bpⱽ   : ∀ {c} (cᴰ dᴰ : Cᴰ.ob[ c ]) → Representationᵁⱽ Cᴰ ((Cᴰ [-][-, cᴰ ]) ×ⱽPsh (Cᴰ [-][-, dᴰ ]))
+    termⱽ : ∀ {c} → Representationᵁⱽ Cᴰ {c = c} (LiftPshᴰ UnitPshᴰ ℓCᴰ')
+    bpⱽ   : ∀ {c} (cᴰ dᴰ : Cᴰ.ob[ c ])
+      → Representationᵁⱽ Cᴰ ((Cᴰ [-][-, cᴰ ]) ×ⱽPsh (Cᴰ [-][-, dᴰ ]))
     cartesianLifts : ∀ {c d} (f : C [ c , d ]) (dᴰ : Cᴰ.ob[ d ])
       → Representationᵁⱽ Cᴰ (reindYo f (Cᴰ [-][-, dᴰ ]))
-
 
 module _ {CC : CartesianCategoryRepr ℓC ℓC'}
          (CCᴰ : CartesianCategoryReprⱽ (CC .CartesianCategoryRepr.C) ℓCᴰ ℓCᴰ') where
@@ -103,8 +109,8 @@ module _ {CC : CartesianCategoryRepr ℓC ℓC'}
   CartesianCategoryⱽ→CartesianCategoryReprᴰ : CartesianCategoryReprᴰ CC ℓCᴰ ℓCᴰ'
   CartesianCategoryⱽ→CartesianCategoryReprᴰ .CartesianCategoryReprᴰ.Cᴰ = Cᴰ
   CartesianCategoryⱽ→CartesianCategoryReprᴰ .termᴰ = _ ,
-    (termⱽ .snd ∙ sym (reindTerminal* Cᴰ _)
-    ◁ reindPathToPshIsoPathP (term .snd) _)
+    termⱽ .snd
+    ◁ Lift-Path UnitPshᴰ≡UnitPshᴰ
   CartesianCategoryⱽ→CartesianCategoryReprᴰ .bpᴰ cᴰ dᴰ =
     _ , ( bpⱽ _ _ .snd
         ◁ ×ᴰ≡π₁*×ⱽπ₂* (bp _ _) (cartesianLifts _ cᴰ) (cartesianLifts _ dᴰ))

--- a/Cubical/Categories/Displayed/Limits/Terminal.agda
+++ b/Cubical/Categories/Displayed/Limits/Terminal.agda
@@ -61,31 +61,11 @@ open isIsoOver
 module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ') where
   private
     module Cᴰ = Categoryᴰ Cᴰ
-  -- For consistency, these should go in Displayed.Presheaf.Constructions
-  TerminalPresheafᴰ : (P : Presheaf C ℓP) → Presheafᴰ P Cᴰ ℓ-zero
-  TerminalPresheafᴰ P .F-obᴰ x x₁ = Unit , isSetUnit
-  TerminalPresheafᴰ P .F-homᴰ = λ _ x _ → tt
-  TerminalPresheafᴰ P .F-idᴰ i = λ x x₁ → tt
-  TerminalPresheafᴰ P .F-seqᴰ fᴰ gᴰ i = λ x _ → tt
-
-  TerminalPresheafᴰ* : ∀ ℓ → (P : Presheaf C ℓP) → Presheafᴰ P Cᴰ ℓ
-  TerminalPresheafᴰ* ℓ P .F-obᴰ x x₁ = (Unit* {ℓ}) , isSetUnit*
-  TerminalPresheafᴰ* ℓ P .F-homᴰ = λ _ x₁ _ → tt*
-  TerminalPresheafᴰ* ℓ P .F-idᴰ i = λ x₁ _ → tt*
-  TerminalPresheafᴰ* ℓ P .F-seqᴰ fᴰ gᴰ i = λ x₁ _ → tt*
-
   -- Terminal object over a terminal object
   -- TODO: refactor using Constant Functorᴰ eventually
-  TerminalᴰSpec : Presheafᴰ (TerminalPresheaf {C = C}) Cᴰ ℓ-zero
-  TerminalᴰSpec = TerminalPresheafᴰ _
-
   Terminalᴰ : (term : Terminal' C) →
     Type (ℓ-max (ℓ-max (ℓ-max ℓC ℓC') ℓCᴰ) ℓCᴰ')
-  Terminalᴰ term = UniversalElementᴰ _ term TerminalᴰSpec
-
-  reindTerminal* : ∀ {ℓ}{P : Presheaf C ℓP}{Q : Presheaf C ℓQ}(α : PshHom P Q)
-    → reind α (TerminalPresheafᴰ* ℓ Q) ≡ TerminalPresheafᴰ* ℓ P
-  reindTerminal* α = Functorᴰ≡ (λ _ → refl) (λ _ → refl)
+  Terminalᴰ term = UniversalElementᴰ Cᴰ term UnitPshᴰ
 
   module TerminalᴰNotation {term' : Terminal' C}
     (termᴰ : Terminalᴰ term') where
@@ -118,17 +98,11 @@ module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ') where
   module _ (c : C .ob) where
     -- Vertical terminal object over a fixed object
 
-    -- If Cᴰ is a fibration, this is equivalent to a terminal object
-    -- in the fiber over c that is preserved by reindexing
-    TerminalⱽSpec : Presheafⱽ c Cᴰ ℓ-zero
-    TerminalⱽSpec = TerminalPresheafᴰ _
-
     -- This says that for every morphism f : c' → c in C and
     -- d ∈ Cᴰ.ob[ c' ] there is a unique lift to fᴰ : Cᴰ [ f ][ d' , 1c ]
     -- In program logic terms this is the "trivial postcondition"
     Terminalⱽ : Type (ℓ-max (ℓ-max (ℓ-max ℓC ℓC') ℓCᴰ) ℓCᴰ')
-    Terminalⱽ =
-      UniversalElementⱽ Cᴰ c TerminalⱽSpec
+    Terminalⱽ = UniversalElementⱽ Cᴰ c UnitPshᴰ
 
     module TerminalⱽNotation (vt : Terminalⱽ) where
       open UniversalElementⱽ vt public
@@ -149,9 +123,13 @@ module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ') where
     module _ (termⱽ : Terminalⱽ 𝟙) where
       private module termⱽ = TerminalⱽNotation _ termⱽ
       Terminalⱽ→Terminalᴰ : Terminalᴰ term
-      Terminalⱽ→Terminalᴰ .vertexᴰ = termⱽ.vertexⱽ
-      Terminalⱽ→Terminalᴰ .elementᴰ = tt
-      Terminalⱽ→Terminalᴰ .universalᴰ .inv _ _ = termⱽ.!tⱽ _ _
-      Terminalⱽ→Terminalᴰ .universalᴰ .rightInv _ _ = refl
-      Terminalⱽ→Terminalᴰ .universalᴰ .leftInv _ _ = R.rectify $ R.≡out $
-        termⱽ.∫ue.extensionality (ΣPathP (𝟙extensionality , refl))
+      Terminalⱽ→Terminalᴰ = termⱽ ◁PshIsoⱽᴰ UnitPshᴰ≅UnitPshᴰ
+      private
+        -- manual proof for comparison
+        Terminalⱽ→Terminalᴰ' : Terminalᴰ term
+        Terminalⱽ→Terminalᴰ' .vertexᴰ = termⱽ.vertexⱽ
+        Terminalⱽ→Terminalᴰ' .elementᴰ = tt
+        Terminalⱽ→Terminalᴰ' .universalᴰ .inv _ _ = termⱽ.!tⱽ _ _
+        Terminalⱽ→Terminalᴰ' .universalᴰ .rightInv _ _ = refl
+        Terminalⱽ→Terminalᴰ' .universalᴰ .leftInv _ _ = R.rectify $ R.≡out $
+          termⱽ.∫ue.extensionality (ΣPathP (𝟙extensionality , refl))

--- a/Cubical/Categories/Displayed/Presheaf/Base.agda
+++ b/Cubical/Categories/Displayed/Presheaf/Base.agda
@@ -5,6 +5,8 @@ open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.Structure
 
+import Cubical.Data.Equality as Eq
+open import Cubical.Data.Equality.More
 open import Cubical.Data.Sigma
 
 open import Cubical.Categories.Category
@@ -194,3 +196,26 @@ module PresheafⱽNotation
       sym (reind-filler _ _)
       ∙ ⋆Assoc _ _ _
       ∙ ⟨⟩⋆⟨ reind-filler _ _ ⟩
+
+module _ {C : Category ℓC ℓC'}
+  {P : Presheaf C ℓP}
+  {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
+  (Pᴰ Qᴰ : Presheafᴰ P Cᴰ ℓPᴰ)
+  where
+  private
+    module P = PresheafNotation P
+    module Pᴰ = PresheafᴰNotation Pᴰ
+    module Qᴰ = PresheafᴰNotation Qᴰ
+    module Cᴰ = Categoryᴰ Cᴰ
+
+  PresheafᴰEq : Type _
+  PresheafᴰEq =
+    Σ[ tyEq ∈ Eq ((∀ {x} (p : P.p[ x ]) (xᴰ : Cᴰ.ob[ x ]) → Type ℓPᴰ )) Pᴰ.p[_][_] Qᴰ.p[_][_] ]
+    Eq.HEq (Eq.ap (λ p[_][_] → (∀ {x y}{f : C [ y , x ]}{xᴰ}{yᴰ}
+      → {p : P.p[ x ]}
+      → Cᴰ [ f ][ yᴰ , xᴰ ]
+      → p[ p ][ xᴰ ]
+      → p[ f P.⋆ p ][ yᴰ ]))
+      tyEq)
+      Pᴰ._⋆ᴰ_
+      Qᴰ._⋆ᴰ_

--- a/Cubical/Categories/Displayed/Presheaf/CartesianLift.agda
+++ b/Cubical/Categories/Displayed/Presheaf/CartesianLift.agda
@@ -275,4 +275,4 @@ module _ {C : Category ℓC ℓC'} {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
          (isFibQᴰ : isFibration' Qᴰ)
          where
   isFibration'Reind : isFibration' (reind {P = P} α Qᴰ)
-  isFibration'Reind p = isFibQᴰ (α .fst _ p) ◃PshIsoⱽ invPshIsoⱽ (reindYo-seqIsoⱽ α Qᴰ p)
+  isFibration'Reind p = isFibQᴰ (α .fst _ p) ◁PshIsoⱽ invPshIsoⱽ (reindYo-seqIsoⱽ α Qᴰ p)

--- a/Cubical/Categories/Displayed/Presheaf/Constructions.agda
+++ b/Cubical/Categories/Displayed/Presheaf/Constructions.agda
@@ -6,7 +6,10 @@ open import Cubical.Foundations.Function
 open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Equiv.Base
 open import Cubical.Foundations.Equiv.Dependent
+
+import Cubical.Data.Equality as Eq
 open import Cubical.Data.Sigma
+open import Cubical.Data.Unit
 
 open import Cubical.Categories.Category
 open import Cubical.Categories.Bifunctor
@@ -33,6 +36,8 @@ open import Cubical.Categories.Displayed.Presheaf.Morphism
 
 open Bifunctorᴰ
 open Functorᴰ
+open isIsoOver
+open PshHomᴰ
 private
   variable
     ℓ ℓ' ℓᴰ ℓᴰ' : Level
@@ -41,7 +46,66 @@ private
     ℓD ℓD' ℓDᴰ ℓDᴰ' : Level
     ℓP ℓQ ℓR ℓPᴰ ℓPᴰ' ℓQᴰ ℓQᴰ' ℓRᴰ : Level
 
--- TODO: Terminal presheafᴰ here.
+
+module _ {C : Category ℓC ℓC'}{Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
+  {P : Presheaf C ℓP} (Pᴰ : Presheafᴰ P Cᴰ ℓPᴰ)
+  where
+  private
+    module Pᴰ = PresheafᴰNotation Pᴰ
+  LiftPshᴰ : (ℓ' : Level) → Presheafᴰ P Cᴰ (ℓ-max ℓPᴰ ℓ')
+  LiftPshᴰ ℓ' .F-obᴰ xᴰ p .fst = Lift {ℓPᴰ}{ℓ'} Pᴰ.p[ p ][ xᴰ ]
+  LiftPshᴰ ℓ' .F-obᴰ xᴰ p .snd = isOfHLevelLift 2 (F-obᴰ Pᴰ xᴰ p .snd)
+  LiftPshᴰ ℓ' .F-homᴰ fᴰ p pᴰ = lift (F-homᴰ Pᴰ fᴰ p (pᴰ .lower))
+  LiftPshᴰ ℓ' .F-idᴰ i p pᴰ = lift (Pᴰ .F-idᴰ i p (pᴰ .lower))
+  LiftPshᴰ ℓ' .F-seqᴰ fᴰ gᴰ i p pᴰ = lift (Pᴰ .F-seqᴰ fᴰ gᴰ i p (pᴰ .lower))
+
+  LiftHomⱽ : ∀ {ℓ'} → PshHomⱽ Pᴰ (LiftPshᴰ ℓ')
+  LiftHomⱽ .N-obᴰ = λ z → lift z
+  LiftHomⱽ .N-homᴰ = refl
+
+  LiftIsoⱽ : ∀ {ℓ'} → PshIsoⱽ Pᴰ (LiftPshᴰ ℓ')
+  LiftIsoⱽ .fst = LiftHomⱽ
+  LiftIsoⱽ .snd .inv = λ a z → z .lower
+  LiftIsoⱽ .snd .rightInv b q = refl
+  LiftIsoⱽ .snd .leftInv a p = refl
+
+module _ {C : Category ℓC ℓC'}{Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
+  {P : Presheaf C ℓP} {Pᴰ : Presheafᴰ P Cᴰ ℓPᴰ}
+  {Q : Presheaf C ℓP} {Qᴰ : Presheafᴰ Q Cᴰ ℓPᴰ}
+  {α : P ≡ Q}
+  where
+  Lift-Path :
+    ∀ (αᴰ : PathP (λ i → Presheafᴰ (α i) Cᴰ ℓPᴰ) Pᴰ Qᴰ)
+    → PathP (λ i → Presheafᴰ (α i) Cᴰ (ℓ-max ℓPᴰ ℓ'))
+        (LiftPshᴰ Pᴰ ℓ')
+        (LiftPshᴰ Qᴰ ℓ')
+  Lift-Path αᴰ i = LiftPshᴰ (αᴰ i) _
+module _ {C : Category ℓC ℓC'}{Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
+  {P : Presheaf C ℓP} {Pᴰ : Presheafᴰ P Cᴰ ℓPᴰ}
+  {Q : Presheaf C ℓQ} {Qᴰ : Presheafᴰ Q Cᴰ ℓQᴰ}
+  where
+  private
+    module Pᴰ = PresheafᴰNotation Pᴰ
+  -- TODO: naming...
+  Lift-F-Homᴰ : ∀ {α : PshHom P Q} (αᴰ : PshHomᴰ α Pᴰ Qᴰ) → PshHomᴰ α (LiftPshᴰ Pᴰ ℓ) (LiftPshᴰ Qᴰ ℓ')
+  Lift-F-Homᴰ αᴰ .N-obᴰ pᴰ = lift (αᴰ .N-obᴰ (pᴰ .lower))
+  Lift-F-Homᴰ αᴰ .N-homᴰ {fᴰ = fᴰ}{pᴰ = pᴰ} i =
+    lift (αᴰ .N-homᴰ {fᴰ = fᴰ}{pᴰ = pᴰ .lower} i)
+
+  Lift-F-Isoᴰ : ∀ {α : PshIso P Q} (αᴰ : PshIsoᴰ α Pᴰ Qᴰ) → PshIsoᴰ α (LiftPshᴰ Pᴰ ℓ) (LiftPshᴰ Qᴰ ℓ')
+  Lift-F-Isoᴰ αᴰ .fst = Lift-F-Homᴰ (αᴰ .fst)
+  Lift-F-Isoᴰ αᴰ .snd .inv _ qᴰ = lift (αᴰ .snd .inv _ (qᴰ .lower))
+  Lift-F-Isoᴰ αᴰ .snd .rightInv p pᴰ i =
+    lift (αᴰ .snd .rightInv p (pᴰ .lower) i)
+  Lift-F-Isoᴰ αᴰ .snd .leftInv q qᴰ i =
+    lift (αᴰ .snd .leftInv q (qᴰ .lower) i)
+
+module _ {C : Category ℓC ℓC'}{Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'} where
+  UnitPshᴰ : ∀ {P : Presheaf C ℓP} → Presheafᴰ P Cᴰ ℓ-zero
+  UnitPshᴰ .F-obᴰ _ _ = Unit , isSetUnit
+  UnitPshᴰ .F-homᴰ _ _ _ = tt
+  UnitPshᴰ .F-idᴰ = refl
+  UnitPshᴰ .F-seqᴰ _ _ = refl
 
 module _ {C : Category ℓ ℓ'} {Cᴰ : Categoryᴰ C ℓᴰ ℓᴰ'}
   where
@@ -85,14 +149,12 @@ module _ {C : Category ℓ ℓ'} {Cᴰ : Categoryᴰ C ℓᴰ ℓᴰ'}
     {Qᴰ' : Presheafᴰ Q Cᴰ ℓQᴰ'}
     where
     module _ {α : PshHom P Q} where
-      open PshHomᴰ
       _×ⱽHom_ : (αᴰ : PshHomᴰ α Pᴰ Qᴰ) (βᴰ : PshHomᴰ α Pᴰ' Qᴰ')
         → PshHomᴰ α (Pᴰ ×ⱽPsh Pᴰ') (Qᴰ ×ⱽPsh Qᴰ')
       (αᴰ ×ⱽHom βᴰ) .N-obᴰ (p , p') = (αᴰ .N-obᴰ p) , (βᴰ .N-obᴰ p')
       (αᴰ ×ⱽHom βᴰ) .N-homᴰ = ΣPathP ((αᴰ .N-homᴰ) , (βᴰ .N-homᴰ))
 
     module _ {α : PshIso P Q} where
-      open isIsoOver
       _×ⱽIso_ : (αᴰ : PshIsoᴰ α Pᴰ Qᴰ) (βᴰ : PshIsoᴰ α Pᴰ' Qᴰ')
         → PshIsoᴰ α (Pᴰ ×ⱽPsh Pᴰ') (Qᴰ ×ⱽPsh Qᴰ')
       (αᴰ ×ⱽIso βᴰ) .fst = (αᴰ .fst) ×ⱽHom (βᴰ .fst)
@@ -162,8 +224,7 @@ module _ {C : Category ℓ ℓ'} {Cᴰ : Categoryᴰ C ℓᴰ ℓᴰ'}
       (Pᴰ.rectify $ Pᴰ.≡out $ Pᴰ.reind-filler _ _)
       , (Qᴰ.rectify $ Qᴰ.≡out $ Qᴰ.reind-filler _ _)
 
-  open PshHomᴰ
-  open isIsoOver
+  -- This one is only Eq.refl on objects, would need a corresponding eqToPshIsoⱽ' like reindF''
   PshProdⱽ≅ᴰ :
     PshIsoⱽ (Pᴰ ×ᴰPsh Qᴰ) (reind (π₁ P Q) Pᴰ ×ⱽPsh reind (π₂ P Q) Qᴰ)
   PshProdⱽ≅ᴰ .fst .N-obᴰ x = x
@@ -293,3 +354,50 @@ module _ {C : Category ℓC ℓC'}{Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
       subst (λ α → reind (α .fst) Qᴰ ≡ Qᴰ)
         (sym pathToPshIsoRefl)
         (sym $ reind-id _)
+
+module _ {C : Category ℓ ℓ'} {Cᴰ : Categoryᴰ C ℓᴰ ℓᴰ'}
+  {P : Presheaf C ℓP}{Q : Presheaf C ℓQ}
+  {α : PshHom P Q}
+  where
+  reindUnitEq : PresheafᴰEq (reind α (UnitPshᴰ {Cᴰ = Cᴰ})) UnitPshᴰ
+  reindUnitEq = Eq.refl , Eq.refl
+
+  reindUnit : reind α (UnitPshᴰ {Cᴰ = Cᴰ}) ≡ UnitPshᴰ
+  reindUnit =
+    Functorᴰ≡ (λ _ → funExt λ _ → Σ≡Prop (λ _ → isPropIsSet) refl)
+    λ fᴰ → refl
+
+  reindUnitIsoⱽ : PshIsoⱽ (reind α (UnitPshᴰ {Cᴰ = Cᴰ})) UnitPshᴰ
+  reindUnitIsoⱽ = eqToPshIsoⱽ reindUnitEq
+
+module _ {C : Category ℓC ℓC'} {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
+  {P : Presheaf C ℓP}{Q : Presheaf C ℓQ}
+  {α : PshIso P Q}
+  where
+  UnitPshᴰ≅UnitPshᴰ : PshIsoᴰ {Cᴰ = Cᴰ} α (UnitPshᴰ {P = P}) (UnitPshᴰ {P = Q})
+  UnitPshᴰ≅UnitPshᴰ =
+    invPshIsoⱽ reindUnitIsoⱽ
+    ⋆PshIsoⱽᴰ reindPshIsoPshIsoᴰ α (UnitPshᴰ {P = Q})
+module _ {C : Category ℓC ℓC'} {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
+  {P : Presheaf C ℓP}{Q : Presheaf C ℓP}
+  {α : P ≡ Q}
+  where
+  UnitPshᴰ≡UnitPshᴰ :
+    PathP
+      (λ i → Presheafᴰ (α i) Cᴰ ℓ-zero)
+      (UnitPshᴰ {P = P})
+      (UnitPshᴰ {P = Q})
+  UnitPshᴰ≡UnitPshᴰ = sym reindUnit ◁ reindPathToPshIsoPathP α UnitPshᴰ
+
+module _{C : Category ℓC ℓC'} {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
+  {P : Presheaf C ℓP}{Q : Presheaf C ℓQ}
+  {α : PshHom P Q} {Qᴰ : Presheafᴰ Q Cᴰ ℓQᴰ}
+  where
+  reindLiftEq : PresheafᴰEq (reind α (LiftPshᴰ Qᴰ ℓ')) (LiftPshᴰ (reind α Qᴰ) ℓ')
+  reindLiftEq = Eq.refl , Eq.refl
+
+  reindLift : reind α (LiftPshᴰ Qᴰ ℓ') ≡ LiftPshᴰ (reind α Qᴰ) ℓ'
+  reindLift = Functorᴰ≡ (λ xᴰ → refl) (λ _ → refl)
+
+  reindLiftIsoⱽ : PshIsoⱽ (reind α (LiftPshᴰ Qᴰ ℓ')) (LiftPshᴰ (reind α Qᴰ) ℓ')
+  reindLiftIsoⱽ = eqToPshIsoⱽ reindLiftEq

--- a/Cubical/Categories/Displayed/Presheaf/Representable.agda
+++ b/Cubical/Categories/Displayed/Presheaf/Representable.agda
@@ -289,61 +289,61 @@ module _ {C : Category ℓC ℓC'}{Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
   {Pᴰ : Presheafᴰ P Cᴰ ℓPᴰ}{Qᴰ : Presheafᴰ Q Cᴰ ℓQᴰ}
   {ue : UniversalElement C P}{α : PshIso P Q}
   where
-  _◃PshIsoᴰ_ : (ueᴰ : UniversalElementᴰ Cᴰ ue Pᴰ) (αᴰ : PshIsoᴰ α Pᴰ Qᴰ)
-    → UniversalElementᴰ Cᴰ (ue ◃PshIso α) Qᴰ
-  ueᴰ ◃PshIsoᴰ αᴰ = record
-    { vertexᴰ = ∫◃ .vertex .snd
-    ; elementᴰ = ∫◃ .element .snd
+  _◁PshIsoᴰ_ : (ueᴰ : UniversalElementᴰ Cᴰ ue Pᴰ) (αᴰ : PshIsoᴰ α Pᴰ Qᴰ)
+    → UniversalElementᴰ Cᴰ (ue ◁PshIso α) Qᴰ
+  ueᴰ ◁PshIsoᴰ αᴰ = record
+    { vertexᴰ = ∫◁ .vertex .snd
+    ; elementᴰ = ∫◁ .element .snd
     ; universalᴰ = isisoover
-      (λ q qᴰ → ∫◃.intro (q , qᴰ) .snd)
-      (λ q qᴰ → Qᴰ.rectify $ Qᴰ.≡out $ ∫◃.β)
-      λ f fᴰ → Cᴰ.rectify $ Cᴰ.≡out $ sym $ ∫◃.η
+      (λ q qᴰ → ∫◁.intro (q , qᴰ) .snd)
+      (λ q qᴰ → Qᴰ.rectify $ Qᴰ.≡out $ ∫◁.β)
+      λ f fᴰ → Cᴰ.rectify $ Cᴰ.≡out $ sym $ ∫◁.η
     } where
       open UniversalElement
       module Cᴰ = Fibers Cᴰ
       module Qᴰ = PresheafᴰNotation Qᴰ
       module ueᴰ = UniversalElementᴰ ueᴰ
-      ∫◃ = ueᴰ.∫ue ◃PshIso ∫PshIsoᴰ αᴰ
-      module ∫◃ = UniversalElementNotation ∫◃
+      ∫◁ = ueᴰ.∫ue ◁PshIso ∫PshIsoᴰ αᴰ
+      module ∫◁ = UniversalElementNotation ∫◁
 
 module _ {C : Category ℓC ℓC'}{Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
   {x}
   {Pⱽ : Presheafⱽ x Cᴰ ℓPᴰ}{Qⱽ : Presheafⱽ x Cᴰ ℓQᴰ}
   where
-  _◃PshIsoⱽ_ : UniversalElementⱽ Cᴰ x Pⱽ → PshIsoⱽ Pⱽ Qⱽ → UniversalElementⱽ Cᴰ x Qⱽ
-  ueⱽ ◃PshIsoⱽ αⱽ = fromUniversalᴰ record
-    { vertexᴰ = ueⱽ◃αⱽ.vertexᴰ
-    ; elementᴰ = ueⱽ◃αⱽ.elementᴰ -- ueᴰ◃αⱽ.elementᴰ
+  _◁PshIsoⱽ_ : UniversalElementⱽ Cᴰ x Pⱽ → PshIsoⱽ Pⱽ Qⱽ → UniversalElementⱽ Cᴰ x Qⱽ
+  ueⱽ ◁PshIsoⱽ αⱽ = fromUniversalᴰ record
+    { vertexᴰ = ueⱽ◁αⱽ.vertexᴰ
+    ; elementᴰ = ueⱽ◁αⱽ.elementᴰ -- ueᴰ◁αⱽ.elementᴰ
     ; universalᴰ = isisoover
-      (λ _ → ueⱽ◃αⱽ.introᴰ)
-      (λ _ _ → Qⱽ.rectify $ Qⱽ.≡out $ ueⱽ◃αⱽ.βᴰ)
-      (λ _ _ → Cᴰ.rectify $ Cᴰ.≡out $ sym $ ueⱽ◃αⱽ.ηᴰ)
+      (λ _ → ueⱽ◁αⱽ.introᴰ)
+      (λ _ _ → Qⱽ.rectify $ Qⱽ.≡out $ ueⱽ◁αⱽ.βᴰ)
+      (λ _ _ → Cᴰ.rectify $ Cᴰ.≡out $ sym $ ueⱽ◁αⱽ.ηᴰ)
     } where
       module ueⱽ = UniversalElementⱽ ueⱽ
-      ueᴰ◃αⱽ = ueⱽ.toUniversalᴰ ◃PshIsoᴰ αⱽ
+      ueᴰ◁αⱽ = ueⱽ.toUniversalᴰ ◁PshIsoᴰ αⱽ
       module Cᴰ = Fibers Cᴰ
       module Qⱽ = PresheafⱽNotation Qⱽ
-      module ueⱽ◃αⱽ = UniversalElementᴰ ueᴰ◃αⱽ
+      module ueⱽ◁αⱽ = UniversalElementᴰ ueᴰ◁αⱽ
 
 module _ {C : Category ℓC ℓC'}{Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
   {P : Presheaf C ℓP}
   {Pᴰ : Presheafᴰ P Cᴰ ℓPᴰ}{Qᴰ : Presheafᴰ P Cᴰ ℓQᴰ}
   {ue : UniversalElement C P}
   where
-  _◃PshIsoᴰⱽ_ : (ueᴰ : UniversalElementᴰ Cᴰ ue Pᴰ) (αⱽ : PshIsoⱽ Pᴰ Qᴰ)
+  _◁PshIsoᴰⱽ_ : (ueᴰ : UniversalElementᴰ Cᴰ ue Pᴰ) (αⱽ : PshIsoⱽ Pᴰ Qᴰ)
     → UniversalElementᴰ Cᴰ ue Qᴰ
-  ueᴰ ◃PshIsoᴰⱽ αⱽ = record
-    { vertexᴰ = ueᴰ◃αⱽ.vertexᴰ
-    ; elementᴰ = ueᴰ◃αⱽ.elementᴰ
+  ueᴰ ◁PshIsoᴰⱽ αⱽ = record
+    { vertexᴰ = ueᴰ◁αⱽ.vertexᴰ
+    ; elementᴰ = ueᴰ◁αⱽ.elementᴰ
     ; universalᴰ = isisoover
-      (λ p qᴰ → ueᴰ◃αⱽ.introᴰ qᴰ)
-      (λ p qᴰ → Qᴰ.rectify $ Qᴰ.≡out $ ueᴰ◃αⱽ.βᴰ)
-      (λ f fᴰ → Cᴰ.rectify $ Cᴰ.≡out $ sym $ ueᴰ◃αⱽ.ηᴰ)
+      (λ p qᴰ → ueᴰ◁αⱽ.introᴰ qᴰ)
+      (λ p qᴰ → Qᴰ.rectify $ Qᴰ.≡out $ ueᴰ◁αⱽ.βᴰ)
+      (λ f fᴰ → Cᴰ.rectify $ Cᴰ.≡out $ sym $ ueᴰ◁αⱽ.ηᴰ)
     } where
-      ueᴰ◃αⱽ = ueᴰ ◃PshIsoᴰ αⱽ
+      ueᴰ◁αⱽ = ueᴰ ◁PshIsoᴰ αⱽ
       module Cᴰ = Fibers Cᴰ
       module Qᴰ = PresheafᴰNotation Qᴰ
-      module ueᴰ◃αⱽ = UniversalElementᴰ ueᴰ◃αⱽ
+      module ueᴰ◁αⱽ = UniversalElementᴰ ueᴰ◁αⱽ
 
 open UniversalElement
 module _ {C : Category ℓC ℓC'}{Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
@@ -352,10 +352,10 @@ module _ {C : Category ℓC ℓC'}{Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
   {Pⱽ : Presheafⱽ (ue .vertex) Cᴰ ℓPᴰ}{Qᴰ : Presheafᴰ Q Cᴰ ℓQᴰ}
   where
   -- This could probably be implemented as a subst instead of manually.
-  _◃PshIsoⱽᴰ_ : UniversalElementⱽ Cᴰ (ue .vertex) Pⱽ
+  _◁PshIsoⱽᴰ_ : UniversalElementⱽ Cᴰ (ue .vertex) Pⱽ
     → PshIsoᴰ (yoRecIso ue) Pⱽ Qᴰ
     → UniversalElementᴰ Cᴰ ue Qᴰ
-  ueⱽ ◃PshIsoⱽᴰ αᴰ = record
+  ueⱽ ◁PshIsoⱽᴰ αᴰ = record
     { vertexᴰ = ueⱽ.vertexⱽ
     ; elementᴰ = Qᴰ.reind (Q.⋆IdL _) (αᴰ .fst .N-obᴰ ueⱽ.elementⱽ)
     ; universalᴰ = isisoover

--- a/Cubical/Categories/Instances/Sets/Properties.agda
+++ b/Cubical/Categories/Instances/Sets/Properties.agda
@@ -56,7 +56,7 @@ module _ {C : Category ℓC ℓC'}
     open SetCoeq.UniversalProperty
     lmap : Σ[ X ∈ ob C ]
            Σ[ Y ∈ ob C ]
-           Σ[ f ∈ (C)[ Y , X ] ] fst( F ⟅ X , Y ⟆b )
+           Σ[ f ∈ (C)[ Y , X ] ] ⟨ F ⟅ X , Y ⟆b ⟩
            →  Σ[ X ∈ ob C ] ⟨ F ⟅ X , X ⟆b ⟩
     lmap (X , Y , f , Fxy ) = X , ( F ⟪ f ⟫r ) Fxy
 

--- a/Cubical/Categories/Presheaf/More.agda
+++ b/Cubical/Categories/Presheaf/More.agda
@@ -470,7 +470,7 @@ module _ {C : Category ℓ ℓ'}{P : Presheaf C ℓS}{Q : Presheaf C ℓS'} wher
     private
       module ue = UniversalElementNotation ue
     open UniversalElement
-    _◃PshIso_ : UniversalElement C Q
-    _◃PshIso_ .vertex = ue.vertex
-    _◃PshIso_ .element = α .fst .fst ue.vertex ue.element
-    _◃PshIso_ .universal = seqIsUniversalPshIso ue.universal α
+    _◁PshIso_ : UniversalElement C Q
+    _◁PshIso_ .vertex = ue.vertex
+    _◁PshIso_ .element = α .fst .fst ue.vertex ue.element
+    _◁PshIso_ .universal = seqIsUniversalPshIso ue.universal α

--- a/Cubical/Data/Equality/More.agda
+++ b/Cubical/Data/Equality/More.agda
@@ -1,0 +1,49 @@
+module Cubical.Data.Equality.More where
+
+open import Cubical.Foundations.Prelude
+  hiding (_≡_ ; step-≡ ; _∎ ; isPropIsContr)
+  renaming ( refl      to reflPath
+           ; transport to transportPath
+           ; J         to JPath
+           ; JRefl     to JPathRefl
+           ; sym       to symPath
+           ; _∙_       to compPath
+           ; cong      to congPath
+           ; subst     to substPath
+           ; substRefl to substPathReflPath
+           ; funExt    to funExtPath
+           ; isContr   to isContrPath
+           ; isProp    to isPropPath
+           )
+open import Cubical.Foundations.Equiv
+  renaming ( fiber     to fiberPath
+           ; isEquiv   to isEquivPath
+           ; _≃_       to EquivPath
+           ; equivFun  to equivFunPath
+           ; isPropIsEquiv to isPropIsEquivPath
+           )
+  hiding   ( equivCtr
+           ; equivIsEquiv )
+open import Cubical.Foundations.Isomorphism
+  using ()
+  renaming ( Iso to IsoPath
+           ; iso to isoPath
+           ; isoToPath to isoPathToPath
+           ; isoToEquiv to isoPathToEquivPath
+           )
+open import Cubical.Data.Equality
+
+private
+ variable
+  a b ℓ ℓ' : Level
+  A : Type a
+  B : Type b
+  x y z : A
+
+mixedHEq : {A0 A1 : Type ℓ} (Aeq : A0 ≡ A1) (a0 : A0)(a1 : A1) → Type _
+mixedHEq Aeq a0 a1 = Path _ (transport (λ A → A) Aeq a0) a1
+
+-- Version of _≡_ where the type is an explicit argument, analogous to Path
+Eq : ∀ {ℓ} (A : Type ℓ) → A → A → Type ℓ
+Eq A a b = a ≡ b
+


### PR DESCRIPTION
closes https://github.com/um-catlab/cubical-categorical-logic/issues/168

I implemented an Eq to PshIsoⱽ construction for convenience, and I did some minor refactorings like fixing the unicode triangles (\T not \t in emacs) and making a `Cubical.Data.Equality.More`