### PR TITLE
Universal Quantifier Parametrized by an Endofunctor

### DIFF
--- a/Cubical/Categories/Displayed/Presheaf/CartesianLift.agda
+++ b/Cubical/Categories/Displayed/Presheaf/CartesianLift.agda
@@ -2,6 +2,7 @@
 module Cubical.Categories.Displayed.Presheaf.CartesianLift where
 
 open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.More
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.Isomorphism
@@ -19,6 +20,7 @@ open import Cubical.Categories.Presheaf.Constructions
 open import Cubical.Categories.Presheaf.More
 open import Cubical.Categories.Presheaf.Morphism.Alt
 open import Cubical.Categories.Functor
+open import Cubical.Categories.NaturalTransformation
 open import Cubical.Categories.Bifunctor
 open import Cubical.Categories.Displayed.Base
 open import Cubical.Categories.Displayed.Instances.Sets.Base
@@ -285,3 +287,86 @@ module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} {Dᴰ : Categoryᴰ
     reindUEⱽ (isFib xᴰ (F ⟪ f ⟫)) ◁PshIsoⱽ
       (invPshIsoⱽ reindYoReindFunc
       ⋆PshIsoⱽ reindPshIsoⱽ reindⱽFuncRepr)
+
+-- Reindexing a projectionlike endofunctor gives a displayed endofunctor
+-- when cartesian lifts along the projection exists
+-- TODO : Find the most general version of this
+module _
+  {C : Category ℓC ℓC'}
+  {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
+  (F : Functor C C)
+  (πF : NatTrans F Id)
+  where
+
+  private
+    module C = Category C
+    module Cᴰ = Fibers Cᴰ
+
+  module _
+    (πF* : {Γ : C.ob} → (Γᴰ : Cᴰ.ob[ Γ ]) →
+      CartesianLift' (πF ⟦ Γ ⟧) (Cᴰ [-][-, Γᴰ ]))
+    where
+
+    open UniversalElementⱽ
+
+    introπF* :
+      ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]}
+        {Δ} {Δᴰ : Cᴰ.ob[ Δ ]}{γ : C [ Δ , F ⟅ Γ ⟆ ]}
+      → (γᴰ : Cᴰ [ γ C.⋆ πF ⟦ Γ ⟧ ][ Δᴰ , Γᴰ ])
+      → Cᴰ [ γ ][ Δᴰ , vertexᴰ (πF* Γᴰ) ]
+    introπF* {Γᴰ = Γᴰ} γᴰ = introᴰ (πF* Γᴰ) γᴰ
+
+    introπF*⟨_⟩⟨_⟩ :
+      ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]}
+        {Δ} {Δᴰ Δᴰ' : Cᴰ.ob[ Δ ]}{γ γ' : C [ Δ , F ⟅ Γ ⟆ ]} →
+        {Δᴰ≡Δᴰ' : Δᴰ ≡ Δᴰ'} →
+        (γ≡γ' : γ ≡ γ') →
+        {γᴰ : Cᴰ [ γ C.⋆ πF ⟦ Γ ⟧ ][ Δᴰ , Γᴰ ]} →
+        {γᴰ' : Cᴰ [ γ' C.⋆ πF ⟦ Γ ⟧ ][ Δᴰ' , Γᴰ ]} →
+        γᴰ ≡[ (λ i → Cᴰ [ γ≡γ' i C.⋆ πF ⟦ Γ ⟧ ][ Δᴰ≡Δᴰ' i , Γᴰ ]) ] γᴰ' →
+        introπF* γᴰ ≡[ (λ i → Cᴰ [ γ≡γ' i ][ Δᴰ≡Δᴰ' i , vertexⱽ (πF* Γᴰ) ]) ] introπF* γᴰ'
+    introπF*⟨ γ≡γ' ⟩⟨ γᴰ≡γᴰ' ⟩ i = introπF* (γᴰ≡γᴰ' i)
+
+    π-πF* : ∀ {Γ} (Γᴰ : Cᴰ.ob[ Γ ]) → Cᴰ [ πF ⟦ Γ ⟧ ][ vertexⱽ (πF* Γᴰ) , Γᴰ ]
+    π-πF* Γᴰ = Cᴰ.reind (C.⋆IdL _) $ πF* Γᴰ .elementⱽ
+
+    β-πF* :
+      ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]}
+        {Δ} {Δᴰ : Cᴰ.ob[ Δ ]}{γ : C [ Δ , F ⟅ Γ ⟆ ]}
+      → (γᴰ : Cᴰ [ γ C.⋆ πF ⟦ Γ ⟧ ][ Δᴰ , Γᴰ ])
+      → introπF* γᴰ Cᴰ.⋆ᴰ π-πF* Γᴰ ≡ γᴰ
+    β-πF* {Γᴰ = Γᴰ} γᴰ =
+      Cᴰ.rectify $ Cᴰ.≡out $
+        Cᴰ.⟨ refl ⟩⋆⟨ sym $ Cᴰ.reind-filler _ _ ⟩
+        ∙ Cᴰ.reind-filler _ _
+        ∙ Cᴰ.reind-filler _ _
+        ∙ Cᴰ.≡in (βⱽ (πF* Γᴰ) {pᴰ = γᴰ})
+
+    open NatTrans
+
+    weakenπFᴰ : Functorᴰ F Cᴰ Cᴰ
+    weakenπFᴰ .F-obᴰ Γᴰ = πF* Γᴰ .vertexⱽ
+    weakenπFᴰ .F-homᴰ {f = γ} {xᴰ = Γᴰ} {yᴰ = Δᴰ} γᴰ =
+      introπF* (Cᴰ.reind (sym $ πF .N-hom γ) $ (π-πF* Γᴰ Cᴰ.⋆ᴰ γᴰ))
+    weakenπFᴰ .F-idᴰ {xᴰ = Γᴰ} =
+        introπF*⟨ F .F-id  ⟩⟨
+          Cᴰ.rectify $ Cᴰ.≡out $
+            (sym $ Cᴰ.reind-filler _ _)
+            ∙ Cᴰ.⋆IdR _
+            ∙ (sym $ Cᴰ.reind-filler _ _)
+        ⟩
+          ▷ (sym $ weak-ηⱽ (πF* Γᴰ))
+    weakenπFᴰ .F-seqᴰ γᴰ δᴰ =
+      introπF*⟨ F .F-seq _ _ ⟩⟨
+        Cᴰ.rectify $ Cᴰ.≡out $
+          (sym $ Cᴰ.reind-filler _ _)
+          ∙ Cᴰ.⟨ sym $ Cᴰ.reind-filler _ _ ⟩⋆⟨ refl ⟩
+          ∙ (sym $ Cᴰ.⋆Assoc _ _ _)
+          ∙ Cᴰ.⟨ Cᴰ.⟨ Cᴰ.reind-filler _ _ ⟩⋆⟨ refl ⟩
+               ∙ Cᴰ.reind-filler _ _
+               ∙ (Cᴰ.≡in $ sym $ β-πF* (Cᴰ.reind (sym $ πF .N-hom _) (π-πF* _ Cᴰ.⋆ᴰ γᴰ)))
+               ⟩⋆⟨ refl ⟩
+          ∙ (Cᴰ.⋆Assoc _ _ _)
+          ∙ Cᴰ.⟨ refl ⟩⋆⟨ Cᴰ.reind-filler _ _ ⟩
+          ∙ Cᴰ.reind-filler _ _
+      ⟩ ▷ (Cᴰ.rectify $ Cᴰ.≡out $ sym $ introᴰ-natural (πF* _))

--- a/Cubical/Categories/Displayed/Quantifiers.agda
+++ b/Cubical/Categories/Displayed/Quantifiers.agda
@@ -19,6 +19,7 @@ open import Cubical.Categories.Presheaf.Base
 open import Cubical.Categories.Presheaf.Morphism.Alt
 open import Cubical.Categories.Presheaf.Representable
 open import Cubical.Categories.Presheaf.More
+open import Cubical.Categories.Presheaf.Constructions
 open import Cubical.Categories.Instances.Sets
 open import Cubical.Categories.NaturalTransformation
 open import Cubical.Categories.FunctorComprehension
@@ -184,238 +185,59 @@ module _
   UniversalQuantifiers = ∀ a Γ pᴰ
     → UniversalQuantifier {a = a} (λ c → bp (c , a)) isFib {Γ = Γ} pᴰ
 
-
 open NatTrans
 open Functor
 open Functorᴰ
 module _
   {C : Category ℓC ℓC'}
   {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
-  (F : Functor (PresheafCategory C ℓC') (PresheafCategory C ℓC'))
+  (F : Functor C C)
   (πF : NatTrans F Id)
-  (ueF : (Γ : C .Category.ob) → UniversalElement C (F ⟅ C [-, Γ ] ⟆))
   where
 
   open UniversalElement
+
   private
     module C = Category C
     module Cᴰ = Fibers Cᴰ
-    module Psh = Category (PresheafCategory C ℓC')
-
-    πF-PshHom : ∀ Q → PshHom (F ⟅ Q ⟆) Q
-    πF-PshHom Q = NatTrans→PshHom (πF .N-ob Q)
-
-    ＂F_＂ : C.ob → C.ob
-    ＂F Γ ＂ = ueF Γ .vertex
-
-    F-Rep : ∀ {Γ} → PshIso (C [-, ＂F Γ ＂ ]) (F ⟅ C [-, Γ ] ⟆)
-    F-Rep = UniversalElementNotation.asPshIso (ueF _)
-
-    πF'-PshHom : ∀ {Γ} → PshHom (C [-, ＂F Γ ＂ ]) (C [-, Γ ])
-    πF'-PshHom {Γ} = _⋆PshHom_ {C = C}
-      {P = C [-, ＂F Γ ＂ ]} {Q = F ⟅ C [-, Γ ] ⟆} {R = C [-, Γ ]}
-      (F-Rep {Γ} .fst) (πF-PshHom (C [-, Γ ]))
-
-    ＂π＂ : {Γ : C.ob} → C [ ＂F Γ ＂ , Γ ]
-    ＂π＂ {Γ = Γ} = πF'-PshHom .fst ＂F Γ ＂ C.id
-    -- πF-PshHom (C [-, Γ ]) .fst ＂F Γ ＂ (ueF Γ .element)
-
-    -- F extends a functor on C
-    FC : Functor C C
-    FC = FunctorComprehension (F ∘F YO) (λ Γ → ueF Γ)
-
-    F-PshHom : (Q : Presheaf C ℓC') → PshHom Q ((F ⟅ Q ⟆) ∘F (FC ^opF))
-    F-PshHom Q .fst Γ q =
-      F ⟪ PshHom→NatTrans (yoRec Q q) ⟫ ⟦ ＂F Γ ＂ ⟧ $ ueF Γ .element
-    -- TODO naturality
-    F-PshHom Q .snd = {!!}
-
-    ＂π＂' : {Γ : C.ob} → C [ ＂F Γ ＂ , Γ ]
-    ＂π＂' {Γ = Γ} = {!!}
-
-    -- よ＂π＂≡ : (Γ : C.ob) → YO ⟪ ＂π＂ {Γ} ⟫ ≡
-    --    seqTrans (no-no-no (F ⟅ C [-, Γ ] ⟆) (ueF Γ .element))
-    --             (πF ⟦ C [-, Γ ] ⟧)
-    -- よ＂π＂≡ Γ = {!!}
-
-    ＂π＂-natural : ∀ {Γ}{Δ}(γ : C [ Γ , Δ ]) → ＂π＂ C.⋆ γ ≡ FC ⟪ γ ⟫ C.⋆ ＂π＂
-    -- TODO naturality
-    ＂π＂-natural {Γ}{Δ} γ =
-      ＂π＂ C.⋆ γ
-        ≡⟨ {!!} ⟩
-      -- πF'-PshHom .fst (F-ob FC Γ)
-      --  (yoRec (C [-, ＂F Δ ＂ ]) C.id .fst (F-ob FC Γ) (F-hom FC γ))
-      --   ≡⟨  (yoRec-natural-elt (C [-, ＂F Δ ＂ ]) (C [-, Δ ]) πF'-PshHom) ⟩
-      FC ⟪ γ ⟫ C.⋆ ＂π＂
-      ∎
-      where
-      module FΓ = PresheafNotation (F ⟅ C [-, Γ ] ⟆)
-      module FΔ = PresheafNotation (F ⟅ C [-, Δ ] ⟆)
-
-      -- isFaithfulYO {C = C} ＂F Γ ＂ Δ _ _ $
-      --   YO .F-seq ＂π＂ γ
-      --   ∙ cong₂ seqTrans (よ＂π＂≡ Γ) refl
-      --   ∙ (Psh.⋆Assoc
-      --       (no-no-no (F ⟅ C [-, Γ ] ⟆) (ueF Γ .element))
-      --       (πF ⟦ C [-, Γ ] ⟧)
-      --       (YO {C = C} ⟪ γ ⟫))
-      --   ∙ cong₂ seqTrans refl (sym $ πF .N-hom (no-no-no (C [-, Δ ]) γ))
-      --   ∙ (sym $ Psh.⋆Assoc (PshHom→NatTrans (yoRec (F ⟅ C [-, Γ ] ⟆) (ueF Γ .element))) (F ⟪ no-no-no (C [-, Δ ]) γ ⟫) (πF ⟦ C [-, Δ ] ⟧))
-      --   ∙ cong₂ seqTrans x refl
-      --   ∙ (Psh.⋆Assoc
-      --       (YO {C = C} ⟪ FC ⟪ γ ⟫ ⟫)
-      --       (no-no-no (F ⟅ C [-, Δ ] ⟆) (ueF Δ .element))
-      --       (πF ⟦ C [-, Δ ] ⟧)
-      --      )
-      --   ∙ cong₂ seqTrans refl (sym $ よ＂π＂≡ Δ)
-      --   -- ∙ cong₂ seqTrans {!!} refl
-      --   ∙ (sym $ YO {C = C} .F-seq {x = ＂F Γ ＂} {y = ＂F Δ ＂} {z = Δ}
-      --             (FC ⟪ γ ⟫) ＂π＂)
-       -- where
-       -- module ueFΓ = UniversalElementNotation (ueF Γ)
-       -- module ueFΔ = UniversalElementNotation (ueF Δ)
-       -- module FΔ = PresheafNotation (F ⟅ C [-, Δ ] ⟆)
-
-       -- x : seqTrans (PshHom→NatTrans (yoRec (F ⟅ C [-, Γ ] ⟆) (ueF Γ .element)))
-       --              (F ⟪ PshHom→NatTrans $ yoRec (C [-, Δ ]) γ ⟫)
-       --     ≡ seqTrans {G = C [-, ＂F Δ ＂ ]} (PshHom→NatTrans (yoRec (C [-, ＂F Δ ＂ ]) (FC ⟪ γ ⟫)))
-       --                (PshHom→NatTrans (yoRec (F ⟅ C [-, Δ ] ⟆) (ueF Δ .element)))
-       -- x = {!!}
 
   module _
     (πF* : {Γ : C.ob} → (Γᴰ : Cᴰ.ob[ Γ ]) →
-      PshᴰCL.CartesianLift' ＂π＂ (Cᴰ [-][-, Γᴰ ]))
+      PshᴰCL.CartesianLift' (πF ⟦ Γ ⟧) (Cᴰ [-][-, Γᴰ ]))
     where
 
     open UniversalElementⱽ
 
-    ＂πF*_＂ : ∀ {Γ} (Γᴰ : Cᴰ.ob[ Γ ]) → Cᴰ.ob[ ＂F Γ ＂ ]
-    ＂πF* Γᴰ ＂ = πF* Γᴰ .vertexⱽ
-
-    introπF* :
-      ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]}
-        {Δ} {Δᴰ : Cᴰ.ob[ Δ ]}{γ : C [ Δ , ＂F Γ ＂ ]}
-      → (γᴰ : Cᴰ [ γ C.⋆ ＂π＂ ][ Δᴰ , Γᴰ ])
-      → Cᴰ [ γ ][ Δᴰ , ＂πF* Γᴰ ＂ ]
-    introπF* {Γᴰ = Γᴰ} γᴰ = introᴰ (πF* Γᴰ) γᴰ
-
-    introπF*⟨_⟩⟨_⟩ :
-      ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]}
-        {Δ} {Δᴰ Δᴰ' : Cᴰ.ob[ Δ ]}{γ γ' : C [ Δ , ＂F Γ ＂ ]} →
-        {Δᴰ≡Δᴰ' : Δᴰ ≡ Δᴰ'} →
-        (γ≡γ' : γ ≡ γ') →
-        {γᴰ : Cᴰ [ γ C.⋆ ＂π＂ ][ Δᴰ , Γᴰ ]} →
-        {γᴰ' : Cᴰ [ γ' C.⋆ ＂π＂ ][ Δᴰ' , Γᴰ ]} →
-        γᴰ ≡[ (λ i → Cᴰ [ γ≡γ' i C.⋆ ＂π＂ ][ Δᴰ≡Δᴰ' i , Γᴰ ]) ] γᴰ' →
-        introπF* γᴰ ≡[ (λ i → Cᴰ [ γ≡γ' i ][ Δᴰ≡Δᴰ' i , ＂πF* Γᴰ ＂ ]) ] introπF* γᴰ'
-    introπF*⟨ γ≡γ' ⟩⟨ γᴰ≡γᴰ' ⟩ i = introπF* (γᴰ≡γᴰ' i)
-
-    π-πF* : ∀ {Γ} (Γᴰ : Cᴰ.ob[ Γ ]) → Cᴰ [ ＂π＂ ][ ＂πF* Γᴰ ＂ , Γᴰ ]
-    π-πF* Γᴰ = Cᴰ.reind (C.⋆IdL _) $ πF* Γᴰ .elementⱽ
-
-    β-πF* :
-      ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]}
-        {Δ} {Δᴰ : Cᴰ.ob[ Δ ]}{γ : C [ Δ , ＂F Γ ＂ ]}
-      → (γᴰ : Cᴰ [ γ C.⋆ ＂π＂ ][ Δᴰ , Γᴰ ])
-      → introπF* γᴰ Cᴰ.⋆ᴰ π-πF* Γᴰ ≡ γᴰ
-    β-πF* {Γᴰ = Γᴰ} γᴰ =
-      Cᴰ.rectify $ Cᴰ.≡out $
-        Cᴰ.⟨ refl ⟩⋆⟨ sym $ Cᴰ.reind-filler _ _ ⟩
-        ∙ Cᴰ.reind-filler _ _
-        ∙ Cᴰ.reind-filler _ _
-        ∙ Cᴰ.≡in (βⱽ (πF* Γᴰ) {pᴰ = γᴰ})
-
-    open PshHomᴰ
-
-    Cᴰ[FC] : Categoryᴰ C ℓCᴰ ℓCᴰ'
-    Cᴰ[FC] = reindex Cᴰ FC
-
-    private
-      module Cᴰ[FC] = Fibers Cᴰ[FC]
-
-    weakenπF : Functorᴰ FC Cᴰ Cᴰ
-    weakenπF .F-obᴰ Γᴰ = πF* Γᴰ .vertexⱽ
-    weakenπF .F-homᴰ {f = γ} {xᴰ = Γᴰ} {yᴰ = Δᴰ} γᴰ =
-      introπF* (Cᴰ.reind (＂π＂-natural γ) (π-πF* Γᴰ Cᴰ.⋆ᴰ γᴰ))
-    weakenπF .F-idᴰ {xᴰ = Γᴰ} =
-        introπF*⟨ FC .F-id  ⟩⟨
-          Cᴰ.rectify $ Cᴰ.≡out $
-            (sym $ Cᴰ.reind-filler _ _)
-            ∙ Cᴰ.⋆IdR _
-            ∙ (sym $ Cᴰ.reind-filler _ _)
-        ⟩
-          ▷ (sym $ weak-ηⱽ (πF* Γᴰ))
-    weakenπF .F-seqᴰ γᴰ δᴰ =
-      introπF*⟨ FC .F-seq _ _ ⟩⟨
-        Cᴰ.rectify $ Cᴰ.≡out $
-          (sym $ Cᴰ.reind-filler _ _)
-          ∙ Cᴰ.⟨ sym $ Cᴰ.reind-filler _ _ ⟩⋆⟨ refl ⟩
-          ∙ (sym $ Cᴰ.⋆Assoc _ _ _)
-          ∙ Cᴰ.⟨ Cᴰ.⟨ Cᴰ.reind-filler _ _ ⟩⋆⟨ refl ⟩
-               ∙ Cᴰ.reind-filler _ _
-               ∙ (Cᴰ.≡in $ sym $ β-πF* (Cᴰ.reind (＂π＂-natural _) (π-πF* _ Cᴰ.⋆ᴰ γᴰ)))
-               ⟩⋆⟨ refl ⟩
-          ∙ (Cᴰ.⋆Assoc _ _ _)
-          ∙ Cᴰ.⟨ refl ⟩⋆⟨ Cᴰ.reind-filler _ _ ⟩
-          ∙ Cᴰ.reind-filler _ _
-      ⟩ ▷ (Cᴰ.rectify $ Cᴰ.≡out $ sym $ introᴰ-natural (πF* _))
-
-    weakenπFⱽ : Functorⱽ Cᴰ Cᴰ[FC]
-    weakenπFⱽ = introF Id (reindF' (FC ∘F Id) Eq.refl Eq.refl weakenπF)
-
-    module _ {Γ} (Γᴰ : Cᴰ.ob[ ＂F Γ ＂ ]) where
-
-      ∀Pshⱽ : Presheafⱽ Γ Cᴰ ℓCᴰ'
-      ∀Pshⱽ = RightAdjointProfⱽ weakenπFⱽ .F-obᴰ Γᴰ
-
-    -- Parametrize by an arbitrary Presheafᴰ
     module _
-      {P : Presheaf C ℓC'}
-      (Pᴰ : Presheafᴰ (F ⟅ P ⟆) Cᴰ ℓPᴰ) where
+      {Γ : C.ob}
+      (Pⱽ : Presheafⱽ (F ⟅ Γ ⟆) Cᴰ ℓPᴰ) where
 
       private
-        module P = PresheafNotation P
-        module FP = PresheafNotation (F ⟅ P ⟆)
-        module Pᴰ = PresheafᴰNotation Pᴰ
+        module Pⱽ = PresheafⱽNotation Pⱽ
+        weakenπFᴰ = PshᴰCL.weakenπFᴰ F πF πF*
 
-      ∀Pshᴰ : Presheafᴰ P Cᴰ ℓPᴰ
-      ∀Pshᴰ .F-obᴰ Γᴰ p =
-        Pᴰ .F-obᴰ ＂πF* Γᴰ ＂ (F-PshHom P .fst _ p)
-      ∀Pshᴰ .F-homᴰ γᴰ p pᴰ =
-        Pᴰ.reind (sym $ F-PshHom P .snd _ _ _ p) $
-          weakenπF .F-homᴰ γᴰ Pᴰ.⋆ᴰ pᴰ
-      ∀Pshᴰ .F-idᴰ = funExt₂ λ p pᴰ →
-        Pᴰ.rectify $ Pᴰ.≡out $
-          (sym $ Pᴰ.reind-filler _ _)
-          ∙ Pᴰ.⟨ Cᴰ.≡in $ weakenπF .F-idᴰ ⟩⋆⟨⟩
-          ∙ Pᴰ.⋆IdL _
-      ∀Pshᴰ .F-seqᴰ γᴰ δᴰ = funExt₂ λ p pᴰ →
-        Pᴰ.rectify $ Pᴰ.≡out $
-          (sym $ Pᴰ.reind-filler _ _)
-          ∙ Pᴰ.⟨ Cᴰ.≡in (weakenπF .F-seqᴰ δᴰ γᴰ) ⟩⋆⟨⟩
-          ∙ Pᴰ.⋆Assoc _ _ _
-          ∙ Pᴰ.⟨ refl ⟩⋆⟨ Pᴰ.reind-filler _ _ ⟩
-          ∙ Pᴰ.reind-filler _ _
+      ∀Pshⱽ : Presheafⱽ Γ Cᴰ ℓPᴰ
+      ∀Pshⱽ .F-obᴰ {x = Δ} Δᴰ δ = Pⱽ .F-obᴰ (πF* Δᴰ .vertexⱽ) (F ⟪ δ ⟫)
+      ∀Pshⱽ .F-homᴰ {x = Δ} {y = Θ} {f = δ} {xᴰ = Δᴰ} {yᴰ = Θᴰ} δᴰ γ γᴰ =
+        Pⱽ.reind (sym $ F .F-seq δ γ) $ (weakenπFᴰ .F-homᴰ δᴰ Pⱽ.⋆ᴰ γᴰ)
+      ∀Pshⱽ .F-idᴰ = funExt₂ λ _ _ →
+        Pⱽ.rectify $ Pⱽ.≡out $
+          (sym $ Pⱽ.reind-filler _ _)
+          ∙ Pⱽ.⟨ Cᴰ.≡in $ weakenπFᴰ .F-idᴰ ⟩⋆⟨⟩
+          ∙ Pⱽ.⋆IdL _
+      ∀Pshⱽ .F-seqᴰ δᴰ θᴰ = funExt₂ λ _ _ →
+        Pⱽ.rectify $ Pⱽ.≡out $
+          (sym $ Pⱽ.reind-filler _ _)
+          ∙ Pⱽ.⟨ Cᴰ.≡in (weakenπFᴰ .F-seqᴰ θᴰ δᴰ) ⟩⋆⟨⟩
+          ∙ Pⱽ.⋆Assoc _ _ _
+          ∙ Pⱽ.⟨ refl ⟩⋆⟨ Pⱽ.reind-filler _ _ ⟩
+          ∙ Pⱽ.reind-filler _ _
 
-      -- An equivalent definition that directly uses
-      -- functoriality of πF*
-      -- but is a lot slower at least with the above holes
-      -- ∀ᴰPshᴰ' : Presheafᴰ P Cᴰ ℓPᴰ
-      -- ∀ᴰPshᴰ' = reind (F-PshHom P) $ (Pᴰ ∘Fᴰ (weakenπF ^opFᴰ))
-
-    module _ {Γ : C.ob} (Γᴰ : Cᴰ.ob[ ＂F Γ ＂ ]) where
+    module _ {Γ : C.ob} (Γᴰ : Cᴰ.ob[ F ⟅ Γ ⟆ ]) where
       UniversalQuantifierF : Type _
-      UniversalQuantifierF = UniversalElementⱽ Cᴰ Γ (∀Pshⱽ Γᴰ)
+      UniversalQuantifierF = UniversalElementⱽ Cᴰ Γ (∀Pshⱽ (Cᴰ [-][-, Γᴰ ]))
 
-      UniversalQuantifierF' : Type _
-      UniversalQuantifierF' =
-        UniversalElementⱽ Cᴰ Γ (∀Pshᴰ (reind α (Cᴰ [-][-, Γᴰ ])))
-        where
-        α : PshHom (F ⟅ C [-, Γ ] ⟆) (C [-, ＂F Γ ＂ ])
-        α = invPshIso {P = C [-, ＂F Γ ＂ ]}{Q = F ⟅ C [-, Γ ] ⟆}
-          (UniversalElementNotation.asPshIso (ueF Γ)) .fst
-
-    module UniversalQuantifierFNotation {Γ}{Γᴰ : Cᴰ.ob[ ＂F Γ ＂ ]}
+    module UniversalQuantifierFNotation {Γ}{Γᴰ : Cᴰ.ob[ F ⟅ Γ ⟆ ]}
       (∀Γᴰ : UniversalQuantifierF Γᴰ) where
 
       module ∀ueFⱽ = UniversalElementⱽ ∀Γᴰ
@@ -423,12 +245,27 @@ module _
       vert : Cᴰ.ob[ Γ ]
       vert = ∀ueFⱽ.vertexⱽ
 
-      app : Cᴰ [ FC ⟪ C.id ⟫ ][ ＂πF* vert ＂ , Γᴰ ]
+      app : Cᴰ [ F ⟪ C.id ⟫ ][ vertexⱽ (πF* ∀ueFⱽ.vertexⱽ) , Γᴰ ]
       app = ∀ueFⱽ.elementⱽ
 
       lda : ∀ {Δ} {Δᴰ : Cᴰ.ob[ Δ ]} {γ} →
-        Cᴰ [ FC ⟪ γ ⟫ ][ ＂πF* Δᴰ ＂ , Γᴰ ] →
+        Cᴰ [ F ⟪ γ ⟫ ][ vertexⱽ (πF* Δᴰ) , Γᴰ ] →
         Cᴰ [ γ ][ Δᴰ , vert ]
       lda = ∀ueFⱽ.universalⱽ .fst
 
-      -- TODO the rest of the interface
+module _
+  {C : Category ℓC ℓC'}
+  {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
+  {a : C .Category.ob}
+  (bp : BinProductsWith C a)
+  where
+
+  private
+    module bp = BinProductsWithNotation bp
+    module C = Category C
+    module Cᴰ = Fibers Cᴰ
+
+  module _ (π₁* : ∀ {Γ} → (Γᴰ : Cᴰ.ob[ Γ ]) → PshᴰCL.CartesianLift' bp.π₁ (Cᴰ [-][-, Γᴰ ]))
+    {Γ} (Γᴰ : Cᴰ.ob[ Γ bp.×a ]) where
+    UniveralQuantifier' : Type _
+    UniveralQuantifier' = UniversalQuantifierF bp.×aF bp.π₁Nat π₁* Γᴰ

--- a/Cubical/Categories/Displayed/Quantifiers.agda
+++ b/Cubical/Categories/Displayed/Quantifiers.agda
@@ -190,7 +190,7 @@ module _
   {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
   (F : Functor (PresheafCategory C ℓC') (PresheafCategory C ℓC'))
   (πF : NatTrans F Id)
-  (ueF : (Q : Presheaf C ℓC') → UniversalElement C (F ⟅ Q ⟆))
+  (ueF : (Γ : C .Category.ob) → UniversalElement C (F ⟅ C [-, Γ ] ⟆))
   where
 
   open UniversalElement
@@ -198,26 +198,61 @@ module _
     module C = Category C
     module Cᴰ = Fibers Cᴰ
     module Psh = Category (PresheafCategory C ℓC')
-    module SET = Category (SET ℓC')
-    -- module _ {Q : Presheaf C ℓC'} where
-    --   module ueF = UniversalElementNotation (ueF Q)
 
     πF-PshHom : ∀ Q → PshHom (F ⟅ Q ⟆) Q
     πF-PshHom Q = NatTrans→PshHom (πF .N-ob Q)
 
     ＂F_＂ : C.ob → C.ob
-    ＂F Γ ＂ = ueF (C [-, Γ ]) .vertex
+    ＂F Γ ＂ = ueF Γ .vertex
 
     ＂π＂ : {Γ : C.ob} → C [ ＂F Γ ＂ , Γ ]
-    ＂π＂ {Γ = Γ} = πF-PshHom (C [-, Γ ]) .fst ＂F Γ ＂ $ ueF (C [-, Γ ]) .element
+    ＂π＂ {Γ = Γ} = πF ⟦ C [-, Γ ] ⟧ ⟦ ＂F Γ ＂ ⟧ $ ueF Γ .element
 
     -- F extends a functor on C
     FC : Functor C C
-    FC = FunctorComprehension (F ∘F YO) (λ Γ → ueF (C [-, Γ ]))
+    FC = FunctorComprehension (F ∘F YO) (λ Γ → ueF Γ)
+
+    よ＂π＂≡ : (Γ : C.ob) → YO ⟪ ＂π＂ {Γ} ⟫ ≡
+       seqTrans (no-no-no (F ⟅ C [-, Γ ] ⟆) (ueF Γ .element))
+                (πF ⟦ C [-, Γ ] ⟧)
+    よ＂π＂≡ Γ = {!!}
+
+    ＂π＂-natural : ∀ {Γ}{Δ}(γ : C [ Γ , Δ ]) → ＂π＂ C.⋆ γ ≡ FC ⟪ γ ⟫ C.⋆ ＂π＂
+    ＂π＂-natural {Γ}{Δ} γ =
+      {!!}
+      -- isFaithfulYO {C = C} ＂F Γ ＂ Δ _ _ $
+      --   YO .F-seq ＂π＂ γ
+      --   ∙ cong₂ seqTrans (よ＂π＂≡ Γ) refl
+      --   ∙ (Psh.⋆Assoc
+      --       (no-no-no (F ⟅ C [-, Γ ] ⟆) (ueF Γ .element))
+      --       (πF ⟦ C [-, Γ ] ⟧)
+      --       (YO {C = C} ⟪ γ ⟫))
+      --   ∙ cong₂ seqTrans refl (sym $ πF .N-hom (no-no-no (C [-, Δ ]) γ))
+      --   ∙ (sym $ Psh.⋆Assoc (PshHom→NatTrans (yoRec (F ⟅ C [-, Γ ] ⟆) (ueF Γ .element))) (F ⟪ no-no-no (C [-, Δ ]) γ ⟫) (πF ⟦ C [-, Δ ] ⟧))
+      --   ∙ cong₂ seqTrans x refl
+      --   ∙ (Psh.⋆Assoc
+      --       (YO {C = C} ⟪ FC ⟪ γ ⟫ ⟫)
+      --       (no-no-no (F ⟅ C [-, Δ ] ⟆) (ueF Δ .element))
+      --       (πF ⟦ C [-, Δ ] ⟧)
+      --      )
+      --   ∙ cong₂ seqTrans refl (sym $ よ＂π＂≡ Δ)
+      --   -- ∙ cong₂ seqTrans {!!} refl
+      --   ∙ (sym $ YO {C = C} .F-seq {x = ＂F Γ ＂} {y = ＂F Δ ＂} {z = Δ}
+      --             (FC ⟪ γ ⟫) ＂π＂)
+       where
+       module ueFΓ = UniversalElementNotation (ueF Γ)
+       module ueFΔ = UniversalElementNotation (ueF Δ)
+       module FΔ = PresheafNotation (F ⟅ C [-, Δ ] ⟆)
+
+       -- x : seqTrans (PshHom→NatTrans (yoRec (F ⟅ C [-, Γ ] ⟆) (ueF Γ .element)))
+       --              (F ⟪ PshHom→NatTrans $ yoRec (C [-, Δ ]) γ ⟫)
+       --     ≡ seqTrans {G = C [-, ＂F Δ ＂ ]} (PshHom→NatTrans (yoRec (C [-, ＂F Δ ＂ ]) (FC ⟪ γ ⟫)))
+       --                (PshHom→NatTrans (yoRec (F ⟅ C [-, Δ ] ⟆) (ueF Δ .element)))
+       -- x = {!!}
 
     module _ (Γ : C.ob) where
       F-PshHom : PshHom (C [-, Γ ]) ((F ⟅ C [-, Γ ] ⟆) ∘F (FC ^opF))
-      F-PshHom = yoRec ((F ⟅ C [-, Γ ] ⟆) ∘F (FC ^opF)) (ueF (C [-, Γ ]) .element)
+      F-PshHom = yoRec ((F ⟅ C [-, Γ ] ⟆) ∘F (FC ^opF)) (ueF Γ .element)
 
   module _
     (πF* : {Γ : C.ob} → (Γᴰ : Cᴰ.ob[ Γ ]) →
@@ -229,182 +264,202 @@ module _
     Cᴰ[FC] : Categoryᴰ C ℓCᴰ ℓCᴰ'
     Cᴰ[FC] = reindex Cᴰ FC
 
+    private
+      module Cᴰ[FC] = Fibers Cᴰ[FC]
+
     weakenπF : Functorⱽ Cᴰ Cᴰ[FC]
-    weakenπF .F-obᴰ Γᴰ = πF* Γᴰ .vertexⱽ
-    weakenπF .F-homᴰ {xᴰ = Γᴰ} {yᴰ = Δᴰ} γᴰ =
-      introᴰ (πF* Δᴰ) (Cᴰ.reind {!!} $ πF* Γᴰ .elementⱽ Cᴰ.⋆ᴰ γᴰ)
-    weakenπF .F-idᴰ = {!!}
-    weakenπF .F-seqᴰ = {!!}
+    weakenπF = FunctorⱽComprehension (λ Γ Γᴰ → {!πF* Γᴰ!})
 
-    module _ {Γ} {Γᴰ : Cᴰ.ob[ ＂F Γ ＂ ]} where
+  --   weakenπF .F-obᴰ Γᴰ = πF* Γᴰ .vertexⱽ
+  --   weakenπF .F-homᴰ {f = γ} {xᴰ = Γᴰ} {yᴰ = Δᴰ} γᴰ =
+  --     {!!}
+  --     -- introᴰ (πF* Δᴰ) $
+  --     --   {!!}
+  --       -- Cᴰ.reind (cong₂ C._⋆_ (C.⋆IdL _) refl ∙ ＂π＂-natural _) $
+  --       -- Cᴰ.reind ({!!} ∙ ＂π＂-natural γ) $
+  --       --   πF* Γᴰ .elementⱽ Cᴰ.⋆ᴰ γᴰ
+  --   weakenπF .F-idᴰ {xᴰ = Γᴰ} =
+  --     {!!}
 
-      ∀Pshᴰ : Presheafⱽ Γ Cᴰ ℓCᴰ'
-      ∀Pshᴰ = RightAdjointProfⱽ weakenπF .F-obᴰ Γᴰ
+  --     -- Cᴰ.rectify $ Cᴰ.≡out $
+  --     --   introᴰ≡ (πF* _)
+  --     --     ({!Cᴰ[FC].≡in!}
+  --     --     ∙ {!!})
+  --     -- Cᴰ.rectify $ Cᴰ.≡out $
+  --     --   introᴰ≡ {!πF* Γᴰ!} $
+  --     --     (sym $ Cᴰ.reind-filler _ _)
+  --     --     ∙ {!!}
+  --   weakenπF .F-seqᴰ = {!!}
 
-  --   module _ (Q : Presheaf C ℓC') where
-  --     private
-  --       module Q = PresheafNotation Q
-  --       module FQ = PresheafNotation (F ⟅ Q ⟆)
-  --     F-elt : ∀ {Γ} → (q : Q.p[ Γ ]) → FQ.p[ ＂F Γ ＂ ]
-  --     F-elt {Γ} q =
-  --       F ⟪ PshHom→NatTrans (yoRec Q q) ⟫ ⟦ ＂F Γ ＂ ⟧ $
-  --         ueF (C [-, Γ ]) .element
+  --   module _ {Γ} {Γᴰ : Cᴰ.ob[ ＂F Γ ＂ ]} where
 
-  --     -- TODO
-  --     F-elt-natural :
-  --       ∀ {Γ} {Δ} {γ : C [ Γ , Δ ]} (q : Q.p[ Δ ]) →
-  --       F-elt (γ Q.⋆ q) ≡ (FC ⟪ γ ⟫) FQ.⋆ F-elt q
-  --     F-elt-natural {Γ = Γ}{Δ = Δ}{γ = γ} q =
-  --       cong (λ z → z ⟦ ＂F Γ ＂ ⟧ $ ueF (C [-, Γ ]) .element) F⟨-⋆γ⟩
-  --       ∙ x
-  --       where
-  --       -⋆γ : PshHom (C [-, Γ ]) (C [-, Δ ])
-  --       -⋆γ = yoRec (C [-, Δ ]) γ
+  --     ∀Pshᴰ : Presheafⱽ Γ Cᴰ ℓCᴰ'
+  --     ∀Pshᴰ = RightAdjointProfⱽ weakenπF .F-obᴰ Γᴰ
 
-  --       -⋆Fγ : PshHom (C [-, ＂F Γ ＂ ]) (C [-, ＂F Δ ＂ ])
-  --       -⋆Fγ = yoRec (C [-, ＂F Δ ＂ ]) {!!}
+  -- --   module _ (Q : Presheaf C ℓC') where
+  -- --     private
+  -- --       module Q = PresheafNotation Q
+  -- --       module FQ = PresheafNotation (F ⟅ Q ⟆)
+  -- --     F-elt : ∀ {Γ} → (q : Q.p[ Γ ]) → FQ.p[ ＂F Γ ＂ ]
+  -- --     F-elt {Γ} q =
+  -- --       F ⟪ PshHom→NatTrans (yoRec Q q) ⟫ ⟦ ＂F Γ ＂ ⟧ $
+  -- --         ueF (C [-, Γ ]) .element
 
-  --       F⟨-⋆γ⟩ :
-  --         F ⟪ PshHom→NatTrans (yoRec Q (γ Q.⋆ q)) ⟫
-  --           ≡ F .F-hom {x = C [-, Γ ]}{y = C [-, Δ ]}
-  --              (PshHom→NatTrans -⋆γ) Psh.⋆
-  --             F ⟪ PshHom→NatTrans (yoRec Q q) ⟫
-  --       F⟨-⋆γ⟩ =
-  --         cong (F .F-hom)
-  --           ((cong PshHom→NatTrans
-  --             (sym $ yoRec-natural (C [-, Δ ]) Q (yoRec Q q)))
-  --             ∙ {!!})
-  --         ∙ (F .F-seq _ _)
+  -- --     -- TODO
+  -- --     F-elt-natural :
+  -- --       ∀ {Γ} {Δ} {γ : C [ Γ , Δ ]} (q : Q.p[ Δ ]) →
+  -- --       F-elt (γ Q.⋆ q) ≡ (FC ⟪ γ ⟫) FQ.⋆ F-elt q
+  -- --     F-elt-natural {Γ = Γ}{Δ = Δ}{γ = γ} q =
+  -- --       cong (λ z → z ⟦ ＂F Γ ＂ ⟧ $ ueF (C [-, Γ ]) .element) F⟨-⋆γ⟩
+  -- --       ∙ x
+  -- --       where
+  -- --       -⋆γ : PshHom (C [-, Γ ]) (C [-, Δ ])
+  -- --       -⋆γ = yoRec (C [-, Δ ]) γ
 
-  --       module FよΔ = PresheafNotation (F ⟅ C [-, Δ ] ⟆)
+  -- --       -⋆Fγ : PshHom (C [-, ＂F Γ ＂ ]) (C [-, ＂F Δ ＂ ])
+  -- --       -⋆Fγ = yoRec (C [-, ＂F Δ ＂ ]) {!!}
 
-  --       y :
-  --         ((F ⟪ PshHom→NatTrans -⋆γ ⟫) ⟦ ＂F Γ ＂ ⟧ $ _) ≡
-  --           (FC ⟪ γ ⟫) FよΔ.⋆ ueF (C [-, Δ ]) .element
-  --       y =
-  --         {!!}
+  -- --       F⟨-⋆γ⟩ :
+  -- --         F ⟪ PshHom→NatTrans (yoRec Q (γ Q.⋆ q)) ⟫
+  -- --           ≡ F .F-hom {x = C [-, Γ ]}{y = C [-, Δ ]}
+  -- --              (PshHom→NatTrans -⋆γ) Psh.⋆
+  -- --             F ⟪ PshHom→NatTrans (yoRec Q q) ⟫
+  -- --       F⟨-⋆γ⟩ =
+  -- --         cong (F .F-hom)
+  -- --           ((cong PshHom→NatTrans
+  -- --             (sym $ yoRec-natural (C [-, Δ ]) Q (yoRec Q q)))
+  -- --             ∙ {!!})
+  -- --         ∙ (F .F-seq _ _)
 
-  --       x :
-  --         ((F ⟪ PshHom→NatTrans (yoRec Q q) ⟫) ⟦ ＂F Γ ＂ ⟧ $
-  --             ((F ⟪ PshHom→NatTrans -⋆γ ⟫) ⟦ ＂F Γ ＂ ⟧ $ (ueF (C [-, Γ ]) .element)))
-  --         ≡ FC ⟪ γ ⟫ FQ.⋆ F-elt q
-  --       x =
-  --         cong (F ⟪ PshHom→NatTrans (yoRec Q q) ⟫ ⟦ ＂F Γ ＂ ⟧) y
-  --         ∙ funExt⁻ ((F ⟪ PshHom→NatTrans (yoRec Q q) ⟫) .N-hom (FC ⟪ γ ⟫)) _
+  -- --       module FよΔ = PresheafNotation (F ⟅ C [-, Δ ] ⟆)
 
-  --     F-PshHom : PshHom Q ((F ⟅ Q ⟆) ∘F (FC ^opF))
-  --     F-PshHom .fst Γ = F-elt
-  --     F-PshHom .snd Γ Δ γ = F-elt-natural
+  -- --       y :
+  -- --         ((F ⟪ PshHom→NatTrans -⋆γ ⟫) ⟦ ＂F Γ ＂ ⟧ $ _) ≡
+  -- --           (FC ⟪ γ ⟫) FよΔ.⋆ ueF (C [-, Δ ]) .element
+  -- --       y =
+  -- --         {!!}
 
-  --   ＂π＂ : {Γ : C.ob} → C [ ＂F Γ ＂ , Γ ]
-  --   ＂π＂ {Γ = Γ} =
-  --     -- natTrans or PshHom here?
-  --     πF-PshHom (C [-, Γ ]) .fst ＂F Γ ＂ $ ueF (C [-, Γ ]) .element
+  -- --       x :
+  -- --         ((F ⟪ PshHom→NatTrans (yoRec Q q) ⟫) ⟦ ＂F Γ ＂ ⟧ $
+  -- --             ((F ⟪ PshHom→NatTrans -⋆γ ⟫) ⟦ ＂F Γ ＂ ⟧ $ (ueF (C [-, Γ ]) .element)))
+  -- --         ≡ FC ⟪ γ ⟫ FQ.⋆ F-elt q
+  -- --       x =
+  -- --         cong (F ⟪ PshHom→NatTrans (yoRec Q q) ⟫ ⟦ ＂F Γ ＂ ⟧) y
+  -- --         ∙ funExt⁻ ((F ⟪ PshHom→NatTrans (yoRec Q q) ⟫) .N-hom (FC ⟪ γ ⟫)) _
+
+  -- --     F-PshHom : PshHom Q ((F ⟅ Q ⟆) ∘F (FC ^opF))
+  -- --     F-PshHom .fst Γ = F-elt
+  -- --     F-PshHom .snd Γ Δ γ = F-elt-natural
+
+  -- --   ＂π＂ : {Γ : C.ob} → C [ ＂F Γ ＂ , Γ ]
+  -- --   ＂π＂ {Γ = Γ} =
+  -- --     -- natTrans or PshHom here?
+  -- --     πF-PshHom (C [-, Γ ]) .fst ＂F Γ ＂ $ ueF (C [-, Γ ]) .element
 
 
-  -- module _
-  --   (πF* : {Γ : C.ob} → (Γᴰ : Cᴰ.ob[ Γ ]) →
-  --     PshᴰCL.isFibration' (Cᴰ [-][-, Γᴰ ]))
-  --   where
+  -- -- module _
+  -- --   (πF* : {Γ : C.ob} → (Γᴰ : Cᴰ.ob[ Γ ]) →
+  -- --     PshᴰCL.isFibration' (Cᴰ [-][-, Γᴰ ]))
+  -- --   where
 
-  --   open UniversalElementⱽ
+  -- --   open UniversalElementⱽ
 
-  --   private
-  --     -- TODO
-  --     πF*-F-homᴰ : ∀ {Γ} {Δ} {γ : C [ Γ , Δ ]} →
-  --       {Γᴰ : Cᴰ.ob[ Γ ]} {Δᴰ : Cᴰ.ob[ Δ ]}
-  --       (γᴰ : Cᴰ [ γ ][ Γᴰ , Δᴰ ]) →
-  --       Cᴰ [ FC ⟪ γ ⟫ ][ πF* Γᴰ ＂π＂ .vertexⱽ ,
-  --                        πF* Δᴰ ＂π＂ .vertexⱽ ]
-  --     πF*-F-homᴰ {Γ = Γ} {Δ = Δ} {γ = γ} {Γᴰ = Γᴰ} {Δᴰ = Δᴰ} γᴰ =
-  --       introᴰ (πF* Δᴰ ＂π＂) $
-  --         Cᴰ.reind (
-  --           (cong₂ C._⋆_ (C.⋆IdL _) refl)
-  --           ∙ πF-natural) $
-  --           (πF* Γᴰ ＂π＂ .elementⱽ Cᴰ.⋆ᴰ γᴰ)
-  --       where
-  --       πF-natural : ＂π＂ C.⋆ γ ≡ FC ⟪ γ ⟫ C.⋆ ＂π＂
-  --       πF-natural = {!!}
+  -- --   private
+  -- --     -- TODO
+  -- --     πF*-F-homᴰ : ∀ {Γ} {Δ} {γ : C [ Γ , Δ ]} →
+  -- --       {Γᴰ : Cᴰ.ob[ Γ ]} {Δᴰ : Cᴰ.ob[ Δ ]}
+  -- --       (γᴰ : Cᴰ [ γ ][ Γᴰ , Δᴰ ]) →
+  -- --       Cᴰ [ FC ⟪ γ ⟫ ][ πF* Γᴰ ＂π＂ .vertexⱽ ,
+  -- --                        πF* Δᴰ ＂π＂ .vertexⱽ ]
+  -- --     πF*-F-homᴰ {Γ = Γ} {Δ = Δ} {γ = γ} {Γᴰ = Γᴰ} {Δᴰ = Δᴰ} γᴰ =
+  -- --       introᴰ (πF* Δᴰ ＂π＂) $
+  -- --         Cᴰ.reind (
+  -- --           (cong₂ C._⋆_ (C.⋆IdL _) refl)
+  -- --           ∙ πF-natural) $
+  -- --           (πF* Γᴰ ＂π＂ .elementⱽ Cᴰ.⋆ᴰ γᴰ)
+  -- --       where
+  -- --       πF-natural : ＂π＂ C.⋆ γ ≡ FC ⟪ γ ⟫ C.⋆ ＂π＂
+  -- --       πF-natural = {!!}
 
-  --     -- TODO
-  --     πF*-F-idᴰ : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} →
-  --       PathP
-  --         (λ i →
-  --           Cᴰ [ FC .F-id i ][ πF* Γᴰ ＂π＂ .vertexⱽ ,
-  --                              πF* Γᴰ ＂π＂ .vertexⱽ ])
-  --         (πF*-F-homᴰ {Γᴰ = Γᴰ} Cᴰ.idᴰ)
-  --         Cᴰ.idᴰ
-  --     πF*-F-idᴰ = {!!}
+  -- --     -- TODO
+  -- --     πF*-F-idᴰ : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} →
+  -- --       PathP
+  -- --         (λ i →
+  -- --           Cᴰ [ FC .F-id i ][ πF* Γᴰ ＂π＂ .vertexⱽ ,
+  -- --                              πF* Γᴰ ＂π＂ .vertexⱽ ])
+  -- --         (πF*-F-homᴰ {Γᴰ = Γᴰ} Cᴰ.idᴰ)
+  -- --         Cᴰ.idᴰ
+  -- --     πF*-F-idᴰ = {!!}
 
-  --     -- TODO
-  --     πF*-F-seqᴰ :
-  --       ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]}
-  --         {Δ} {Δᴰ : Cᴰ.ob[ Δ ]}
-  --         {Θ} {Θᴰ : Cᴰ.ob[ Θ ]} →
-  --         {γ : C [ Γ , Δ ]} →
-  --         {δ : C [ Δ , Θ ]} →
-  --       (γᴰ : Cᴰ [ γ ][ Γᴰ , Δᴰ ]) →
-  --       (δᴰ : Cᴰ [ δ ][ Δᴰ , Θᴰ ]) →
-  --       PathP
-  --         (λ i →
-  --           Cᴰ [ FC .F-seq γ δ i ][ πF* Γᴰ ＂π＂ .vertexⱽ ,
-  --                                   πF* Θᴰ ＂π＂ .vertexⱽ ])
-  --         (πF*-F-homᴰ (γᴰ Cᴰ.⋆ᴰ δᴰ))
-  --         (πF*-F-homᴰ γᴰ Cᴰ.⋆ᴰ πF*-F-homᴰ δᴰ)
-  --     πF*-F-seqᴰ = {!!}
+  -- --     -- TODO
+  -- --     πF*-F-seqᴰ :
+  -- --       ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]}
+  -- --         {Δ} {Δᴰ : Cᴰ.ob[ Δ ]}
+  -- --         {Θ} {Θᴰ : Cᴰ.ob[ Θ ]} →
+  -- --         {γ : C [ Γ , Δ ]} →
+  -- --         {δ : C [ Δ , Θ ]} →
+  -- --       (γᴰ : Cᴰ [ γ ][ Γᴰ , Δᴰ ]) →
+  -- --       (δᴰ : Cᴰ [ δ ][ Δᴰ , Θᴰ ]) →
+  -- --       PathP
+  -- --         (λ i →
+  -- --           Cᴰ [ FC .F-seq γ δ i ][ πF* Γᴰ ＂π＂ .vertexⱽ ,
+  -- --                                   πF* Θᴰ ＂π＂ .vertexⱽ ])
+  -- --         (πF*-F-homᴰ (γᴰ Cᴰ.⋆ᴰ δᴰ))
+  -- --         (πF*-F-homᴰ γᴰ Cᴰ.⋆ᴰ πF*-F-homᴰ δᴰ)
+  -- --     πF*-F-seqᴰ = {!!}
 
-  --     -- Should probably call this weakenF instead
-  --     πF*-Functorᴰ : Functorᴰ FC Cᴰ Cᴰ
-  --     πF*-Functorᴰ .F-obᴰ Γᴰ = πF* Γᴰ ＂π＂ .vertexⱽ
-  --     πF*-Functorᴰ .F-homᴰ = πF*-F-homᴰ
-  --     πF*-Functorᴰ .F-idᴰ = πF*-F-idᴰ
-  --     πF*-Functorᴰ .F-seqᴰ = πF*-F-seqᴰ
+  -- --     -- Should probably call this weakenF instead
+  -- --     πF*-Functorᴰ : Functorᴰ FC Cᴰ Cᴰ
+  -- --     πF*-Functorᴰ .F-obᴰ Γᴰ = πF* Γᴰ ＂π＂ .vertexⱽ
+  -- --     πF*-Functorᴰ .F-homᴰ = πF*-F-homᴰ
+  -- --     πF*-Functorᴰ .F-idᴰ = πF*-F-idᴰ
+  -- --     πF*-Functorᴰ .F-seqᴰ = πF*-F-seqᴰ
 
-  --   module _
-  --     {P : Presheaf C ℓC'}
-  --     (Pᴰ : Presheafᴰ (F ⟅ P ⟆) Cᴰ ℓPᴰ) where
+  -- --   module _
+  -- --     {P : Presheaf C ℓC'}
+  -- --     (Pᴰ : Presheafᴰ (F ⟅ P ⟆) Cᴰ ℓPᴰ) where
 
-  --     private
-  --       module P = PresheafNotation P
-  --       module FP = PresheafNotation (F ⟅ P ⟆)
-  --       module Pᴰ = PresheafᴰNotation Pᴰ
+  -- --     private
+  -- --       module P = PresheafNotation P
+  -- --       module FP = PresheafNotation (F ⟅ P ⟆)
+  -- --       module Pᴰ = PresheafᴰNotation Pᴰ
 
-  --     -- Trying to do this manually and I
-  --     -- run into obligations that seem to necessitate
-  --     -- functorialiaty for πF*
-  --     -- At the very least, the functoriality of πF* is
-  --     -- sufficient
-  --     ∀ᴰPshᴰ : Presheafᴰ P Cᴰ ℓPᴰ
-  --     ∀ᴰPshᴰ .F-obᴰ Γᴰ p =
-  --       Pᴰ .F-obᴰ (πF* Γᴰ ＂π＂ .vertexⱽ) (F-elt P p)
-  --     ∀ᴰPshᴰ .F-homᴰ γᴰ p pᴰ =
-  --       Pᴰ.reind (sym $ F-elt-natural P p) $
-  --         πF*-F-homᴰ γᴰ Pᴰ.⋆ᴰ pᴰ
-  --     ∀ᴰPshᴰ .F-idᴰ = funExt₂ λ p pᴰ →
-  --       Pᴰ.rectify $ Pᴰ.≡out $
-  --         (sym $ Pᴰ.reind-filler _ _)
-  --         ∙ Pᴰ.⟨ Cᴰ.≡in πF*-F-idᴰ ⟩⋆⟨⟩
-  --         ∙ Pᴰ.⋆IdL _
-  --     ∀ᴰPshᴰ .F-seqᴰ γᴰ δᴰ = funExt₂ λ p pᴰ →
-  --       Pᴰ.rectify $ Pᴰ.≡out $
-  --         (sym $ Pᴰ.reind-filler _ _)
-  --         ∙ Pᴰ.⟨ Cᴰ.≡in (πF*-F-seqᴰ δᴰ γᴰ) ⟩⋆⟨⟩
-  --         ∙ Pᴰ.⋆Assoc _ _ _
-  --         ∙ Pᴰ.⟨ refl ⟩⋆⟨ Pᴰ.reind-filler _ _ ⟩
-  --         ∙ Pᴰ.reind-filler _ _
+  -- --     -- Trying to do this manually and I
+  -- --     -- run into obligations that seem to necessitate
+  -- --     -- functorialiaty for πF*
+  -- --     -- At the very least, the functoriality of πF* is
+  -- --     -- sufficient
+  -- --     ∀ᴰPshᴰ : Presheafᴰ P Cᴰ ℓPᴰ
+  -- --     ∀ᴰPshᴰ .F-obᴰ Γᴰ p =
+  -- --       Pᴰ .F-obᴰ (πF* Γᴰ ＂π＂ .vertexⱽ) (F-elt P p)
+  -- --     ∀ᴰPshᴰ .F-homᴰ γᴰ p pᴰ =
+  -- --       Pᴰ.reind (sym $ F-elt-natural P p) $
+  -- --         πF*-F-homᴰ γᴰ Pᴰ.⋆ᴰ pᴰ
+  -- --     ∀ᴰPshᴰ .F-idᴰ = funExt₂ λ p pᴰ →
+  -- --       Pᴰ.rectify $ Pᴰ.≡out $
+  -- --         (sym $ Pᴰ.reind-filler _ _)
+  -- --         ∙ Pᴰ.⟨ Cᴰ.≡in πF*-F-idᴰ ⟩⋆⟨⟩
+  -- --         ∙ Pᴰ.⋆IdL _
+  -- --     ∀ᴰPshᴰ .F-seqᴰ γᴰ δᴰ = funExt₂ λ p pᴰ →
+  -- --       Pᴰ.rectify $ Pᴰ.≡out $
+  -- --         (sym $ Pᴰ.reind-filler _ _)
+  -- --         ∙ Pᴰ.⟨ Cᴰ.≡in (πF*-F-seqᴰ δᴰ γᴰ) ⟩⋆⟨⟩
+  -- --         ∙ Pᴰ.⋆Assoc _ _ _
+  -- --         ∙ Pᴰ.⟨ refl ⟩⋆⟨ Pᴰ.reind-filler _ _ ⟩
+  -- --         ∙ Pᴰ.reind-filler _ _
 
-  --     -- An equivalent definition that directly uses
-  --     -- functoriality of πF*
-  --     -- but is a lot slower at least with the above holes
-  --     -- ∀ᴰPshᴰ' : Presheafᴰ P Cᴰ ℓPᴰ
-  --     -- ∀ᴰPshᴰ' = reind (F-PshHom P) $
-  --     --   (Pᴰ ∘Fᴰ (πF*-Functorᴰ ^opFᴰ))
+  -- --     -- An equivalent definition that directly uses
+  -- --     -- functoriality of πF*
+  -- --     -- but is a lot slower at least with the above holes
+  -- --     -- ∀ᴰPshᴰ' : Presheafᴰ P Cᴰ ℓPᴰ
+  -- --     -- ∀ᴰPshᴰ' = reind (F-PshHom P) $
+  -- --     --   (Pᴰ ∘Fᴰ (πF*-Functorᴰ ^opFᴰ))
 
-  --   module _ {Γ : C.ob} {Γᴰ : Cᴰ.ob[ ＂F Γ ＂ ]} where
-  --     ∀ᴰ : Type _
-  --     ∀ᴰ = UniversalElementⱽ Cᴰ Γ
-  --       (∀ᴰPshᴰ (reind α (Cᴰ [-][-, Γᴰ ])))
-  --       where
-  --       α : PshHom (F ⟅ C [-, Γ ] ⟆) (C [-, ＂F Γ ＂ ])
-  --       α = invPshIso {P = C [-, ＂F Γ ＂ ]}{Q = F ⟅ C [-, Γ ] ⟆}
-  --         (UniversalElementNotation.asPshIso (ueF (C [-, Γ ]))) .fst
+  -- --   module _ {Γ : C.ob} {Γᴰ : Cᴰ.ob[ ＂F Γ ＂ ]} where
+  -- --     ∀ᴰ : Type _
+  -- --     ∀ᴰ = UniversalElementⱽ Cᴰ Γ
+  -- --       (∀ᴰPshᴰ (reind α (Cᴰ [-][-, Γᴰ ])))
+  -- --       where
+  -- --       α : PshHom (F ⟅ C [-, Γ ] ⟆) (C [-, ＂F Γ ＂ ])
+  -- --       α = invPshIso {P = C [-, ＂F Γ ＂ ]}{Q = F ⟅ C [-, Γ ] ⟆}
+  -- --         (UniversalElementNotation.asPshIso (ueF (C [-, Γ ]))) .fst

--- a/Cubical/Categories/Displayed/Quantifiers.agda
+++ b/Cubical/Categories/Displayed/Quantifiers.agda
@@ -14,6 +14,7 @@ open import Cubical.Categories.Yoneda
 open import Cubical.Categories.Constructions.Fiber
 open import Cubical.Categories.Limits.BinProduct.More
 open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.Morphism.Alt
 open import Cubical.Categories.Presheaf.Representable
 open import Cubical.Categories.Presheaf.More
 open import Cubical.Categories.Instances.Sets
@@ -22,6 +23,7 @@ open import Cubical.Categories.FunctorComprehension
 
 open import Cubical.Categories.Displayed.Base
 open import Cubical.Categories.Displayed.Instances.Sets
+open import Cubical.Categories.Displayed.Instances.Functor.Base
 open import Cubical.Categories.Displayed.Functor
 open import Cubical.Categories.Displayed.Profunctor
 open import Cubical.Categories.Displayed.Functor.More
@@ -41,7 +43,7 @@ import Cubical.Categories.Displayed.Presheaf.CartesianLift as PshᴰCL
 
 private
   variable
-    ℓC ℓC' ℓCᴰ ℓCᴰ' ℓ ℓ' ℓP ℓPᴰ : Level
+    ℓC ℓC' ℓCᴰ ℓCᴰ' ℓ ℓ' ℓP ℓPᴰ ℓD ℓD' ℓDᴰ ℓDᴰ' : Level
 
 module _
   {C : Category ℓC ℓC'}
@@ -60,6 +62,7 @@ module _
   Cᴰ[-×a] = reindex Cᴰ bp.×aF
 
   open Functorᴰ
+
   weakenⱽ : Functorⱽ Cᴰ Cᴰ[-×a]
   weakenⱽ .F-obᴰ bᴰ = isFib.f*yᴰ bᴰ bp.π₁
   weakenⱽ .F-homᴰ fᴰ =
@@ -178,6 +181,7 @@ module _
   UniversalQuantifiers = ∀ a Γ pᴰ
     → UniversalQuantifier {a = a} (λ c → bp (c , a)) isFib {Γ = Γ} pᴰ
 
+
 open NatTrans
 open Functor
 open Functorᴰ
@@ -195,8 +199,8 @@ module _
     module Cᴰ = Fibers Cᴰ
     module Psh = Category (PresheafCategory C ℓC')
     module SET = Category (SET ℓC')
-    module _ {Q : Presheaf C ℓC'} where
-      module ueF = UniversalElementNotation (ueF Q)
+    -- module _ {Q : Presheaf C ℓC'} where
+    --   module ueF = UniversalElementNotation (ueF Q)
 
     πF-PshHom : ∀ Q → PshHom (F ⟅ Q ⟆) Q
     πF-PshHom Q = NatTrans→PshHom (πF .N-ob Q)
@@ -204,151 +208,203 @@ module _
     ＂F_＂ : C.ob → C.ob
     ＂F Γ ＂ = ueF (C [-, Γ ]) .vertex
 
+    ＂π＂ : {Γ : C.ob} → C [ ＂F Γ ＂ , Γ ]
+    ＂π＂ {Γ = Γ} = πF-PshHom (C [-, Γ ]) .fst ＂F Γ ＂ $ ueF (C [-, Γ ]) .element
+
     -- F extends a functor on C
-    -- i.e when F (Yo c) ≅ Yo c', define FC c := c'
     FC : Functor C C
     FC = FunctorComprehension (F ∘F YO) (λ Γ → ueF (C [-, Γ ]))
 
-    module _ (Q : Presheaf C ℓC') where
-      private
-        module Q = PresheafNotation Q
-        module FQ = PresheafNotation (F ⟅ Q ⟆)
-      F-elt : ∀ {Γ} → (q : Q.p[ Γ ]) → FQ.p[ ＂F Γ ＂ ]
-      F-elt {Γ} q =
-        F ⟪ PshHom→NatTrans (yoRec Q q) ⟫ ⟦ ＂F Γ ＂ ⟧ $
-          ueF (C [-, Γ ]) .element
-
-      -- TODO
-      F-elt-natural :
-        ∀ {Γ} {Δ} {γ : C [ Γ , Δ ]} (q : Q.p[ Δ ]) →
-        F-elt (γ Q.⋆ q) ≡ (FC ⟪ γ ⟫) FQ.⋆ F-elt q
-      F-elt-natural {Γ = Γ}{Δ = Δ}{γ = γ} q =
-        {!!}
-        -- I don't think this lemma would actually help
-        -- funExt⁻ F-elt-natural' (ueF (C [-, Γ ]) .element)
-        -- where
-        -- F-elt-natural' :
-        --   F ⟪ PshHom→NatTrans (yoRec Q (γ Q.⋆ q)) ⟫
-        --     ⟦ ＂F Γ ＂ ⟧
-        --   ≡ (λ z → F ⟅ Q ⟆ ⟪ FC ⟪ γ ⟫ ⟫ $
-        --     F ⟪ PshHom→NatTrans (yoRec Q q) ⟫ ⟦ ＂F Δ ＂ ⟧ $
-        --       ueF.element)
-        -- F-elt-natural' = {!!}
-
-
-      F-PshHom : PshHom Q ((F ⟅ Q ⟆) ∘F (FC ^opF))
-      F-PshHom .fst Γ = F-elt
-      F-PshHom .snd Γ Δ γ = F-elt-natural
-
-    ＂π＂ : {Γ : C.ob} → C [ ＂F Γ ＂ , Γ ]
-    ＂π＂ {Γ = Γ} =
-      -- natTrans or PshHom here?
-      πF-PshHom (C [-, Γ ]) .fst ＂F Γ ＂ ueF.element
-
+    module _ (Γ : C.ob) where
+      F-PshHom : PshHom (C [-, Γ ]) ((F ⟅ C [-, Γ ] ⟆) ∘F (FC ^opF))
+      F-PshHom = yoRec ((F ⟅ C [-, Γ ] ⟆) ∘F (FC ^opF)) (ueF (C [-, Γ ]) .element)
 
   module _
     (πF* : {Γ : C.ob} → (Γᴰ : Cᴰ.ob[ Γ ]) →
-      PshᴰCL.isFibration' (Cᴰ [-][-, Γᴰ ]))
+      PshᴰCL.CartesianLift' ＂π＂ (Cᴰ [-][-, Γᴰ ]))
     where
 
     open UniversalElementⱽ
 
-    private
-      -- TODO
-      πF*-F-homᴰ : ∀ {Γ} {Δ} {γ : C [ Γ , Δ ]} →
-        {Γᴰ : Cᴰ.ob[ Γ ]} {Δᴰ : Cᴰ.ob[ Δ ]}
-        (γᴰ : Cᴰ [ γ ][ Γᴰ , Δᴰ ]) →
-        Cᴰ [ FC ⟪ γ ⟫ ][ πF* Γᴰ ＂π＂ .vertexⱽ ,
-                         πF* Δᴰ ＂π＂ .vertexⱽ ]
-      πF*-F-homᴰ {γ = γ} {Γᴰ = Γᴰ} {Δᴰ = Δᴰ} γᴰ =
-        introᴰ (πF* Δᴰ ＂π＂) $
-          Cᴰ.reind (
-            (cong₂ C._⋆_ (C.⋆IdL _) refl)
-            ∙ πF-natural) $
-            (πF* Γᴰ ＂π＂ .elementⱽ Cᴰ.⋆ᴰ γᴰ)
-        where
-        πF-natural : ＂π＂ C.⋆ γ ≡ FC ⟪ γ ⟫ C.⋆ ＂π＂
-        πF-natural = {!!}
+    Cᴰ[FC] : Categoryᴰ C ℓCᴰ ℓCᴰ'
+    Cᴰ[FC] = reindex Cᴰ FC
 
-      -- TODO
-      πF*-F-idᴰ : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} →
-        PathP
-          (λ i →
-            Cᴰ [ FC .F-id i ][ πF* Γᴰ ＂π＂ .vertexⱽ ,
-                               πF* Γᴰ ＂π＂ .vertexⱽ ])
-          (πF*-F-homᴰ {Γᴰ = Γᴰ} Cᴰ.idᴰ)
-          Cᴰ.idᴰ
-      πF*-F-idᴰ = {!!}
+    weakenπF : Functorⱽ Cᴰ Cᴰ[FC]
+    weakenπF .F-obᴰ Γᴰ = πF* Γᴰ .vertexⱽ
+    weakenπF .F-homᴰ {xᴰ = Γᴰ} {yᴰ = Δᴰ} γᴰ =
+      introᴰ (πF* Δᴰ) (Cᴰ.reind {!!} $ πF* Γᴰ .elementⱽ Cᴰ.⋆ᴰ γᴰ)
+    weakenπF .F-idᴰ = {!!}
+    weakenπF .F-seqᴰ = {!!}
 
-      -- TODO
-      πF*-F-seqᴰ :
-        ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]}
-          {Δ} {Δᴰ : Cᴰ.ob[ Δ ]}
-          {Θ} {Θᴰ : Cᴰ.ob[ Θ ]} →
-          {γ : C [ Γ , Δ ]} →
-          {δ : C [ Δ , Θ ]} →
-        (γᴰ : Cᴰ [ γ ][ Γᴰ , Δᴰ ]) →
-        (δᴰ : Cᴰ [ δ ][ Δᴰ , Θᴰ ]) →
-        PathP
-          (λ i →
-            Cᴰ [ FC .F-seq γ δ i ][ πF* Γᴰ ＂π＂ .vertexⱽ ,
-                                    πF* Θᴰ ＂π＂ .vertexⱽ ])
-          (πF*-F-homᴰ (γᴰ Cᴰ.⋆ᴰ δᴰ))
-          (πF*-F-homᴰ γᴰ Cᴰ.⋆ᴰ πF*-F-homᴰ δᴰ)
-      πF*-F-seqᴰ = {!!}
+    module _ {Γ} {Γᴰ : Cᴰ.ob[ ＂F Γ ＂ ]} where
 
-      -- Should probably call this weakenF instead
-      πF*-Functorᴰ : Functorᴰ FC Cᴰ Cᴰ
-      πF*-Functorᴰ .F-obᴰ Γᴰ = πF* Γᴰ ＂π＂ .vertexⱽ
-      πF*-Functorᴰ .F-homᴰ = πF*-F-homᴰ
-      πF*-Functorᴰ .F-idᴰ = πF*-F-idᴰ
-      πF*-Functorᴰ .F-seqᴰ = πF*-F-seqᴰ
+      ∀Pshᴰ : Presheafⱽ Γ Cᴰ ℓCᴰ'
+      ∀Pshᴰ = RightAdjointProfⱽ weakenπF .F-obᴰ Γᴰ
 
-    module _
-      {P : Presheaf C ℓC'}
-      (Pᴰ : Presheafᴰ (F ⟅ P ⟆) Cᴰ ℓPᴰ) where
+  --   module _ (Q : Presheaf C ℓC') where
+  --     private
+  --       module Q = PresheafNotation Q
+  --       module FQ = PresheafNotation (F ⟅ Q ⟆)
+  --     F-elt : ∀ {Γ} → (q : Q.p[ Γ ]) → FQ.p[ ＂F Γ ＂ ]
+  --     F-elt {Γ} q =
+  --       F ⟪ PshHom→NatTrans (yoRec Q q) ⟫ ⟦ ＂F Γ ＂ ⟧ $
+  --         ueF (C [-, Γ ]) .element
 
-      private
-        module P = PresheafNotation P
-        module FP = PresheafNotation (F ⟅ P ⟆)
-        module Pᴰ = PresheafᴰNotation Pᴰ
+  --     -- TODO
+  --     F-elt-natural :
+  --       ∀ {Γ} {Δ} {γ : C [ Γ , Δ ]} (q : Q.p[ Δ ]) →
+  --       F-elt (γ Q.⋆ q) ≡ (FC ⟪ γ ⟫) FQ.⋆ F-elt q
+  --     F-elt-natural {Γ = Γ}{Δ = Δ}{γ = γ} q =
+  --       cong (λ z → z ⟦ ＂F Γ ＂ ⟧ $ ueF (C [-, Γ ]) .element) F⟨-⋆γ⟩
+  --       ∙ x
+  --       where
+  --       -⋆γ : PshHom (C [-, Γ ]) (C [-, Δ ])
+  --       -⋆γ = yoRec (C [-, Δ ]) γ
 
-      -- Trying to do this manually and I
-      -- run into obligations that seem to necessitate
-      -- functorialiaty for πF*
-      -- At the very least, the functoriality of πF* is
-      -- sufficient
-      ∀ᴰPshᴰ : Presheafᴰ P Cᴰ ℓPᴰ
-      ∀ᴰPshᴰ .F-obᴰ Γᴰ p =
-        Pᴰ .F-obᴰ (πF* Γᴰ ＂π＂ .vertexⱽ) (F-elt P p)
-      ∀ᴰPshᴰ .F-homᴰ γᴰ p pᴰ =
-        Pᴰ.reind (sym $ F-elt-natural P p) $
-          πF*-F-homᴰ γᴰ Pᴰ.⋆ᴰ pᴰ
-      ∀ᴰPshᴰ .F-idᴰ = funExt₂ λ p pᴰ →
-        Pᴰ.rectify $ Pᴰ.≡out $
-          (sym $ Pᴰ.reind-filler _ _)
-          ∙ Pᴰ.⟨ Cᴰ.≡in πF*-F-idᴰ ⟩⋆⟨⟩
-          ∙ Pᴰ.⋆IdL _
-      ∀ᴰPshᴰ .F-seqᴰ γᴰ δᴰ = funExt₂ λ p pᴰ →
-        Pᴰ.rectify $ Pᴰ.≡out $
-          (sym $ Pᴰ.reind-filler _ _)
-          ∙ Pᴰ.⟨ Cᴰ.≡in (πF*-F-seqᴰ δᴰ γᴰ) ⟩⋆⟨⟩
-          ∙ Pᴰ.⋆Assoc _ _ _
-          ∙ Pᴰ.⟨ refl ⟩⋆⟨ Pᴰ.reind-filler _ _ ⟩
-          ∙ Pᴰ.reind-filler _ _
+  --       -⋆Fγ : PshHom (C [-, ＂F Γ ＂ ]) (C [-, ＂F Δ ＂ ])
+  --       -⋆Fγ = yoRec (C [-, ＂F Δ ＂ ]) {!!}
 
-      -- An equivalent definition that directly uses
-      -- functoriality of πF*
-      -- but is a lot slower at least with the above holes
-      -- ∀ᴰPshᴰ' : Presheafᴰ P Cᴰ ℓPᴰ
-      -- ∀ᴰPshᴰ' = reind (F-PshHom P) $
-      --   (Pᴰ ∘Fᴰ (πF*-Functorᴰ ^opFᴰ))
+  --       F⟨-⋆γ⟩ :
+  --         F ⟪ PshHom→NatTrans (yoRec Q (γ Q.⋆ q)) ⟫
+  --           ≡ F .F-hom {x = C [-, Γ ]}{y = C [-, Δ ]}
+  --              (PshHom→NatTrans -⋆γ) Psh.⋆
+  --             F ⟪ PshHom→NatTrans (yoRec Q q) ⟫
+  --       F⟨-⋆γ⟩ =
+  --         cong (F .F-hom)
+  --           ((cong PshHom→NatTrans
+  --             (sym $ yoRec-natural (C [-, Δ ]) Q (yoRec Q q)))
+  --             ∙ {!!})
+  --         ∙ (F .F-seq _ _)
 
-    module _ {Γ : C.ob} {Γᴰ : Cᴰ.ob[ ＂F Γ ＂ ]} where
-      ∀ᴰ : Type _
-      ∀ᴰ = UniversalElementⱽ Cᴰ Γ
-        (∀ᴰPshᴰ (reind α (Cᴰ [-][-, Γᴰ ])))
-        where
-        α : PshHom (F ⟅ C [-, Γ ] ⟆) (C [-, ＂F Γ ＂ ])
-        α = invPshIso {P = C [-, ＂F Γ ＂ ]}{Q = F ⟅ C [-, Γ ] ⟆}
-          (UniversalElementNotation.asPshIso (ueF (C [-, Γ ]))) .fst
+  --       module FよΔ = PresheafNotation (F ⟅ C [-, Δ ] ⟆)
+
+  --       y :
+  --         ((F ⟪ PshHom→NatTrans -⋆γ ⟫) ⟦ ＂F Γ ＂ ⟧ $ _) ≡
+  --           (FC ⟪ γ ⟫) FよΔ.⋆ ueF (C [-, Δ ]) .element
+  --       y =
+  --         {!!}
+
+  --       x :
+  --         ((F ⟪ PshHom→NatTrans (yoRec Q q) ⟫) ⟦ ＂F Γ ＂ ⟧ $
+  --             ((F ⟪ PshHom→NatTrans -⋆γ ⟫) ⟦ ＂F Γ ＂ ⟧ $ (ueF (C [-, Γ ]) .element)))
+  --         ≡ FC ⟪ γ ⟫ FQ.⋆ F-elt q
+  --       x =
+  --         cong (F ⟪ PshHom→NatTrans (yoRec Q q) ⟫ ⟦ ＂F Γ ＂ ⟧) y
+  --         ∙ funExt⁻ ((F ⟪ PshHom→NatTrans (yoRec Q q) ⟫) .N-hom (FC ⟪ γ ⟫)) _
+
+  --     F-PshHom : PshHom Q ((F ⟅ Q ⟆) ∘F (FC ^opF))
+  --     F-PshHom .fst Γ = F-elt
+  --     F-PshHom .snd Γ Δ γ = F-elt-natural
+
+  --   ＂π＂ : {Γ : C.ob} → C [ ＂F Γ ＂ , Γ ]
+  --   ＂π＂ {Γ = Γ} =
+  --     -- natTrans or PshHom here?
+  --     πF-PshHom (C [-, Γ ]) .fst ＂F Γ ＂ $ ueF (C [-, Γ ]) .element
+
+
+  -- module _
+  --   (πF* : {Γ : C.ob} → (Γᴰ : Cᴰ.ob[ Γ ]) →
+  --     PshᴰCL.isFibration' (Cᴰ [-][-, Γᴰ ]))
+  --   where
+
+  --   open UniversalElementⱽ
+
+  --   private
+  --     -- TODO
+  --     πF*-F-homᴰ : ∀ {Γ} {Δ} {γ : C [ Γ , Δ ]} →
+  --       {Γᴰ : Cᴰ.ob[ Γ ]} {Δᴰ : Cᴰ.ob[ Δ ]}
+  --       (γᴰ : Cᴰ [ γ ][ Γᴰ , Δᴰ ]) →
+  --       Cᴰ [ FC ⟪ γ ⟫ ][ πF* Γᴰ ＂π＂ .vertexⱽ ,
+  --                        πF* Δᴰ ＂π＂ .vertexⱽ ]
+  --     πF*-F-homᴰ {Γ = Γ} {Δ = Δ} {γ = γ} {Γᴰ = Γᴰ} {Δᴰ = Δᴰ} γᴰ =
+  --       introᴰ (πF* Δᴰ ＂π＂) $
+  --         Cᴰ.reind (
+  --           (cong₂ C._⋆_ (C.⋆IdL _) refl)
+  --           ∙ πF-natural) $
+  --           (πF* Γᴰ ＂π＂ .elementⱽ Cᴰ.⋆ᴰ γᴰ)
+  --       where
+  --       πF-natural : ＂π＂ C.⋆ γ ≡ FC ⟪ γ ⟫ C.⋆ ＂π＂
+  --       πF-natural = {!!}
+
+  --     -- TODO
+  --     πF*-F-idᴰ : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} →
+  --       PathP
+  --         (λ i →
+  --           Cᴰ [ FC .F-id i ][ πF* Γᴰ ＂π＂ .vertexⱽ ,
+  --                              πF* Γᴰ ＂π＂ .vertexⱽ ])
+  --         (πF*-F-homᴰ {Γᴰ = Γᴰ} Cᴰ.idᴰ)
+  --         Cᴰ.idᴰ
+  --     πF*-F-idᴰ = {!!}
+
+  --     -- TODO
+  --     πF*-F-seqᴰ :
+  --       ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]}
+  --         {Δ} {Δᴰ : Cᴰ.ob[ Δ ]}
+  --         {Θ} {Θᴰ : Cᴰ.ob[ Θ ]} →
+  --         {γ : C [ Γ , Δ ]} →
+  --         {δ : C [ Δ , Θ ]} →
+  --       (γᴰ : Cᴰ [ γ ][ Γᴰ , Δᴰ ]) →
+  --       (δᴰ : Cᴰ [ δ ][ Δᴰ , Θᴰ ]) →
+  --       PathP
+  --         (λ i →
+  --           Cᴰ [ FC .F-seq γ δ i ][ πF* Γᴰ ＂π＂ .vertexⱽ ,
+  --                                   πF* Θᴰ ＂π＂ .vertexⱽ ])
+  --         (πF*-F-homᴰ (γᴰ Cᴰ.⋆ᴰ δᴰ))
+  --         (πF*-F-homᴰ γᴰ Cᴰ.⋆ᴰ πF*-F-homᴰ δᴰ)
+  --     πF*-F-seqᴰ = {!!}
+
+  --     -- Should probably call this weakenF instead
+  --     πF*-Functorᴰ : Functorᴰ FC Cᴰ Cᴰ
+  --     πF*-Functorᴰ .F-obᴰ Γᴰ = πF* Γᴰ ＂π＂ .vertexⱽ
+  --     πF*-Functorᴰ .F-homᴰ = πF*-F-homᴰ
+  --     πF*-Functorᴰ .F-idᴰ = πF*-F-idᴰ
+  --     πF*-Functorᴰ .F-seqᴰ = πF*-F-seqᴰ
+
+  --   module _
+  --     {P : Presheaf C ℓC'}
+  --     (Pᴰ : Presheafᴰ (F ⟅ P ⟆) Cᴰ ℓPᴰ) where
+
+  --     private
+  --       module P = PresheafNotation P
+  --       module FP = PresheafNotation (F ⟅ P ⟆)
+  --       module Pᴰ = PresheafᴰNotation Pᴰ
+
+  --     -- Trying to do this manually and I
+  --     -- run into obligations that seem to necessitate
+  --     -- functorialiaty for πF*
+  --     -- At the very least, the functoriality of πF* is
+  --     -- sufficient
+  --     ∀ᴰPshᴰ : Presheafᴰ P Cᴰ ℓPᴰ
+  --     ∀ᴰPshᴰ .F-obᴰ Γᴰ p =
+  --       Pᴰ .F-obᴰ (πF* Γᴰ ＂π＂ .vertexⱽ) (F-elt P p)
+  --     ∀ᴰPshᴰ .F-homᴰ γᴰ p pᴰ =
+  --       Pᴰ.reind (sym $ F-elt-natural P p) $
+  --         πF*-F-homᴰ γᴰ Pᴰ.⋆ᴰ pᴰ
+  --     ∀ᴰPshᴰ .F-idᴰ = funExt₂ λ p pᴰ →
+  --       Pᴰ.rectify $ Pᴰ.≡out $
+  --         (sym $ Pᴰ.reind-filler _ _)
+  --         ∙ Pᴰ.⟨ Cᴰ.≡in πF*-F-idᴰ ⟩⋆⟨⟩
+  --         ∙ Pᴰ.⋆IdL _
+  --     ∀ᴰPshᴰ .F-seqᴰ γᴰ δᴰ = funExt₂ λ p pᴰ →
+  --       Pᴰ.rectify $ Pᴰ.≡out $
+  --         (sym $ Pᴰ.reind-filler _ _)
+  --         ∙ Pᴰ.⟨ Cᴰ.≡in (πF*-F-seqᴰ δᴰ γᴰ) ⟩⋆⟨⟩
+  --         ∙ Pᴰ.⋆Assoc _ _ _
+  --         ∙ Pᴰ.⟨ refl ⟩⋆⟨ Pᴰ.reind-filler _ _ ⟩
+  --         ∙ Pᴰ.reind-filler _ _
+
+  --     -- An equivalent definition that directly uses
+  --     -- functoriality of πF*
+  --     -- but is a lot slower at least with the above holes
+  --     -- ∀ᴰPshᴰ' : Presheafᴰ P Cᴰ ℓPᴰ
+  --     -- ∀ᴰPshᴰ' = reind (F-PshHom P) $
+  --     --   (Pᴰ ∘Fᴰ (πF*-Functorᴰ ^opFᴰ))
+
+  --   module _ {Γ : C.ob} {Γᴰ : Cᴰ.ob[ ＂F Γ ＂ ]} where
+  --     ∀ᴰ : Type _
+  --     ∀ᴰ = UniversalElementⱽ Cᴰ Γ
+  --       (∀ᴰPshᴰ (reind α (Cᴰ [-][-, Γᴰ ])))
+  --       where
+  --       α : PshHom (F ⟅ C [-, Γ ] ⟆) (C [-, ＂F Γ ＂ ])
+  --       α = invPshIso {P = C [-, ＂F Γ ＂ ]}{Q = F ⟅ C [-, Γ ] ⟆}
+  --         (UniversalElementNotation.asPshIso (ueF (C [-, Γ ]))) .fst

--- a/Cubical/Categories/Displayed/Quantifiers.agda
+++ b/Cubical/Categories/Displayed/Quantifiers.agda
@@ -193,6 +193,10 @@ module _
   private
     module C = Category C
     module Cᴰ = Fibers Cᴰ
+    module Psh = Category (PresheafCategory C ℓC')
+    module _ {Q : Presheaf C ℓC'} where
+      module ueF = UniversalElementNotation (ueF Q)
+
     πF-PshHom : ∀ Q → PshHom (F ⟅ Q ⟆) Q
     πF-PshHom Q = NatTrans→PshHom (πF .N-ob Q)
 
@@ -211,8 +215,12 @@ module _
     ＂π＂ {Γ = Γ} = πF ⟦ C [-, Γ ] ⟧ ⟦ ＂F Γ ＂ ⟧ $ ＂F Γ ＂elt
 
     -- F extends a functor on C
+    -- i.e whem F (Yo c) ≅ Yo c', define F c := c'
     FC : Functor C C
     FC = FunctorComprehension (F ∘F YO) (λ Γ → ueF (C [-, Γ ]))
+
+    πFβ : ∀ {Q}{Q'}{α : NatTrans Q Q'} → F ⟪ α ⟫ Psh.⋆ (πF ⟦ Q' ⟧) ≡ (πF ⟦ Q ⟧ Psh.⋆ α)
+    πFβ = N-hom πF _
 
   module _
     (πF*' : {Γ : C.ob} → (Γᴰ : Cᴰ.ob[ Γ ]) →
@@ -229,11 +237,27 @@ module _
       ＂πF*_＂ : ∀ {Γ} → (Γᴰ : Cᴰ.ob[ Γ ]) → Cᴰ.ob[ ＂F Γ ＂ ]
       ＂πF* Γᴰ ＂ = πF* Γᴰ .vertexⱽ
 
-    -- πF-Functorᴰ : Functorᴰ FC Cᴰ Cᴰ
-    -- πF-Functorᴰ =
-    --   FunctorᴰComprehension
-    --     {!!}
-    --     (λ Γ Γᴰ → πF* Γᴰ ◁PshIsoⱽᴰ {!!})
+    πF-Functorᴰ : Functorᴰ FC Cᴰ Cᴰ
+    πF-Functorᴰ .F-obᴰ = ＂πF*_＂
+    πF-Functorᴰ .F-homᴰ {x = Γ}{y = Δ}{f = γ}{xᴰ = Γᴰ}{yᴰ = Δᴰ} γᴰ =
+      introᴰ (πF* Δᴰ) $
+        Cᴰ.reind ((cong₂ C._⋆_ (C.⋆IdL _) refl) ∙ πF-natural) $
+          πF* Γᴰ .elementⱽ Cᴰ.⋆ᴰ γᴰ
+      where
+      module π*よΔᴰ =
+        PresheafⱽNotation (reindYo ＂π＂ (Cᴰ [-][-, Δᴰ ]))
+
+      ＂Fγ＂ : C [ ＂F Γ ＂ , ＂F Δ ＂ ]
+      ＂Fγ＂ = FC ⟪ γ ⟫
+
+      πF-natural : ＂π＂ C.⋆ γ ≡ ＂Fγ＂ C.⋆ ＂π＂
+      πF-natural =
+        {!!}
+        -- cong (λ z → z ⟦ ueF.vertex ⟧ $ ueF.element) (sym $ πFβ {Q = C [-, Γ ]}{Q' = C [-, Δ ]}{α = {!!}})
+        -- ∙ {!!}
+
+    πF-Functorᴰ .F-idᴰ = {!!}
+    πF-Functorᴰ .F-seqᴰ = {!!}
 
     module _
       {P : Presheaf C ℓC'}
@@ -246,11 +270,40 @@ module _
 
         mkFPElt : ∀ {Γ} → (p : P.p[ Γ ]) →
           FP.p[ ＂F Γ ＂ ]
-        mkFPElt {Γ} p =
-          (F ⟪ α ⟫) ⟦ ＂F Γ ＂ ⟧ $ ＂F Γ ＂elt
-          where
-          α : NatTrans (C [-, Γ ]) P
-          α = PshHom→NatTrans (yoRec P p)
+        mkFPElt {Γ} p = {!!}
+          -- (F ⟪ α ⟫) ⟦ ＂F Γ ＂ ⟧ $ ＂F Γ ＂elt
+          -- where
+          -- α : NatTrans (C [-, Γ ]) P
+          -- α = PshHom→NatTrans (yoRec P p)
+
+        -- FP ≅ C [ - , c ]
+        -- FP ∘F FC ^op ≅ C [ FC ^op - , c ]
+
+        the-nat-trans : NatTrans P ((F ⟅ P ⟆) ∘F (FC ^opF))
+        the-nat-trans = {!!}
+
+        -- the-psh-hom : PshHom P ((F ⟅ P ⟆) ∘F (FC ^opF))
+        -- the-psh-hom .fst _ = mkFPElt
+        -- the-psh-hom .snd Γ Δ γ δ =
+        --   {!!}
+        --   -- mkFPElt (γ P.⋆ δ)
+        --   --   ≡⟨ refl ⟩
+        --   -- ((F ⟪ PshHom→NatTrans (yoRec P (P .F-hom γ δ)) ⟫) ⟦ ＂F Γ ＂ ⟧ $ ＂F Γ ＂elt)
+        --   --   ≡⟨ {!!} ⟩
+        --   -- {!!}
+        --   -- -- {!(F-ob F (C [-, Δ ]) .F-hom (F-hom FC γ)
+        --   -- --   Cubical.Categories.NaturalTransformation.Base._.⋆ᴰ
+        --   -- --   N-ob (F-hom F α) (F-ob FC Γ))
+        --   -- --  ＂F Δ ＂elt!}
+        --   --   ≡⟨ funExt⁻ ((F ⟪ α ⟫) .N-hom (FC ⟪ γ ⟫)) ＂F Δ ＂elt ⟩
+        --   -- (FC ⟪ γ ⟫) FP.⋆ mkFPElt δ
+        --   -- ∎
+        --   -- -- {!!}
+        --   -- -- ∙ funExt⁻ ((F ⟪ α ⟫) .N-hom (FC ⟪ γ ⟫)) ＂F Δ ＂elt
+        --   where
+        --   α : NatTrans (C [-, Δ ]) P
+        --   α = PshHom→NatTrans (yoRec P δ)
+
 
       -- Define ∀ᴰ Pᴰ such that
       --   (∀ᴰ Pᴰ) [ p ][ Γᴰ ] ≅ Pᴰ [ F p ][ πF* Γᴰ ]
@@ -267,98 +320,76 @@ module _
       --     v     Fp       v
       --   ＂FΓ＂ --------> F P
       ∀ᴰPshᴰ : Presheafᴰ P Cᴰ ℓPᴰ
-      ∀ᴰPshᴰ .F-obᴰ {x = Γ} Γᴰ p = Pᴰ .F-obᴰ ＂πF* Γᴰ ＂ (mkFPElt p)
-      -- Homs
-      -- Given morphism γᴰ
-      --            γᴰ
-      --     Δᴰ ----------> Γᴰ
-      --     _              _
-      --     |              |
-      --     v      γ       v
-      --     Δ -----------> Γ
-      --
-      -- and element pᴰ
-      --
-      --            pᴰ
-      --     Γᴰ --------> ∀ᴰ Pᴰ
-      --     _              _
-      --     |              |
-      --     v      p       v
-      --     Γ -----------> P
-      --
-      --            pᴰ
-      --   πF* Γᴰ --------> Pᴰ
-      --     _              _
-      --     |              |
-      --     v     Fp       v
-      --   ＂FΓ＂ --------> F P
-      --
-      -- want
-      --
-      --   πF* Δᴰ --------> Pᴰ
-      --     _              _
-      --     |              |
-      --     v              v
-      --   ＂FΔ＂ --------> F P
-      --
-      -- πF* should have a functorial action on γᴰ
-      --
-      --         πF* γᴰ
-      --   πF* Δᴰ -----> πF* Γᴰ
-      --     _              _
-      --     |              |
-      --     v    ＂Fγ＂    v
-      --   ＂FΔ＂ ------> ＂FΓ＂
-
-      ∀ᴰPshᴰ .F-homᴰ {x = Γ}{y = Δ}{f = γ}{xᴰ = Γᴰ}{yᴰ = Δᴰ} γᴰ p pᴰ =
-        Pᴰ.reind mkFPElt-natural $ πF*γᴰ Pᴰ.⋆ᴰ pᴰ
-          where
-          module π*よΓᴰ =
-            PresheafⱽNotation (reindYo ＂π＂ (Cᴰ [-][-, Γᴰ ]))
-          module π*よΔᴰ =
-            PresheafⱽNotation (reindYo ＂π＂ (Cᴰ [-][-, Δᴰ ]))
-          module よΓ = PresheafNotation (C [-, Γ ])
-          module よΔ = PresheafNotation (C [-, Δ ])
-
-          ＂Fγ＂ : C [ ＂F Δ ＂ , ＂F Γ ＂ ]
-          ＂Fγ＂ = FC ⟪ γ ⟫
-
-          πF-natural : ＂π＂ C.⋆ γ ≡ ＂Fγ＂ C.⋆ ＂π＂
-          πF-natural =
-            {!!}
-            ∙ funExt⁻ ((πF ⟦ C [-, Γ ] ⟧) .N-hom ＂Fγ＂) ＂F Γ ＂elt
+      ∀ᴰPshᴰ = reind {!!} $ (Pᴰ ∘Fᴰ (πF-Functorᴰ ^opFᴰ))
 
 
-          δᴰ : π*よΓᴰ.p[ ＂Fγ＂ ][ ＂πF* Δᴰ ＂ ]
-          δᴰ = Cᴰ.reind ((cong₂ C._⋆_ (C.⋆IdL _) refl) ∙ πF-natural) $
-            πF* Δᴰ .elementⱽ Cᴰ.⋆ᴰ γᴰ
+    --   ∀ᴰPshᴰ .F-obᴰ {x = Γ} Γᴰ p =
+    --     {!!}
+    --     -- Pᴰ .F-obᴰ ＂πF* Γᴰ ＂ (mkFPElt p)
+    --   -- Homs
+    --   -- Given morphism γᴰ
+    --   --            γᴰ
+    --   --     Δᴰ ----------> Γᴰ
+    --   --     _              _
+    --   --     |              |
+    --   --     v      γ       v
+    --   --     Δ -----------> Γ
+    --   --
+    --   -- and element pᴰ
+    --   --
+    --   --            pᴰ
+    --   --     Γᴰ --------> ∀ᴰ Pᴰ
+    --   --     _              _
+    --   --     |              |
+    --   --     v      p       v
+    --   --     Γ -----------> P
+    --   --
+    --   --            pᴰ
+    --   --   πF* Γᴰ --------> Pᴰ
+    --   --     _              _
+    --   --     |              |
+    --   --     v     Fp       v
+    --   --   ＂FΓ＂ --------> F P
+    --   --
+    --   -- want
+    --   --
+    --   --   πF* Δᴰ --------> Pᴰ
+    --   --     _              _
+    --   --     |              |
+    --   --     v              v
+    --   --   ＂FΔ＂ --------> F P
+    --   --
+    --   -- πF* should have a functorial action on γᴰ
+    --   --
+    --   --         πF* γᴰ
+    --   --   πF* Δᴰ -----> πF* Γᴰ
+    --   --     _              _
+    --   --     |              |
+    --   --     v    ＂Fγ＂    v
+    --   --   ＂FΔ＂ ------> ＂FΓ＂
 
-          πF*γᴰ : Cᴰ [ ＂Fγ＂ ][ ＂πF* Δᴰ ＂ , ＂πF* Γᴰ ＂ ]
-          πF*γᴰ = introᴰ (πF* Γᴰ) δᴰ
+    --   ∀ᴰPshᴰ .F-homᴰ {x = Γ}{y = Δ}{f = γ}{xᴰ = Γᴰ}{yᴰ = Δᴰ} γᴰ p pᴰ =
+    --     {!!}
+    --     -- Pᴰ.reind mkFPElt-natural $ πF-Functorᴰ .F-homᴰ γᴰ Pᴰ.⋆ᴰ pᴰ
+    --       where
+    --       ＂Fγ＂ : C [ ＂F Δ ＂ , ＂F Γ ＂ ]
+    --       ＂Fγ＂ = FC ⟪ γ ⟫
 
-          mkFPElt-natural : ＂Fγ＂ FP.⋆ (mkFPElt p) ≡ mkFPElt (γ P.⋆ p)
-          mkFPElt-natural = {!!}
+    --       mkFPElt-natural : ＂Fγ＂ FP.⋆ (mkFPElt p) ≡ mkFPElt (γ P.⋆ p)
+    --       mkFPElt-natural = {!!}
 
-      ∀ᴰPshᴰ .F-idᴰ {xᴰ = Γᴰ} = funExt₂ λ p pᴰ →
-        Pᴰ.rectify $ Pᴰ.≡out $
-          (sym $ Pᴰ.reind-filler _ _)
-          ∙ Pᴰ.⟨
-            introᴰ≡ (πF* Γᴰ)
-              {!!}
-            ⟩⋆⟨⟩
-          ∙ Pᴰ.⋆IdL _
-          where
-          module よΓᴰ =
-            PresheafⱽNotation (Cᴰ [-][-, Γᴰ ])
-          module π*よΓᴰ =
-            PresheafⱽNotation (reindYo ＂π＂ (Cᴰ [-][-, Γᴰ ]))
-      ∀ᴰPshᴰ .F-seqᴰ = {!!}
+    --   ∀ᴰPshᴰ .F-idᴰ {xᴰ = Γᴰ} = funExt₂ λ p pᴰ →
+    --     Pᴰ.rectify $ Pᴰ.≡out $
+    --       (sym $ Pᴰ.reind-filler _ _)
+    --       ∙ Pᴰ.⟨ Cᴰ.≡in (πF-Functorᴰ .F-idᴰ) ⟩⋆⟨⟩
+    --       ∙ Pᴰ.⋆IdL _
+    --   ∀ᴰPshᴰ .F-seqᴰ = {!!}
 
-    module _ {Γ : C.ob} {Γᴰ : Cᴰ.ob[ ＂F Γ ＂ ]} where
-      ∀ᴰ : Type _
-      ∀ᴰ = UniversalElementⱽ Cᴰ Γ
-        (∀ᴰPshᴰ (reind α (Cᴰ [-][-, Γᴰ ])))
-        where
-        α : PshHom (F ⟅ C [-, Γ ] ⟆) (C [-, ＂F Γ ＂ ])
-        α = invPshIso {P = C [-, ＂F Γ ＂ ]}{Q = F ⟅ C [-, Γ ] ⟆}
-          (UniversalElementNotation.asPshIso (ueF (C [-, Γ ]))) .fst
+    -- module _ {Γ : C.ob} {Γᴰ : Cᴰ.ob[ ＂F Γ ＂ ]} where
+    --   ∀ᴰ : Type _
+    --   ∀ᴰ = UniversalElementⱽ Cᴰ Γ
+    --     (∀ᴰPshᴰ (reind α (Cᴰ [-][-, Γᴰ ])))
+    --     where
+    --     α : PshHom (F ⟅ C [-, Γ ] ⟆) (C [-, ＂F Γ ＂ ])
+    --     α = invPshIso {P = C [-, ＂F Γ ＂ ]}{Q = F ⟅ C [-, Γ ] ⟆}
+    --       (UniversalElementNotation.asPshIso (ueF (C [-, Γ ]))) .fst

--- a/Cubical/Categories/Displayed/Quantifiers.agda
+++ b/Cubical/Categories/Displayed/Quantifiers.agda
@@ -1,6 +1,7 @@
 module Cubical.Categories.Displayed.Quantifiers where
 
 open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.More
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.Structure
 open import Cubical.Functions.FunExtEquiv
@@ -26,6 +27,7 @@ open import Cubical.Categories.Displayed.Instances.Sets
 open import Cubical.Categories.Displayed.Instances.Functor.Base
 open import Cubical.Categories.Displayed.Functor
 open import Cubical.Categories.Displayed.Profunctor
+open import Cubical.Categories.Displayed.NaturalTransformation
 open import Cubical.Categories.Displayed.Functor.More
 open import Cubical.Categories.Displayed.Adjoint.More
 open import Cubical.Categories.Displayed.Constructions.Reindex.Base
@@ -261,40 +263,81 @@ module _
 
     open UniversalElementⱽ
 
+    ＂πF*_＂ : ∀ {Γ} (Γᴰ : Cᴰ.ob[ Γ ]) → Cᴰ.ob[ ＂F Γ ＂ ]
+    ＂πF* Γᴰ ＂ = πF* Γᴰ .vertexⱽ
+
+    introπF* :
+      ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]}
+        {Δ} {Δᴰ : Cᴰ.ob[ Δ ]}{γ : C [ Δ , ＂F Γ ＂ ]}
+      → (γᴰ : Cᴰ [ γ C.⋆ ＂π＂ ][ Δᴰ , Γᴰ ])
+      → Cᴰ [ γ ][ Δᴰ , ＂πF* Γᴰ ＂ ]
+    introπF* {Γᴰ = Γᴰ} γᴰ = introᴰ (πF* Γᴰ) γᴰ
+
+    introπF*⟨_⟩⟨_⟩ :
+      ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]}
+        {Δ} {Δᴰ Δᴰ' : Cᴰ.ob[ Δ ]}{γ γ' : C [ Δ , ＂F Γ ＂ ]} →
+        {Δᴰ≡Δᴰ' : Δᴰ ≡ Δᴰ'} →
+        (γ≡γ' : γ ≡ γ') →
+        {γᴰ : Cᴰ [ γ C.⋆ ＂π＂ ][ Δᴰ , Γᴰ ]} →
+        {γᴰ' : Cᴰ [ γ' C.⋆ ＂π＂ ][ Δᴰ' , Γᴰ ]} →
+        γᴰ ≡[ (λ i → Cᴰ [ γ≡γ' i C.⋆ ＂π＂ ][ Δᴰ≡Δᴰ' i , Γᴰ ]) ] γᴰ' →
+        introπF* γᴰ ≡[ (λ i → Cᴰ [ γ≡γ' i ][ Δᴰ≡Δᴰ' i , ＂πF* Γᴰ ＂ ]) ] introπF* γᴰ'
+    introπF*⟨ γ≡γ' ⟩⟨ γᴰ≡γᴰ' ⟩ i = introπF* (γᴰ≡γᴰ' i)
+
+    π-πF* : ∀ {Γ} (Γᴰ : Cᴰ.ob[ Γ ]) → Cᴰ [ ＂π＂ ][ ＂πF* Γᴰ ＂ , Γᴰ ]
+    π-πF* Γᴰ = Cᴰ.reind (C.⋆IdL _) $ πF* Γᴰ .elementⱽ
+
+    β-πF* :
+      ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]}
+        {Δ} {Δᴰ : Cᴰ.ob[ Δ ]}{γ : C [ Δ , ＂F Γ ＂ ]}
+      → (γᴰ : Cᴰ [ γ C.⋆ ＂π＂ ][ Δᴰ , Γᴰ ])
+      → introπF* γᴰ Cᴰ.⋆ᴰ π-πF* Γᴰ ≡ γᴰ
+    β-πF* {Γᴰ = Γᴰ} γᴰ =
+      Cᴰ.rectify $ Cᴰ.≡out $
+        Cᴰ.⟨ refl ⟩⋆⟨ sym $ Cᴰ.reind-filler _ _ ⟩
+        ∙ Cᴰ.reind-filler _ _
+        ∙ Cᴰ.reind-filler _ _
+        ∙ Cᴰ.≡in (βⱽ (πF* Γᴰ) {pᴰ = γᴰ})
+
+    open PshHomᴰ
+
     Cᴰ[FC] : Categoryᴰ C ℓCᴰ ℓCᴰ'
     Cᴰ[FC] = reindex Cᴰ FC
 
     private
       module Cᴰ[FC] = Fibers Cᴰ[FC]
 
-    weakenπF : Functorⱽ Cᴰ Cᴰ[FC]
-    weakenπF = FunctorⱽComprehension (λ Γ Γᴰ → {!πF* Γᴰ!})
+    weakenπF : Functorᴰ FC Cᴰ Cᴰ
+    weakenπF .F-obᴰ Γᴰ = πF* Γᴰ .vertexⱽ
+    weakenπF .F-homᴰ {f = γ} {xᴰ = Γᴰ} {yᴰ = Δᴰ} γᴰ =
+      introπF* (Cᴰ.reind (＂π＂-natural γ) (π-πF* Γᴰ Cᴰ.⋆ᴰ γᴰ))
+    weakenπF .F-idᴰ {xᴰ = Γᴰ} =
+        introπF*⟨ FC .F-id  ⟩⟨
+          Cᴰ.rectify $ Cᴰ.≡out $
+            (sym $ Cᴰ.reind-filler _ _)
+            ∙ Cᴰ.⋆IdR _
+            ∙ (sym $ Cᴰ.reind-filler _ _)
+        ⟩
+          ▷ (sym $ weak-ηⱽ (πF* Γᴰ))
+    weakenπF .F-seqᴰ γᴰ δᴰ =
+      introπF*⟨ FC .F-seq _ _ ⟩⟨
+        Cᴰ.rectify $ Cᴰ.≡out $
+          (sym $ Cᴰ.reind-filler _ _)
+          ∙ Cᴰ.⟨ sym $ Cᴰ.reind-filler _ _ ⟩⋆⟨ refl ⟩
+          ∙ (sym $ Cᴰ.⋆Assoc _ _ _)
+          ∙ Cᴰ.⟨ Cᴰ.⟨ Cᴰ.reind-filler _ _ ⟩⋆⟨ refl ⟩
+               ∙ Cᴰ.reind-filler _ _
+               ∙ (Cᴰ.≡in $ sym $ β-πF* (Cᴰ.reind (＂π＂-natural _) (π-πF* _ Cᴰ.⋆ᴰ γᴰ)))
+               ⟩⋆⟨ refl ⟩
+          ∙ (Cᴰ.⋆Assoc _ _ _)
+          ∙ Cᴰ.⟨ refl ⟩⋆⟨ Cᴰ.reind-filler _ _ ⟩
+          ∙ Cᴰ.reind-filler _ _
+      ⟩ ▷ (Cᴰ.rectify $ Cᴰ.≡out $ sym $ introᴰ-natural (πF* _))
 
-  --   weakenπF .F-obᴰ Γᴰ = πF* Γᴰ .vertexⱽ
-  --   weakenπF .F-homᴰ {f = γ} {xᴰ = Γᴰ} {yᴰ = Δᴰ} γᴰ =
-  --     {!!}
-  --     -- introᴰ (πF* Δᴰ) $
-  --     --   {!!}
-  --       -- Cᴰ.reind (cong₂ C._⋆_ (C.⋆IdL _) refl ∙ ＂π＂-natural _) $
-  --       -- Cᴰ.reind ({!!} ∙ ＂π＂-natural γ) $
-  --       --   πF* Γᴰ .elementⱽ Cᴰ.⋆ᴰ γᴰ
-  --   weakenπF .F-idᴰ {xᴰ = Γᴰ} =
-  --     {!!}
+    module _ {Γ} {Γᴰ : Cᴰ.ob[ ＂F Γ ＂ ]} where
 
-  --     -- Cᴰ.rectify $ Cᴰ.≡out $
-  --     --   introᴰ≡ (πF* _)
-  --     --     ({!Cᴰ[FC].≡in!}
-  --     --     ∙ {!!})
-  --     -- Cᴰ.rectify $ Cᴰ.≡out $
-  --     --   introᴰ≡ {!πF* Γᴰ!} $
-  --     --     (sym $ Cᴰ.reind-filler _ _)
-  --     --     ∙ {!!}
-  --   weakenπF .F-seqᴰ = {!!}
-
-  --   module _ {Γ} {Γᴰ : Cᴰ.ob[ ＂F Γ ＂ ]} where
-
-  --     ∀Pshᴰ : Presheafⱽ Γ Cᴰ ℓCᴰ'
-  --     ∀Pshᴰ = RightAdjointProfⱽ weakenπF .F-obᴰ Γᴰ
+      -- ∀Pshᴰ : Presheafⱽ Γ Cᴰ ℓCᴰ'
+      -- ∀Pshᴰ = RightAdjointProfⱽ weakenπF .F-obᴰ Γᴰ
 
   -- --   module _ (Q : Presheaf C ℓC') where
   -- --     private

--- a/Cubical/Categories/Displayed/Quantifiers.agda
+++ b/Cubical/Categories/Displayed/Quantifiers.agda
@@ -194,70 +194,115 @@ module _
     module C = Category C
     module Cᴰ = Fibers Cᴰ
     module Psh = Category (PresheafCategory C ℓC')
+    module SET = Category (SET ℓC')
     module _ {Q : Presheaf C ℓC'} where
       module ueF = UniversalElementNotation (ueF Q)
 
     πF-PshHom : ∀ Q → PshHom (F ⟅ Q ⟆) Q
     πF-PshHom Q = NatTrans→PshHom (πF .N-ob Q)
 
-    F-PshHom : ∀ {Q Q' : Presheaf C ℓC'} →
-      (α : NatTrans Q Q') →
-      PshHom (F ⟅ Q ⟆) (F ⟅ Q' ⟆)
-    F-PshHom α = NatTrans→PshHom (F ⟪ α ⟫)
-
     ＂F_＂ : C.ob → C.ob
     ＂F Γ ＂ = ueF (C [-, Γ ]) .vertex
 
-    ＂F_＂elt : (Γ : C.ob) → _
-    ＂F Γ ＂elt = ueF (C [-, Γ ]) .element
-
-    ＂π＂ : {Γ : C.ob} → C [ ＂F Γ ＂ , Γ ]
-    ＂π＂ {Γ = Γ} = πF ⟦ C [-, Γ ] ⟧ ⟦ ＂F Γ ＂ ⟧ $ ＂F Γ ＂elt
-
     -- F extends a functor on C
-    -- i.e whem F (Yo c) ≅ Yo c', define F c := c'
+    -- i.e when F (Yo c) ≅ Yo c', define FC c := c'
     FC : Functor C C
     FC = FunctorComprehension (F ∘F YO) (λ Γ → ueF (C [-, Γ ]))
 
-    πFβ : ∀ {Q}{Q'}{α : NatTrans Q Q'} → F ⟪ α ⟫ Psh.⋆ (πF ⟦ Q' ⟧) ≡ (πF ⟦ Q ⟧ Psh.⋆ α)
-    πFβ = N-hom πF _
+    module _ (Q : Presheaf C ℓC') where
+      private
+        module Q = PresheafNotation Q
+        module FQ = PresheafNotation (F ⟅ Q ⟆)
+      F-elt : ∀ {Γ} → (q : Q.p[ Γ ]) → FQ.p[ ＂F Γ ＂ ]
+      F-elt {Γ} q =
+        F ⟪ PshHom→NatTrans (yoRec Q q) ⟫ ⟦ ＂F Γ ＂ ⟧ $
+          ueF (C [-, Γ ]) .element
+
+      -- TODO
+      F-elt-natural :
+        ∀ {Γ} {Δ} {γ : C [ Γ , Δ ]} (q : Q.p[ Δ ]) →
+        F-elt (γ Q.⋆ q) ≡ (FC ⟪ γ ⟫) FQ.⋆ F-elt q
+      F-elt-natural {Γ = Γ}{Δ = Δ}{γ = γ} q =
+        {!!}
+        -- I don't think this lemma would actually help
+        -- funExt⁻ F-elt-natural' (ueF (C [-, Γ ]) .element)
+        -- where
+        -- F-elt-natural' :
+        --   F ⟪ PshHom→NatTrans (yoRec Q (γ Q.⋆ q)) ⟫
+        --     ⟦ ＂F Γ ＂ ⟧
+        --   ≡ (λ z → F ⟅ Q ⟆ ⟪ FC ⟪ γ ⟫ ⟫ $
+        --     F ⟪ PshHom→NatTrans (yoRec Q q) ⟫ ⟦ ＂F Δ ＂ ⟧ $
+        --       ueF.element)
+        -- F-elt-natural' = {!!}
+
+
+      F-PshHom : PshHom Q ((F ⟅ Q ⟆) ∘F (FC ^opF))
+      F-PshHom .fst Γ = F-elt
+      F-PshHom .snd Γ Δ γ = F-elt-natural
+
+    ＂π＂ : {Γ : C.ob} → C [ ＂F Γ ＂ , Γ ]
+    ＂π＂ {Γ = Γ} =
+      -- natTrans or PshHom here?
+      πF-PshHom (C [-, Γ ]) .fst ＂F Γ ＂ ueF.element
+
 
   module _
-    (πF*' : {Γ : C.ob} → (Γᴰ : Cᴰ.ob[ Γ ]) →
+    (πF* : {Γ : C.ob} → (Γᴰ : Cᴰ.ob[ Γ ]) →
       PshᴰCL.isFibration' (Cᴰ [-][-, Γᴰ ]))
     where
 
     open UniversalElementⱽ
 
     private
-      πF* : ∀ {Γ} → (Γᴰ : Cᴰ.ob[ Γ ]) →
-        UniversalElementⱽ Cᴰ ＂F Γ ＂ (reindYo ＂π＂ (Cᴰ [-][-, Γᴰ ]))
-      πF* Γᴰ = πF*' Γᴰ ＂π＂
+      -- TODO
+      πF*-F-homᴰ : ∀ {Γ} {Δ} {γ : C [ Γ , Δ ]} →
+        {Γᴰ : Cᴰ.ob[ Γ ]} {Δᴰ : Cᴰ.ob[ Δ ]}
+        (γᴰ : Cᴰ [ γ ][ Γᴰ , Δᴰ ]) →
+        Cᴰ [ FC ⟪ γ ⟫ ][ πF* Γᴰ ＂π＂ .vertexⱽ ,
+                         πF* Δᴰ ＂π＂ .vertexⱽ ]
+      πF*-F-homᴰ {γ = γ} {Γᴰ = Γᴰ} {Δᴰ = Δᴰ} γᴰ =
+        introᴰ (πF* Δᴰ ＂π＂) $
+          Cᴰ.reind (
+            (cong₂ C._⋆_ (C.⋆IdL _) refl)
+            ∙ πF-natural) $
+            (πF* Γᴰ ＂π＂ .elementⱽ Cᴰ.⋆ᴰ γᴰ)
+        where
+        πF-natural : ＂π＂ C.⋆ γ ≡ FC ⟪ γ ⟫ C.⋆ ＂π＂
+        πF-natural = {!!}
 
-      ＂πF*_＂ : ∀ {Γ} → (Γᴰ : Cᴰ.ob[ Γ ]) → Cᴰ.ob[ ＂F Γ ＂ ]
-      ＂πF* Γᴰ ＂ = πF* Γᴰ .vertexⱽ
+      -- TODO
+      πF*-F-idᴰ : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} →
+        PathP
+          (λ i →
+            Cᴰ [ FC .F-id i ][ πF* Γᴰ ＂π＂ .vertexⱽ ,
+                               πF* Γᴰ ＂π＂ .vertexⱽ ])
+          (πF*-F-homᴰ {Γᴰ = Γᴰ} Cᴰ.idᴰ)
+          Cᴰ.idᴰ
+      πF*-F-idᴰ = {!!}
 
-    πF-Functorᴰ : Functorᴰ FC Cᴰ Cᴰ
-    πF-Functorᴰ .F-obᴰ = ＂πF*_＂
-    πF-Functorᴰ .F-homᴰ {x = Γ}{y = Δ}{f = γ}{xᴰ = Γᴰ}{yᴰ = Δᴰ} γᴰ =
-      introᴰ (πF* Δᴰ) $
-        Cᴰ.reind ((cong₂ C._⋆_ (C.⋆IdL _) refl) ∙ πF-natural) $
-          πF* Γᴰ .elementⱽ Cᴰ.⋆ᴰ γᴰ
-      where
-      module π*よΔᴰ =
-        PresheafⱽNotation (reindYo ＂π＂ (Cᴰ [-][-, Δᴰ ]))
+      -- TODO
+      πF*-F-seqᴰ :
+        ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]}
+          {Δ} {Δᴰ : Cᴰ.ob[ Δ ]}
+          {Θ} {Θᴰ : Cᴰ.ob[ Θ ]} →
+          {γ : C [ Γ , Δ ]} →
+          {δ : C [ Δ , Θ ]} →
+        (γᴰ : Cᴰ [ γ ][ Γᴰ , Δᴰ ]) →
+        (δᴰ : Cᴰ [ δ ][ Δᴰ , Θᴰ ]) →
+        PathP
+          (λ i →
+            Cᴰ [ FC .F-seq γ δ i ][ πF* Γᴰ ＂π＂ .vertexⱽ ,
+                                    πF* Θᴰ ＂π＂ .vertexⱽ ])
+          (πF*-F-homᴰ (γᴰ Cᴰ.⋆ᴰ δᴰ))
+          (πF*-F-homᴰ γᴰ Cᴰ.⋆ᴰ πF*-F-homᴰ δᴰ)
+      πF*-F-seqᴰ = {!!}
 
-      ＂Fγ＂ : C [ ＂F Γ ＂ , ＂F Δ ＂ ]
-      ＂Fγ＂ = FC ⟪ γ ⟫
-
-      πF-natural : ＂π＂ C.⋆ γ ≡ ＂Fγ＂ C.⋆ ＂π＂
-      πF-natural =
-        {!!}
-        -- cong (λ z → z ⟦ ueF.vertex ⟧ $ ueF.element) (sym $ πFβ {Q = C [-, Γ ]}{Q' = C [-, Δ ]}{α = {!!}})
-        -- ∙ {!!}
-
-    πF-Functorᴰ .F-idᴰ = {!!}
-    πF-Functorᴰ .F-seqᴰ = {!!}
+      -- Should probably call this weakenF instead
+      πF*-Functorᴰ : Functorᴰ FC Cᴰ Cᴰ
+      πF*-Functorᴰ .F-obᴰ Γᴰ = πF* Γᴰ ＂π＂ .vertexⱽ
+      πF*-Functorᴰ .F-homᴰ = πF*-F-homᴰ
+      πF*-Functorᴰ .F-idᴰ = πF*-F-idᴰ
+      πF*-Functorᴰ .F-seqᴰ = πF*-F-seqᴰ
 
     module _
       {P : Presheaf C ℓC'}
@@ -268,128 +313,42 @@ module _
         module FP = PresheafNotation (F ⟅ P ⟆)
         module Pᴰ = PresheafᴰNotation Pᴰ
 
-        mkFPElt : ∀ {Γ} → (p : P.p[ Γ ]) →
-          FP.p[ ＂F Γ ＂ ]
-        mkFPElt {Γ} p = {!!}
-          -- (F ⟪ α ⟫) ⟦ ＂F Γ ＂ ⟧ $ ＂F Γ ＂elt
-          -- where
-          -- α : NatTrans (C [-, Γ ]) P
-          -- α = PshHom→NatTrans (yoRec P p)
-
-        -- FP ≅ C [ - , c ]
-        -- FP ∘F FC ^op ≅ C [ FC ^op - , c ]
-
-        the-nat-trans : NatTrans P ((F ⟅ P ⟆) ∘F (FC ^opF))
-        the-nat-trans = {!!}
-
-        -- the-psh-hom : PshHom P ((F ⟅ P ⟆) ∘F (FC ^opF))
-        -- the-psh-hom .fst _ = mkFPElt
-        -- the-psh-hom .snd Γ Δ γ δ =
-        --   {!!}
-        --   -- mkFPElt (γ P.⋆ δ)
-        --   --   ≡⟨ refl ⟩
-        --   -- ((F ⟪ PshHom→NatTrans (yoRec P (P .F-hom γ δ)) ⟫) ⟦ ＂F Γ ＂ ⟧ $ ＂F Γ ＂elt)
-        --   --   ≡⟨ {!!} ⟩
-        --   -- {!!}
-        --   -- -- {!(F-ob F (C [-, Δ ]) .F-hom (F-hom FC γ)
-        --   -- --   Cubical.Categories.NaturalTransformation.Base._.⋆ᴰ
-        --   -- --   N-ob (F-hom F α) (F-ob FC Γ))
-        --   -- --  ＂F Δ ＂elt!}
-        --   --   ≡⟨ funExt⁻ ((F ⟪ α ⟫) .N-hom (FC ⟪ γ ⟫)) ＂F Δ ＂elt ⟩
-        --   -- (FC ⟪ γ ⟫) FP.⋆ mkFPElt δ
-        --   -- ∎
-        --   -- -- {!!}
-        --   -- -- ∙ funExt⁻ ((F ⟪ α ⟫) .N-hom (FC ⟪ γ ⟫)) ＂F Δ ＂elt
-        --   where
-        --   α : NatTrans (C [-, Δ ]) P
-        --   α = PshHom→NatTrans (yoRec P δ)
-
-
-      -- Define ∀ᴰ Pᴰ such that
-      --   (∀ᴰ Pᴰ) [ p ][ Γᴰ ] ≅ Pᴰ [ F p ][ πF* Γᴰ ]
-      --
-      --     Γᴰ --------> ∀ᴰ Pᴰ
-      --     _              _
-      --     |              |
-      --     v      p       v
-      --     Γ -----------> P
-      --
-      --   πF* Γᴰ --------> Pᴰ
-      --     _              _
-      --     |              |
-      --     v     Fp       v
-      --   ＂FΓ＂ --------> F P
+      -- Trying to do this manually and I
+      -- run into obligations that seem to necessitate
+      -- functorialiaty for πF*
+      -- At the very least, the functoriality of πF* is
+      -- sufficient
       ∀ᴰPshᴰ : Presheafᴰ P Cᴰ ℓPᴰ
-      ∀ᴰPshᴰ = reind {!!} $ (Pᴰ ∘Fᴰ (πF-Functorᴰ ^opFᴰ))
+      ∀ᴰPshᴰ .F-obᴰ Γᴰ p =
+        Pᴰ .F-obᴰ (πF* Γᴰ ＂π＂ .vertexⱽ) (F-elt P p)
+      ∀ᴰPshᴰ .F-homᴰ γᴰ p pᴰ =
+        Pᴰ.reind (sym $ F-elt-natural P p) $
+          πF*-F-homᴰ γᴰ Pᴰ.⋆ᴰ pᴰ
+      ∀ᴰPshᴰ .F-idᴰ = funExt₂ λ p pᴰ →
+        Pᴰ.rectify $ Pᴰ.≡out $
+          (sym $ Pᴰ.reind-filler _ _)
+          ∙ Pᴰ.⟨ Cᴰ.≡in πF*-F-idᴰ ⟩⋆⟨⟩
+          ∙ Pᴰ.⋆IdL _
+      ∀ᴰPshᴰ .F-seqᴰ γᴰ δᴰ = funExt₂ λ p pᴰ →
+        Pᴰ.rectify $ Pᴰ.≡out $
+          (sym $ Pᴰ.reind-filler _ _)
+          ∙ Pᴰ.⟨ Cᴰ.≡in (πF*-F-seqᴰ δᴰ γᴰ) ⟩⋆⟨⟩
+          ∙ Pᴰ.⋆Assoc _ _ _
+          ∙ Pᴰ.⟨ refl ⟩⋆⟨ Pᴰ.reind-filler _ _ ⟩
+          ∙ Pᴰ.reind-filler _ _
 
+      -- An equivalent definition that directly uses
+      -- functoriality of πF*
+      -- but is a lot slower at least with the above holes
+      -- ∀ᴰPshᴰ' : Presheafᴰ P Cᴰ ℓPᴰ
+      -- ∀ᴰPshᴰ' = reind (F-PshHom P) $
+      --   (Pᴰ ∘Fᴰ (πF*-Functorᴰ ^opFᴰ))
 
-    --   ∀ᴰPshᴰ .F-obᴰ {x = Γ} Γᴰ p =
-    --     {!!}
-    --     -- Pᴰ .F-obᴰ ＂πF* Γᴰ ＂ (mkFPElt p)
-    --   -- Homs
-    --   -- Given morphism γᴰ
-    --   --            γᴰ
-    --   --     Δᴰ ----------> Γᴰ
-    --   --     _              _
-    --   --     |              |
-    --   --     v      γ       v
-    --   --     Δ -----------> Γ
-    --   --
-    --   -- and element pᴰ
-    --   --
-    --   --            pᴰ
-    --   --     Γᴰ --------> ∀ᴰ Pᴰ
-    --   --     _              _
-    --   --     |              |
-    --   --     v      p       v
-    --   --     Γ -----------> P
-    --   --
-    --   --            pᴰ
-    --   --   πF* Γᴰ --------> Pᴰ
-    --   --     _              _
-    --   --     |              |
-    --   --     v     Fp       v
-    --   --   ＂FΓ＂ --------> F P
-    --   --
-    --   -- want
-    --   --
-    --   --   πF* Δᴰ --------> Pᴰ
-    --   --     _              _
-    --   --     |              |
-    --   --     v              v
-    --   --   ＂FΔ＂ --------> F P
-    --   --
-    --   -- πF* should have a functorial action on γᴰ
-    --   --
-    --   --         πF* γᴰ
-    --   --   πF* Δᴰ -----> πF* Γᴰ
-    --   --     _              _
-    --   --     |              |
-    --   --     v    ＂Fγ＂    v
-    --   --   ＂FΔ＂ ------> ＂FΓ＂
-
-    --   ∀ᴰPshᴰ .F-homᴰ {x = Γ}{y = Δ}{f = γ}{xᴰ = Γᴰ}{yᴰ = Δᴰ} γᴰ p pᴰ =
-    --     {!!}
-    --     -- Pᴰ.reind mkFPElt-natural $ πF-Functorᴰ .F-homᴰ γᴰ Pᴰ.⋆ᴰ pᴰ
-    --       where
-    --       ＂Fγ＂ : C [ ＂F Δ ＂ , ＂F Γ ＂ ]
-    --       ＂Fγ＂ = FC ⟪ γ ⟫
-
-    --       mkFPElt-natural : ＂Fγ＂ FP.⋆ (mkFPElt p) ≡ mkFPElt (γ P.⋆ p)
-    --       mkFPElt-natural = {!!}
-
-    --   ∀ᴰPshᴰ .F-idᴰ {xᴰ = Γᴰ} = funExt₂ λ p pᴰ →
-    --     Pᴰ.rectify $ Pᴰ.≡out $
-    --       (sym $ Pᴰ.reind-filler _ _)
-    --       ∙ Pᴰ.⟨ Cᴰ.≡in (πF-Functorᴰ .F-idᴰ) ⟩⋆⟨⟩
-    --       ∙ Pᴰ.⋆IdL _
-    --   ∀ᴰPshᴰ .F-seqᴰ = {!!}
-
-    -- module _ {Γ : C.ob} {Γᴰ : Cᴰ.ob[ ＂F Γ ＂ ]} where
-    --   ∀ᴰ : Type _
-    --   ∀ᴰ = UniversalElementⱽ Cᴰ Γ
-    --     (∀ᴰPshᴰ (reind α (Cᴰ [-][-, Γᴰ ])))
-    --     where
-    --     α : PshHom (F ⟅ C [-, Γ ] ⟆) (C [-, ＂F Γ ＂ ])
-    --     α = invPshIso {P = C [-, ＂F Γ ＂ ]}{Q = F ⟅ C [-, Γ ] ⟆}
-    --       (UniversalElementNotation.asPshIso (ueF (C [-, Γ ]))) .fst
+    module _ {Γ : C.ob} {Γᴰ : Cᴰ.ob[ ＂F Γ ＂ ]} where
+      ∀ᴰ : Type _
+      ∀ᴰ = UniversalElementⱽ Cᴰ Γ
+        (∀ᴰPshᴰ (reind α (Cᴰ [-][-, Γᴰ ])))
+        where
+        α : PshHom (F ⟅ C [-, Γ ] ⟆) (C [-, ＂F Γ ＂ ])
+        α = invPshIso {P = C [-, ＂F Γ ＂ ]}{Q = F ⟅ C [-, Γ ] ⟆}
+          (UniversalElementNotation.asPshIso (ueF (C [-, Γ ]))) .fst

--- a/Cubical/Categories/Displayed/Quantifiers.agda
+++ b/Cubical/Categories/Displayed/Quantifiers.agda
@@ -7,6 +7,7 @@ open import Cubical.Foundations.Structure
 open import Cubical.Functions.FunExtEquiv
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Data.Sigma
+import Cubical.Data.Equality as Eq
 
 open import Cubical.Categories.Category
 open import Cubical.Categories.Functor
@@ -252,10 +253,6 @@ module _
        --                (PshHom→NatTrans (yoRec (F ⟅ C [-, Δ ] ⟆) (ueF Δ .element)))
        -- x = {!!}
 
-    module _ (Γ : C.ob) where
-      F-PshHom : PshHom (C [-, Γ ]) ((F ⟅ C [-, Γ ] ⟆) ∘F (FC ^opF))
-      F-PshHom = yoRec ((F ⟅ C [-, Γ ] ⟆) ∘F (FC ^opF)) (ueF Γ .element)
-
   module _
     (πF* : {Γ : C.ob} → (Γᴰ : Cᴰ.ob[ Γ ]) →
       PshᴰCL.CartesianLift' ＂π＂ (Cᴰ [-][-, Γᴰ ]))
@@ -334,129 +331,13 @@ module _
           ∙ Cᴰ.reind-filler _ _
       ⟩ ▷ (Cᴰ.rectify $ Cᴰ.≡out $ sym $ introᴰ-natural (πF* _))
 
-    module _ {Γ} {Γᴰ : Cᴰ.ob[ ＂F Γ ＂ ]} where
+    weakenπFⱽ : Functorⱽ Cᴰ Cᴰ[FC]
+    weakenπFⱽ = introF Id (reindF' (FC ∘F Id) Eq.refl Eq.refl weakenπF)
 
-      -- ∀Pshᴰ : Presheafⱽ Γ Cᴰ ℓCᴰ'
-      -- ∀Pshᴰ = RightAdjointProfⱽ weakenπF .F-obᴰ Γᴰ
+    module _ {Γ} (Γᴰ : Cᴰ.ob[ ＂F Γ ＂ ]) where
 
-  -- --   module _ (Q : Presheaf C ℓC') where
-  -- --     private
-  -- --       module Q = PresheafNotation Q
-  -- --       module FQ = PresheafNotation (F ⟅ Q ⟆)
-  -- --     F-elt : ∀ {Γ} → (q : Q.p[ Γ ]) → FQ.p[ ＂F Γ ＂ ]
-  -- --     F-elt {Γ} q =
-  -- --       F ⟪ PshHom→NatTrans (yoRec Q q) ⟫ ⟦ ＂F Γ ＂ ⟧ $
-  -- --         ueF (C [-, Γ ]) .element
-
-  -- --     -- TODO
-  -- --     F-elt-natural :
-  -- --       ∀ {Γ} {Δ} {γ : C [ Γ , Δ ]} (q : Q.p[ Δ ]) →
-  -- --       F-elt (γ Q.⋆ q) ≡ (FC ⟪ γ ⟫) FQ.⋆ F-elt q
-  -- --     F-elt-natural {Γ = Γ}{Δ = Δ}{γ = γ} q =
-  -- --       cong (λ z → z ⟦ ＂F Γ ＂ ⟧ $ ueF (C [-, Γ ]) .element) F⟨-⋆γ⟩
-  -- --       ∙ x
-  -- --       where
-  -- --       -⋆γ : PshHom (C [-, Γ ]) (C [-, Δ ])
-  -- --       -⋆γ = yoRec (C [-, Δ ]) γ
-
-  -- --       -⋆Fγ : PshHom (C [-, ＂F Γ ＂ ]) (C [-, ＂F Δ ＂ ])
-  -- --       -⋆Fγ = yoRec (C [-, ＂F Δ ＂ ]) {!!}
-
-  -- --       F⟨-⋆γ⟩ :
-  -- --         F ⟪ PshHom→NatTrans (yoRec Q (γ Q.⋆ q)) ⟫
-  -- --           ≡ F .F-hom {x = C [-, Γ ]}{y = C [-, Δ ]}
-  -- --              (PshHom→NatTrans -⋆γ) Psh.⋆
-  -- --             F ⟪ PshHom→NatTrans (yoRec Q q) ⟫
-  -- --       F⟨-⋆γ⟩ =
-  -- --         cong (F .F-hom)
-  -- --           ((cong PshHom→NatTrans
-  -- --             (sym $ yoRec-natural (C [-, Δ ]) Q (yoRec Q q)))
-  -- --             ∙ {!!})
-  -- --         ∙ (F .F-seq _ _)
-
-  -- --       module FよΔ = PresheafNotation (F ⟅ C [-, Δ ] ⟆)
-
-  -- --       y :
-  -- --         ((F ⟪ PshHom→NatTrans -⋆γ ⟫) ⟦ ＂F Γ ＂ ⟧ $ _) ≡
-  -- --           (FC ⟪ γ ⟫) FよΔ.⋆ ueF (C [-, Δ ]) .element
-  -- --       y =
-  -- --         {!!}
-
-  -- --       x :
-  -- --         ((F ⟪ PshHom→NatTrans (yoRec Q q) ⟫) ⟦ ＂F Γ ＂ ⟧ $
-  -- --             ((F ⟪ PshHom→NatTrans -⋆γ ⟫) ⟦ ＂F Γ ＂ ⟧ $ (ueF (C [-, Γ ]) .element)))
-  -- --         ≡ FC ⟪ γ ⟫ FQ.⋆ F-elt q
-  -- --       x =
-  -- --         cong (F ⟪ PshHom→NatTrans (yoRec Q q) ⟫ ⟦ ＂F Γ ＂ ⟧) y
-  -- --         ∙ funExt⁻ ((F ⟪ PshHom→NatTrans (yoRec Q q) ⟫) .N-hom (FC ⟪ γ ⟫)) _
-
-  -- --     F-PshHom : PshHom Q ((F ⟅ Q ⟆) ∘F (FC ^opF))
-  -- --     F-PshHom .fst Γ = F-elt
-  -- --     F-PshHom .snd Γ Δ γ = F-elt-natural
-
-  -- --   ＂π＂ : {Γ : C.ob} → C [ ＂F Γ ＂ , Γ ]
-  -- --   ＂π＂ {Γ = Γ} =
-  -- --     -- natTrans or PshHom here?
-  -- --     πF-PshHom (C [-, Γ ]) .fst ＂F Γ ＂ $ ueF (C [-, Γ ]) .element
-
-
-  -- -- module _
-  -- --   (πF* : {Γ : C.ob} → (Γᴰ : Cᴰ.ob[ Γ ]) →
-  -- --     PshᴰCL.isFibration' (Cᴰ [-][-, Γᴰ ]))
-  -- --   where
-
-  -- --   open UniversalElementⱽ
-
-  -- --   private
-  -- --     -- TODO
-  -- --     πF*-F-homᴰ : ∀ {Γ} {Δ} {γ : C [ Γ , Δ ]} →
-  -- --       {Γᴰ : Cᴰ.ob[ Γ ]} {Δᴰ : Cᴰ.ob[ Δ ]}
-  -- --       (γᴰ : Cᴰ [ γ ][ Γᴰ , Δᴰ ]) →
-  -- --       Cᴰ [ FC ⟪ γ ⟫ ][ πF* Γᴰ ＂π＂ .vertexⱽ ,
-  -- --                        πF* Δᴰ ＂π＂ .vertexⱽ ]
-  -- --     πF*-F-homᴰ {Γ = Γ} {Δ = Δ} {γ = γ} {Γᴰ = Γᴰ} {Δᴰ = Δᴰ} γᴰ =
-  -- --       introᴰ (πF* Δᴰ ＂π＂) $
-  -- --         Cᴰ.reind (
-  -- --           (cong₂ C._⋆_ (C.⋆IdL _) refl)
-  -- --           ∙ πF-natural) $
-  -- --           (πF* Γᴰ ＂π＂ .elementⱽ Cᴰ.⋆ᴰ γᴰ)
-  -- --       where
-  -- --       πF-natural : ＂π＂ C.⋆ γ ≡ FC ⟪ γ ⟫ C.⋆ ＂π＂
-  -- --       πF-natural = {!!}
-
-  -- --     -- TODO
-  -- --     πF*-F-idᴰ : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} →
-  -- --       PathP
-  -- --         (λ i →
-  -- --           Cᴰ [ FC .F-id i ][ πF* Γᴰ ＂π＂ .vertexⱽ ,
-  -- --                              πF* Γᴰ ＂π＂ .vertexⱽ ])
-  -- --         (πF*-F-homᴰ {Γᴰ = Γᴰ} Cᴰ.idᴰ)
-  -- --         Cᴰ.idᴰ
-  -- --     πF*-F-idᴰ = {!!}
-
-  -- --     -- TODO
-  -- --     πF*-F-seqᴰ :
-  -- --       ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]}
-  -- --         {Δ} {Δᴰ : Cᴰ.ob[ Δ ]}
-  -- --         {Θ} {Θᴰ : Cᴰ.ob[ Θ ]} →
-  -- --         {γ : C [ Γ , Δ ]} →
-  -- --         {δ : C [ Δ , Θ ]} →
-  -- --       (γᴰ : Cᴰ [ γ ][ Γᴰ , Δᴰ ]) →
-  -- --       (δᴰ : Cᴰ [ δ ][ Δᴰ , Θᴰ ]) →
-  -- --       PathP
-  -- --         (λ i →
-  -- --           Cᴰ [ FC .F-seq γ δ i ][ πF* Γᴰ ＂π＂ .vertexⱽ ,
-  -- --                                   πF* Θᴰ ＂π＂ .vertexⱽ ])
-  -- --         (πF*-F-homᴰ (γᴰ Cᴰ.⋆ᴰ δᴰ))
-  -- --         (πF*-F-homᴰ γᴰ Cᴰ.⋆ᴰ πF*-F-homᴰ δᴰ)
-  -- --     πF*-F-seqᴰ = {!!}
-
-  -- --     -- Should probably call this weakenF instead
-  -- --     πF*-Functorᴰ : Functorᴰ FC Cᴰ Cᴰ
-  -- --     πF*-Functorᴰ .F-obᴰ Γᴰ = πF* Γᴰ ＂π＂ .vertexⱽ
-  -- --     πF*-Functorᴰ .F-homᴰ = πF*-F-homᴰ
-  -- --     πF*-Functorᴰ .F-idᴰ = πF*-F-idᴰ
-  -- --     πF*-Functorᴰ .F-seqᴰ = πF*-F-seqᴰ
+      ∀Pshⱽ : Presheafⱽ Γ Cᴰ ℓCᴰ'
+      ∀Pshⱽ = RightAdjointProfⱽ weakenπFⱽ .F-obᴰ Γᴰ
 
   -- --   module _
   -- --     {P : Presheaf C ℓC'}
@@ -498,11 +379,24 @@ module _
   -- --     -- ∀ᴰPshᴰ' = reind (F-PshHom P) $
   -- --     --   (Pᴰ ∘Fᴰ (πF*-Functorᴰ ^opFᴰ))
 
-  -- --   module _ {Γ : C.ob} {Γᴰ : Cᴰ.ob[ ＂F Γ ＂ ]} where
-  -- --     ∀ᴰ : Type _
-  -- --     ∀ᴰ = UniversalElementⱽ Cᴰ Γ
-  -- --       (∀ᴰPshᴰ (reind α (Cᴰ [-][-, Γᴰ ])))
-  -- --       where
-  -- --       α : PshHom (F ⟅ C [-, Γ ] ⟆) (C [-, ＂F Γ ＂ ])
-  -- --       α = invPshIso {P = C [-, ＂F Γ ＂ ]}{Q = F ⟅ C [-, Γ ] ⟆}
-  -- --         (UniversalElementNotation.asPshIso (ueF (C [-, Γ ]))) .fst
+    module _ {Γ : C.ob} (Γᴰ : Cᴰ.ob[ ＂F Γ ＂ ]) where
+      UniversalQuantifierF : Type _
+      UniversalQuantifierF = UniversalElementⱽ Cᴰ Γ (∀Pshⱽ Γᴰ)
+
+    module UniversalQuantifierFNotation {Γ}{Γᴰ : Cᴰ.ob[ ＂F Γ ＂ ]}
+      (∀Γᴰ : UniversalQuantifierF Γᴰ) where
+
+      module ∀ueFⱽ = UniversalElementⱽ ∀Γᴰ
+
+      vert : Cᴰ.ob[ Γ ]
+      vert = ∀ueFⱽ.vertexⱽ
+
+      app : Cᴰ [ FC ⟪ C.id ⟫ ][ ＂πF* vert ＂ , Γᴰ ]
+      app = ∀ueFⱽ.elementⱽ
+
+      lda : ∀ {Δ} {Δᴰ : Cᴰ.ob[ Δ ]} {γ} →
+        Cᴰ [ FC ⟪ γ ⟫ ][ ＂πF* Δᴰ ＂ , Γᴰ ] →
+        Cᴰ [ γ ][ Δᴰ , vert ]
+      lda = ∀ueFⱽ.universalⱽ .fst
+
+      -- TODO the rest of the interface

--- a/Cubical/Categories/Displayed/Quantifiers.agda
+++ b/Cubical/Categories/Displayed/Quantifiers.agda
@@ -208,21 +208,50 @@ module _
     ＂F_＂ : C.ob → C.ob
     ＂F Γ ＂ = ueF Γ .vertex
 
+    F-Rep : ∀ {Γ} → PshIso (C [-, ＂F Γ ＂ ]) (F ⟅ C [-, Γ ] ⟆)
+    F-Rep = UniversalElementNotation.asPshIso (ueF _)
+
+    πF'-PshHom : ∀ {Γ} → PshHom (C [-, ＂F Γ ＂ ]) (C [-, Γ ])
+    πF'-PshHom {Γ} = _⋆PshHom_ {C = C}
+      {P = C [-, ＂F Γ ＂ ]} {Q = F ⟅ C [-, Γ ] ⟆} {R = C [-, Γ ]}
+      (F-Rep {Γ} .fst) (πF-PshHom (C [-, Γ ]))
+
     ＂π＂ : {Γ : C.ob} → C [ ＂F Γ ＂ , Γ ]
-    ＂π＂ {Γ = Γ} = πF ⟦ C [-, Γ ] ⟧ ⟦ ＂F Γ ＂ ⟧ $ ueF Γ .element
+    ＂π＂ {Γ = Γ} = πF'-PshHom .fst ＂F Γ ＂ C.id
+    -- πF-PshHom (C [-, Γ ]) .fst ＂F Γ ＂ (ueF Γ .element)
 
     -- F extends a functor on C
     FC : Functor C C
     FC = FunctorComprehension (F ∘F YO) (λ Γ → ueF Γ)
 
-    よ＂π＂≡ : (Γ : C.ob) → YO ⟪ ＂π＂ {Γ} ⟫ ≡
-       seqTrans (no-no-no (F ⟅ C [-, Γ ] ⟆) (ueF Γ .element))
-                (πF ⟦ C [-, Γ ] ⟧)
-    よ＂π＂≡ Γ = {!!}
+    F-PshHom : (Q : Presheaf C ℓC') → PshHom Q ((F ⟅ Q ⟆) ∘F (FC ^opF))
+    F-PshHom Q .fst Γ q =
+      F ⟪ PshHom→NatTrans (yoRec Q q) ⟫ ⟦ ＂F Γ ＂ ⟧ $ ueF Γ .element
+    -- TODO naturality
+    F-PshHom Q .snd = {!!}
+
+    ＂π＂' : {Γ : C.ob} → C [ ＂F Γ ＂ , Γ ]
+    ＂π＂' {Γ = Γ} = {!!}
+
+    -- よ＂π＂≡ : (Γ : C.ob) → YO ⟪ ＂π＂ {Γ} ⟫ ≡
+    --    seqTrans (no-no-no (F ⟅ C [-, Γ ] ⟆) (ueF Γ .element))
+    --             (πF ⟦ C [-, Γ ] ⟧)
+    -- よ＂π＂≡ Γ = {!!}
 
     ＂π＂-natural : ∀ {Γ}{Δ}(γ : C [ Γ , Δ ]) → ＂π＂ C.⋆ γ ≡ FC ⟪ γ ⟫ C.⋆ ＂π＂
+    -- TODO naturality
     ＂π＂-natural {Γ}{Δ} γ =
-      {!!}
+      ＂π＂ C.⋆ γ
+        ≡⟨ {!!} ⟩
+      -- πF'-PshHom .fst (F-ob FC Γ)
+      --  (yoRec (C [-, ＂F Δ ＂ ]) C.id .fst (F-ob FC Γ) (F-hom FC γ))
+      --   ≡⟨  (yoRec-natural-elt (C [-, ＂F Δ ＂ ]) (C [-, Δ ]) πF'-PshHom) ⟩
+      FC ⟪ γ ⟫ C.⋆ ＂π＂
+      ∎
+      where
+      module FΓ = PresheafNotation (F ⟅ C [-, Γ ] ⟆)
+      module FΔ = PresheafNotation (F ⟅ C [-, Δ ] ⟆)
+
       -- isFaithfulYO {C = C} ＂F Γ ＂ Δ _ _ $
       --   YO .F-seq ＂π＂ γ
       --   ∙ cong₂ seqTrans (よ＂π＂≡ Γ) refl
@@ -242,10 +271,10 @@ module _
       --   -- ∙ cong₂ seqTrans {!!} refl
       --   ∙ (sym $ YO {C = C} .F-seq {x = ＂F Γ ＂} {y = ＂F Δ ＂} {z = Δ}
       --             (FC ⟪ γ ⟫) ＂π＂)
-       where
-       module ueFΓ = UniversalElementNotation (ueF Γ)
-       module ueFΔ = UniversalElementNotation (ueF Δ)
-       module FΔ = PresheafNotation (F ⟅ C [-, Δ ] ⟆)
+       -- where
+       -- module ueFΓ = UniversalElementNotation (ueF Γ)
+       -- module ueFΔ = UniversalElementNotation (ueF Δ)
+       -- module FΔ = PresheafNotation (F ⟅ C [-, Δ ] ⟆)
 
        -- x : seqTrans (PshHom→NatTrans (yoRec (F ⟅ C [-, Γ ] ⟆) (ueF Γ .element)))
        --              (F ⟪ PshHom→NatTrans $ yoRec (C [-, Δ ]) γ ⟫)
@@ -339,49 +368,52 @@ module _
       ∀Pshⱽ : Presheafⱽ Γ Cᴰ ℓCᴰ'
       ∀Pshⱽ = RightAdjointProfⱽ weakenπFⱽ .F-obᴰ Γᴰ
 
-  -- --   module _
-  -- --     {P : Presheaf C ℓC'}
-  -- --     (Pᴰ : Presheafᴰ (F ⟅ P ⟆) Cᴰ ℓPᴰ) where
+    -- Parametrize by an arbitrary Presheafᴰ
+    module _
+      {P : Presheaf C ℓC'}
+      (Pᴰ : Presheafᴰ (F ⟅ P ⟆) Cᴰ ℓPᴰ) where
 
-  -- --     private
-  -- --       module P = PresheafNotation P
-  -- --       module FP = PresheafNotation (F ⟅ P ⟆)
-  -- --       module Pᴰ = PresheafᴰNotation Pᴰ
+      private
+        module P = PresheafNotation P
+        module FP = PresheafNotation (F ⟅ P ⟆)
+        module Pᴰ = PresheafᴰNotation Pᴰ
 
-  -- --     -- Trying to do this manually and I
-  -- --     -- run into obligations that seem to necessitate
-  -- --     -- functorialiaty for πF*
-  -- --     -- At the very least, the functoriality of πF* is
-  -- --     -- sufficient
-  -- --     ∀ᴰPshᴰ : Presheafᴰ P Cᴰ ℓPᴰ
-  -- --     ∀ᴰPshᴰ .F-obᴰ Γᴰ p =
-  -- --       Pᴰ .F-obᴰ (πF* Γᴰ ＂π＂ .vertexⱽ) (F-elt P p)
-  -- --     ∀ᴰPshᴰ .F-homᴰ γᴰ p pᴰ =
-  -- --       Pᴰ.reind (sym $ F-elt-natural P p) $
-  -- --         πF*-F-homᴰ γᴰ Pᴰ.⋆ᴰ pᴰ
-  -- --     ∀ᴰPshᴰ .F-idᴰ = funExt₂ λ p pᴰ →
-  -- --       Pᴰ.rectify $ Pᴰ.≡out $
-  -- --         (sym $ Pᴰ.reind-filler _ _)
-  -- --         ∙ Pᴰ.⟨ Cᴰ.≡in πF*-F-idᴰ ⟩⋆⟨⟩
-  -- --         ∙ Pᴰ.⋆IdL _
-  -- --     ∀ᴰPshᴰ .F-seqᴰ γᴰ δᴰ = funExt₂ λ p pᴰ →
-  -- --       Pᴰ.rectify $ Pᴰ.≡out $
-  -- --         (sym $ Pᴰ.reind-filler _ _)
-  -- --         ∙ Pᴰ.⟨ Cᴰ.≡in (πF*-F-seqᴰ δᴰ γᴰ) ⟩⋆⟨⟩
-  -- --         ∙ Pᴰ.⋆Assoc _ _ _
-  -- --         ∙ Pᴰ.⟨ refl ⟩⋆⟨ Pᴰ.reind-filler _ _ ⟩
-  -- --         ∙ Pᴰ.reind-filler _ _
+      ∀Pshᴰ : Presheafᴰ P Cᴰ ℓPᴰ
+      ∀Pshᴰ .F-obᴰ Γᴰ p =
+        Pᴰ .F-obᴰ ＂πF* Γᴰ ＂ (F-PshHom P .fst _ p)
+      ∀Pshᴰ .F-homᴰ γᴰ p pᴰ =
+        Pᴰ.reind (sym $ F-PshHom P .snd _ _ _ p) $
+          weakenπF .F-homᴰ γᴰ Pᴰ.⋆ᴰ pᴰ
+      ∀Pshᴰ .F-idᴰ = funExt₂ λ p pᴰ →
+        Pᴰ.rectify $ Pᴰ.≡out $
+          (sym $ Pᴰ.reind-filler _ _)
+          ∙ Pᴰ.⟨ Cᴰ.≡in $ weakenπF .F-idᴰ ⟩⋆⟨⟩
+          ∙ Pᴰ.⋆IdL _
+      ∀Pshᴰ .F-seqᴰ γᴰ δᴰ = funExt₂ λ p pᴰ →
+        Pᴰ.rectify $ Pᴰ.≡out $
+          (sym $ Pᴰ.reind-filler _ _)
+          ∙ Pᴰ.⟨ Cᴰ.≡in (weakenπF .F-seqᴰ δᴰ γᴰ) ⟩⋆⟨⟩
+          ∙ Pᴰ.⋆Assoc _ _ _
+          ∙ Pᴰ.⟨ refl ⟩⋆⟨ Pᴰ.reind-filler _ _ ⟩
+          ∙ Pᴰ.reind-filler _ _
 
-  -- --     -- An equivalent definition that directly uses
-  -- --     -- functoriality of πF*
-  -- --     -- but is a lot slower at least with the above holes
-  -- --     -- ∀ᴰPshᴰ' : Presheafᴰ P Cᴰ ℓPᴰ
-  -- --     -- ∀ᴰPshᴰ' = reind (F-PshHom P) $
-  -- --     --   (Pᴰ ∘Fᴰ (πF*-Functorᴰ ^opFᴰ))
+      -- An equivalent definition that directly uses
+      -- functoriality of πF*
+      -- but is a lot slower at least with the above holes
+      -- ∀ᴰPshᴰ' : Presheafᴰ P Cᴰ ℓPᴰ
+      -- ∀ᴰPshᴰ' = reind (F-PshHom P) $ (Pᴰ ∘Fᴰ (weakenπF ^opFᴰ))
 
     module _ {Γ : C.ob} (Γᴰ : Cᴰ.ob[ ＂F Γ ＂ ]) where
       UniversalQuantifierF : Type _
       UniversalQuantifierF = UniversalElementⱽ Cᴰ Γ (∀Pshⱽ Γᴰ)
+
+      UniversalQuantifierF' : Type _
+      UniversalQuantifierF' =
+        UniversalElementⱽ Cᴰ Γ (∀Pshᴰ (reind α (Cᴰ [-][-, Γᴰ ])))
+        where
+        α : PshHom (F ⟅ C [-, Γ ] ⟆) (C [-, ＂F Γ ＂ ])
+        α = invPshIso {P = C [-, ＂F Γ ＂ ]}{Q = F ⟅ C [-, Γ ] ⟆}
+          (UniversalElementNotation.asPshIso (ueF Γ)) .fst
 
     module UniversalQuantifierFNotation {Γ}{Γᴰ : Cᴰ.ob[ ＂F Γ ＂ ]}
       (∀Γᴰ : UniversalQuantifierF Γᴰ) where

--- a/Cubical/Categories/Displayed/Quantifiers.agda
+++ b/Cubical/Categories/Displayed/Quantifiers.agda
@@ -208,7 +208,7 @@ module _
     ＂F Γ ＂elt = ueF (C [-, Γ ]) .element
 
     ＂π＂ : {Γ : C.ob} → C [ ＂F Γ ＂ , Γ ]
-    ＂π＂ {Γ = Γ} = πF ⟦ C [-, Γ ] ⟧ ⟦ ＂F Γ ＂ ⟧ $ ueF _ .element
+    ＂π＂ {Γ = Γ} = πF ⟦ C [-, Γ ] ⟧ ⟦ ＂F Γ ＂ ⟧ $ ＂F Γ ＂elt
 
     -- F extends a functor on C
     FC : Functor C C
@@ -229,24 +229,28 @@ module _
       ＂πF*_＂ : ∀ {Γ} → (Γᴰ : Cᴰ.ob[ Γ ]) → Cᴰ.ob[ ＂F Γ ＂ ]
       ＂πF* Γᴰ ＂ = πF* Γᴰ .vertexⱽ
 
+    -- πF-Functorᴰ : Functorᴰ FC Cᴰ Cᴰ
+    -- πF-Functorᴰ =
+    --   FunctorᴰComprehension
+    --     {!!}
+    --     (λ Γ Γᴰ → πF* Γᴰ ◁PshIsoⱽᴰ {!!})
+
     module _
       {P : Presheaf C ℓC'}
       (Pᴰ : Presheafᴰ (F ⟅ P ⟆) Cᴰ ℓPᴰ) where
 
       private
-
         module P = PresheafNotation P
         module FP = PresheafNotation (F ⟅ P ⟆)
         module Pᴰ = PresheafᴰNotation Pᴰ
 
         mkFPElt : ∀ {Γ} → (p : P.p[ Γ ]) →
           FP.p[ ＂F Γ ＂ ]
-        mkFPElt {Γ} p = (F ⟪ α ⟫) ⟦ ＂F Γ ＂ ⟧ $ ＂F Γ ＂elt
+        mkFPElt {Γ} p =
+          (F ⟪ α ⟫) ⟦ ＂F Γ ＂ ⟧ $ ＂F Γ ＂elt
           where
           α : NatTrans (C [-, Γ ]) P
-          -- TODO this name should be changed upstream
-          -- or made private
-          α = no-no-no P p
+          α = PshHom→NatTrans (yoRec P p)
 
       -- Define ∀ᴰ Pᴰ such that
       --   (∀ᴰ Pᴰ) [ p ][ Γᴰ ] ≅ Pᴰ [ F p ][ πF* Γᴰ ]
@@ -262,7 +266,7 @@ module _
       --     |              |
       --     v     Fp       v
       --   ＂FΓ＂ --------> F P
-      ∀ᴰPshᴰ : Presheafᴰ P Cᴰ {!!}
+      ∀ᴰPshᴰ : Presheafᴰ P Cᴰ ℓPᴰ
       ∀ᴰPshᴰ .F-obᴰ {x = Γ} Γᴰ p = Pᴰ .F-obᴰ ＂πF* Γᴰ ＂ (mkFPElt p)
       -- Homs
       -- Given morphism γᴰ
@@ -297,7 +301,7 @@ module _
       --     v              v
       --   ＂FΔ＂ --------> F P
       --
-      -- Should πF* should have a functorial action on γᴰ
+      -- πF* should have a functorial action on γᴰ
       --
       --         πF* γᴰ
       --   πF* Δᴰ -----> πF* Γᴰ
@@ -307,22 +311,34 @@ module _
       --   ＂FΔ＂ ------> ＂FΓ＂
 
       ∀ᴰPshᴰ .F-homᴰ {x = Γ}{y = Δ}{f = γ}{xᴰ = Γᴰ}{yᴰ = Δᴰ} γᴰ p pᴰ =
-        Pᴰ.reind {!!} $ πF*γᴰ Pᴰ.⋆ᴰ pᴰ
+        Pᴰ.reind mkFPElt-natural $ πF*γᴰ Pᴰ.⋆ᴰ pᴰ
           where
           module π*よΓᴰ =
             PresheafⱽNotation (reindYo ＂π＂ (Cᴰ [-][-, Γᴰ ]))
           module π*よΔᴰ =
             PresheafⱽNotation (reindYo ＂π＂ (Cᴰ [-][-, Δᴰ ]))
+          module よΓ = PresheafNotation (C [-, Γ ])
+          module よΔ = PresheafNotation (C [-, Δ ])
 
           ＂Fγ＂ : C [ ＂F Δ ＂ , ＂F Γ ＂ ]
           ＂Fγ＂ = FC ⟪ γ ⟫
 
+          πF-natural : ＂π＂ C.⋆ γ ≡ ＂Fγ＂ C.⋆ ＂π＂
+          πF-natural =
+            {!!}
+            ∙ funExt⁻ ((πF ⟦ C [-, Γ ] ⟧) .N-hom ＂Fγ＂) ＂F Γ ＂elt
+
+
           δᴰ : π*よΓᴰ.p[ ＂Fγ＂ ][ ＂πF* Δᴰ ＂ ]
-          δᴰ = Cᴰ.reind {!!} $
+          δᴰ = Cᴰ.reind ((cong₂ C._⋆_ (C.⋆IdL _) refl) ∙ πF-natural) $
             πF* Δᴰ .elementⱽ Cᴰ.⋆ᴰ γᴰ
 
           πF*γᴰ : Cᴰ [ ＂Fγ＂ ][ ＂πF* Δᴰ ＂ , ＂πF* Γᴰ ＂ ]
           πF*γᴰ = introᴰ (πF* Γᴰ) δᴰ
+
+          mkFPElt-natural : ＂Fγ＂ FP.⋆ (mkFPElt p) ≡ mkFPElt (γ P.⋆ p)
+          mkFPElt-natural = {!!}
+
       ∀ᴰPshᴰ .F-idᴰ {xᴰ = Γᴰ} = funExt₂ λ p pᴰ →
         Pᴰ.rectify $ Pᴰ.≡out $
           (sym $ Pᴰ.reind-filler _ _)
@@ -330,8 +346,10 @@ module _
             introᴰ≡ (πF* Γᴰ)
               {!!}
             ⟩⋆⟨⟩
-          ∙ {!!}
+          ∙ Pᴰ.⋆IdL _
           where
+          module よΓᴰ =
+            PresheafⱽNotation (Cᴰ [-][-, Γᴰ ])
           module π*よΓᴰ =
             PresheafⱽNotation (reindYo ＂π＂ (Cᴰ [-][-, Γᴰ ]))
       ∀ᴰPshᴰ .F-seqᴰ = {!!}

--- a/Cubical/Categories/Limits/BinProduct/More.agda
+++ b/Cubical/Categories/Limits/BinProduct/More.agda
@@ -149,6 +149,10 @@ module BinProductsWithNotation {C : Category ℓ ℓ'}{a} (bp : BinProductsWith 
   ×aF : Functor C C
   ×aF = BinProductWithF C bp
 
+  π₁Nat : ×aF ⇒ Id
+  π₁Nat .NatTrans.N-ob _ = π₁
+  π₁Nat .NatTrans.N-hom _ = ×β₁
+
 private
   variable
     C D : Category ℓ ℓ'


### PR DESCRIPTION
This PR defines a more general universal quantifier parametrized by an endofunctor `F` with a natural transformation `πF : F ⇒ Id`

When the cartesian lift by `πF` exists for an arbitrary displayed object we can define a displayed endofunctor over `F`, which is given in `Displayed.Presheaf.CartesianLift`