### PR TITLE
Yoneda strictification of a presheaf

### DIFF
--- a/Cubical/Categories/Instances/FiberOverStrictify.agda
+++ b/Cubical/Categories/Instances/FiberOverStrictify.agda
@@ -1,0 +1,169 @@
+{-# OPTIONS --lossy-unification #-}
+module Cubical.Categories.Instances.FiberOverStrictify where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.More
+open import Cubical.Foundations.Function
+
+import Cubical.Data.Equality as Eq
+
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Instances.TotalCategory
+open import Cubical.Categories.Instances.Strictify
+open import Cubical.Categories.NaturalTransformation
+open import Cubical.Categories.Profunctor.General
+
+open import Cubical.Categories.Displayed.Base
+import Cubical.Categories.More as CatReasoning
+
+private
+  variable
+    ℓC ℓC' ℓCᴰ ℓCᴰ' ℓD ℓD' ℓDᴰ ℓDᴰ' : Level
+
+module _ {C' : Category ℓC ℓC'} where
+  private
+    C : Category _ _
+    C = YonedaStrictify C'
+
+  module Fibers (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ') where
+    private
+      module C = Category C
+      module Cᴰ = Categoryᴰ Cᴰ
+      module R {a b : C.ob} {aᴰ : Cᴰ.ob[ a ]}{bᴰ : Cᴰ.ob[ b ]} =
+        hSetReasoning (C [ a , b ] , C.isSetHom) Cᴰ.Hom[_][ aᴰ , bᴰ ]
+        renaming
+          (Prectify to rectify) hiding (_P≡[_]_)
+      module ∫Cᴰ = Category (∫C Cᴰ)
+    open Cᴰ public
+
+    v[_] : C.ob → Category ℓCᴰ ℓCᴰ'
+    v[ x ] .Category.ob = ob[ x ]
+    v[ x ] .Category.Hom[_,_] = Hom[ C.id ][_,_]
+    v[ x ] .Category.id = idᴰ
+    -- Removed a reind here
+    v[ x ] .Category._⋆_ fⱽ gⱽ = fⱽ ⋆ᴰ gⱽ
+    v[ x ] .Category.⋆IdL fⱽ = R.rectifyOut $ ∫Cᴰ.⋆IdL _
+    v[ x ] .Category.⋆IdR fⱽ = R.rectifyOut $ ∫Cᴰ.⋆IdR _
+    v[ x ] .Category.⋆Assoc fⱽ gⱽ hⱽ = R.rectifyOut $ ∫Cᴰ.⋆Assoc _ _ _
+    v[ x ] .Category.isSetHom = isSetHomᴰ
+
+    idⱽ : ∀ {x xᴰ} → v[ x ] [ xᴰ , xᴰ ]
+    idⱽ = v[ _ ] .Category.id
+
+    _⋆ⱽ_ : ∀ {x xᴰ xᴰ' xᴰ''} → v[ x ] [ xᴰ , xᴰ' ] → v[ x ] [ xᴰ' , xᴰ'' ]
+      → v[ x ] [ xᴰ , xᴰ'' ]
+    _⋆ⱽ_ = v[ _ ] .Category._⋆_
+
+    private
+      variable
+        x y z : C.ob
+        xᴰ xᴰ' xᴰ'' yᴰ yᴰ' yᴰ'' zᴰ : ob[ x ]
+        f g h : C [ x , y ]
+        fᴰ fᴰ' gᴰ gᴰ' hᴰ hᴰ' : Cᴰ [ f ][ xᴰ , yᴰ ]
+        fⱽ fⱽ' gⱽ gⱽ' hⱽ hⱽ' : v[ x ] [ xᴰ , xᴰ' ]
+
+    ⋆IdLⱽ : idⱽ ⋆ⱽ fⱽ ≡ fⱽ
+    ⋆IdLⱽ = v[ _ ] .Category.⋆IdL _
+
+    ⋆IdRⱽ : fⱽ ⋆ⱽ idⱽ ≡ fⱽ
+    ⋆IdRⱽ = v[ _ ] .Category.⋆IdR _
+
+    ⋆Assocⱽ : (fⱽ ⋆ⱽ gⱽ) ⋆ⱽ hⱽ ≡ fⱽ ⋆ⱽ (gⱽ ⋆ⱽ hⱽ)
+    ⋆Assocⱽ = v[ _ ] .Category.⋆Assoc _ _ _
+
+    isSetHomⱽ : isSet (v[ x ] [ xᴰ , xᴰ' ])
+    isSetHomⱽ = isSetHomᴰ
+
+    -- Removed a reind here
+    _⋆ᴰⱽ_ : Hom[ f ][ xᴰ , yᴰ ] → v[ y ] [ yᴰ , yᴰ' ] → Hom[ f ][ xᴰ , yᴰ' ]
+    _⋆ᴰⱽ_ {f = f} fᴰ gⱽ = fᴰ ⋆ᴰ gⱽ
+
+    ⋆IdLᴰⱽ : idᴰ ⋆ᴰⱽ fⱽ ≡ fⱽ
+    ⋆IdLᴰⱽ = R.rectifyOut $ ∫Cᴰ.⋆IdL _
+
+    ⋆IdRᴰⱽ : fᴰ ⋆ᴰⱽ idⱽ ≡ fᴰ
+    ⋆IdRᴰⱽ = R.rectifyOut $ ∫Cᴰ.⋆IdR _
+
+    ⋆Assocᴰⱽⱽ : (fᴰ ⋆ᴰⱽ gⱽ) ⋆ᴰⱽ hⱽ ≡ (fᴰ ⋆ᴰⱽ (gⱽ ⋆ⱽ hⱽ))
+    ⋆Assocᴰⱽⱽ = R.rectifyOut $ ∫Cᴰ.⋆Assoc _ _ _
+
+    _⋆ⱽᴰ_ : v[ x ] [ xᴰ , xᴰ' ] → Hom[ f ][ xᴰ' , yᴰ ] → Hom[ f ][ xᴰ , yᴰ ]
+    _⋆ⱽᴰ_ {f = f} gⱽ fᴰ = gⱽ ⋆ᴰ fᴰ
+
+    ⋆IdLⱽᴰ : ∀ (fᴰ : Hom[ f ][ xᴰ , yᴰ ]) → idⱽ ⋆ⱽᴰ fᴰ ≡ fᴰ
+    ⋆IdLⱽᴰ fᴰ = R.rectifyOut $ ∫Cᴰ.⋆IdL _
+
+    ⋆IdRⱽᴰ : ∀ (fⱽ : v[ x ] [ xᴰ , xᴰ' ]) → fⱽ ⋆ⱽᴰ idᴰ ≡ fⱽ
+    ⋆IdRⱽᴰ fⱽ = R.rectifyOut $ ∫Cᴰ.⋆IdR _
+
+    ⋆Assocⱽⱽᴰ : (fⱽ ⋆ⱽ gⱽ) ⋆ⱽᴰ hᴰ ≡ (fⱽ ⋆ⱽᴰ (gⱽ ⋆ⱽᴰ hᴰ))
+    ⋆Assocⱽⱽᴰ = R.rectifyOut $ ∫Cᴰ.⋆Assoc _ _ _
+
+    ⋆Assocⱽᴰⱽ : (fⱽ ⋆ⱽᴰ gᴰ) ⋆ᴰⱽ hⱽ ≡ (fⱽ ⋆ⱽᴰ (gᴰ ⋆ᴰⱽ hⱽ))
+    ⋆Assocⱽᴰⱽ = R.rectifyOut $ ∫Cᴰ.⋆Assoc _ _ _
+
+    ⋆Assocᴰⱽᴰ : (fᴰ ⋆ᴰⱽ gⱽ) ⋆ᴰ hᴰ ≡ (fᴰ ⋆ᴰ (gⱽ ⋆ⱽᴰ hᴰ))
+    ⋆Assocᴰⱽᴰ = R.rectifyOut $ ∫Cᴰ.⋆Assoc _ _ _
+
+    ⋆Assocⱽᴰᴰ : ((fⱽ ⋆ⱽᴰ gᴰ) ⋆ᴰ hᴰ) R.∫≡ (fⱽ ⋆ⱽᴰ (gᴰ ⋆ᴰ hᴰ))
+    ⋆Assocⱽᴰᴰ = ∫Cᴰ.⋆Assoc _ _ _
+
+    ∫⋆Assocᴰⱽᴰ : ((fᴰ ⋆ᴰⱽ gⱽ) ⋆ᴰ hᴰ) R.∫≡ (fᴰ ⋆ᴰ (gⱽ ⋆ⱽᴰ hᴰ))
+    ∫⋆Assocᴰⱽᴰ = R.≡in ⋆Assocᴰⱽᴰ
+
+    open NatTrans
+    HomᴰProf : (f : C [ x , y ]) → Profunctor v[ y ] v[ x ] ℓCᴰ'
+    HomᴰProf f .Functor.F-ob yᴰ .Functor.F-ob xᴰ .fst = Hom[ f ][ xᴰ , yᴰ ]
+    HomᴰProf f .Functor.F-ob yᴰ .Functor.F-ob xᴰ .snd = isSetHomᴰ
+    HomᴰProf f .Functor.F-ob yᴰ .Functor.F-hom gⱽ fᴰ = gⱽ ⋆ⱽᴰ fᴰ
+    HomᴰProf f .Functor.F-ob yᴰ .Functor.F-id = funExt ⋆IdLⱽᴰ
+    HomᴰProf f .Functor.F-ob yᴰ .Functor.F-seq hⱽ gⱽ = funExt λ fᴰ → ⋆Assocⱽⱽᴰ
+    HomᴰProf f .Functor.F-hom gⱽ .N-ob x fᴰ = fᴰ ⋆ᴰⱽ gⱽ
+    HomᴰProf f .Functor.F-hom gⱽ .N-hom fⱽ = funExt λ hᴰ → ⋆Assocⱽᴰⱽ
+    HomᴰProf f .Functor.F-id = makeNatTransPath (funExt (λ _ → funExt λ fᴰ →
+      ⋆IdRᴰⱽ))
+    HomᴰProf f .Functor.F-seq gⱽ hⱽ = makeNatTransPath (funExt λ _ → funExt λ fᴰ →
+      sym $ ⋆Assocᴰⱽⱽ)
+
+    open R public
+    open ∫Cᴰ public
+    open CatReasoning.Reasoning (∫C Cᴰ) public
+
+
+    ⟨_⟩⋆ⱽᴰ⟨_⟩
+      : Path Hom[ _ , _ ] (_ , fⱽ) (_ , fⱽ')
+      → Path Hom[ _ , _ ] (_ , gᴰ) (_ , gᴰ')
+      → Path Hom[ _ , _ ]
+          (_ , fⱽ ⋆ⱽᴰ gᴰ)
+          (_ , fⱽ' ⋆ⱽᴰ gᴰ')
+    ⟨ fⱽ≡fⱽ' ⟩⋆ⱽᴰ⟨ gᴰ≡gᴰ' ⟩ = ⟨ fⱽ≡fⱽ' ⟩⋆⟨ gᴰ≡gᴰ' ⟩
+
+    ⟨⟩⋆ⱽᴰ⟨_⟩
+      : Path Hom[ _ , _ ] (_ , gᴰ) (_ , gᴰ')
+      → Path Hom[ _ , _ ]
+          (_ , fⱽ ⋆ⱽᴰ gᴰ)
+          (_ , fⱽ ⋆ⱽᴰ gᴰ')
+    ⟨⟩⋆ⱽᴰ⟨ gᴰ≡gᴰ' ⟩ = ⟨ refl ⟩⋆ⱽᴰ⟨ gᴰ≡gᴰ' ⟩
+
+    ⟨_⟩⋆ⱽᴰ⟨⟩
+      : Path Hom[ _ , _ ] (_ , fⱽ) (_ , fⱽ')
+      → Path Hom[ _ , _ ]
+          (_ , fⱽ  ⋆ⱽᴰ gᴰ)
+          (_ , fⱽ' ⋆ⱽᴰ gᴰ)
+    ⟨ fⱽ≡fⱽ' ⟩⋆ⱽᴰ⟨⟩ = ⟨ fⱽ≡fⱽ' ⟩⋆ⱽᴰ⟨ refl ⟩
+
+    cong-reind : ∀ {a b : C.ob} {f f' g g' : C [ a , b ]}{aᴰ bᴰ}
+        {fᴰ : Cᴰ [ f ][ aᴰ , bᴰ ]}
+        {fᴰ' : Cᴰ [ f' ][ aᴰ , bᴰ ]}
+        (p : f ≡ g)
+        (p' : f' ≡ g')
+      → fᴰ ∫≡ fᴰ'
+      → reind p fᴰ ∫≡ reind p' fᴰ'
+    cong-reind p p' fᴰ≡fᴰ' = sym (reind-filler _) ∙ fᴰ≡fᴰ' ∙ reind-filler _
+
+module _ {C : Category ℓC ℓC'}
+         (Cᴰ : Categoryᴰ (YonedaStrictify C) ℓCᴰ ℓCᴰ') where
+  open Category
+  fiber : C .ob → Category ℓCᴰ ℓCᴰ'
+  fiber x = Fibers.v[_] Cᴰ x

--- a/Cubical/Categories/Instances/FullImage.agda
+++ b/Cubical/Categories/Instances/FullImage.agda
@@ -70,3 +70,9 @@ module _
   inv .F-seq f g =
     sym (invEq (equivAdjointEquiv FF≃)
     (F .F-seq _ _ ∙ cong₂ (seq' D) (secEq FF≃ _) (secEq FF≃ _)))
+
+  inv∘ToFullImage≡Id : inv ∘F ToFullImage F ≡ Id
+  inv∘ToFullImage≡Id = Functor≡ (λ _ → refl) (λ f → retEq FF≃ f)
+
+  ToFullImage∘inv≡Id : ToFullImage F ∘F inv ≡ Id
+  ToFullImage∘inv≡Id = Functor≡ (λ _ → refl) (λ f → secEq FF≃ f)

--- a/Cubical/Categories/Instances/Strictify.agda
+++ b/Cubical/Categories/Instances/Strictify.agda
@@ -37,12 +37,8 @@ module _ (C : Category ℓC ℓC') where
   fromYonedaStrictify : Functor YonedaStrictify C
   fromYonedaStrictify = inv isFullyFaithfulYOStrict
 
-  private
-    Hom≃ : ∀ {x y} → C [ x , y ] ≃ PshHomStrict (C [-, x ]) (C [-, y ])
-    Hom≃ {x}{y} = YOStrict .F-hom , isFullyFaithfulYOStrict x y
-
   fromYonedaStrictify∘toYonedaStrictify≡Id : fromYonedaStrictify ∘F toYonedaStrictify ≡ Id
-  fromYonedaStrictify∘toYonedaStrictify≡Id = Functor≡ (λ _ → refl) (λ f → retEq Hom≃ f)
+  fromYonedaStrictify∘toYonedaStrictify≡Id = inv∘ToFullImage≡Id isFullyFaithfulYOStrict
 
   toYonedaStrictify∘fromYonedaStrictify≡Id : toYonedaStrictify ∘F fromYonedaStrictify ≡ Id
-  toYonedaStrictify∘fromYonedaStrictify≡Id = Functor≡ (λ _ → refl) (λ f → secEq Hom≃ f)
+  toYonedaStrictify∘fromYonedaStrictify≡Id = ToFullImage∘inv≡Id isFullyFaithfulYOStrict

--- a/Cubical/Categories/Instances/Strictify.agda
+++ b/Cubical/Categories/Instances/Strictify.agda
@@ -1,0 +1,86 @@
+module Cubical.Categories.Instances.Strictify where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Functions.FunExtEquiv
+open import Cubical.Foundations.HLevels
+
+import Cubical.Data.Equality as Eq
+
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.NaturalTransformation
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.More
+open import Cubical.Categories.Presheaf.Representable
+open import Cubical.Categories.Presheaf.StrictHom
+
+private
+  variable ℓ ℓC ℓC' ℓD ℓD' : Level
+
+open Category
+open Functor
+
+module _ (C : Category ℓC ℓC') where
+  private
+    module C = Category C
+
+  YonedaStrictify : Category ℓC (ℓ-max ℓC ℓC')
+  YonedaStrictify .ob = C.ob
+  YonedaStrictify .Hom[_,_] c d = PshHomStrict (C [-, c ]) (C [-, d ])
+  YonedaStrictify .id = idPshHomStrict
+  YonedaStrictify ._⋆_ = _⋆PshHomStrict_
+  YonedaStrictify .⋆IdL = λ _ → refl
+  YonedaStrictify .⋆IdR = λ _ → refl
+  YonedaStrictify .⋆Assoc = λ _ _ _ → refl
+  YonedaStrictify .isSetHom = isSetPshHomStrict _ _
+
+  -- The path fields below (F-id, F-seq, to-from .N-hom) use copatterns
+  -- rather than makePshHomStrictPath so that .N-ob projections reduce.
+  -- The displayed versions in Displayed/Instances/Strictify rely on this
+  -- to apply makePshHomStrictᴰPathP without inlining their own copatterns.
+  toYonedaStrictify : Functor C YonedaStrictify
+  toYonedaStrictify .F-ob = λ z → z
+  toYonedaStrictify .F-hom f .PshHomStrict.N-ob = λ c z → z C.⋆ f
+  toYonedaStrictify .F-hom f .PshHomStrict.N-hom _ _ _ _ _ e =
+    (sym $ C.⋆Assoc _ _ _) ∙ C.⟨ e ⟩⋆⟨ refl ⟩
+  toYonedaStrictify .F-id {x = x} i .PshHomStrict.N-ob Γ p = C.⋆IdR p i
+  toYonedaStrictify .F-id {x = x} i .PshHomStrict.N-hom =
+    isProp→PathP (λ j → isPropN-hom (C [-, x ]) (C [-, x ]) (λ Γ p → C.⋆IdR p j))
+      (toYonedaStrictify .F-hom C.id .PshHomStrict.N-hom)
+      (idPshHomStrict {P = C [-, x ]} .PshHomStrict.N-hom) i
+  toYonedaStrictify .F-seq {x = x} {z = z} f g i .PshHomStrict.N-ob Γ p =
+    sym (C.⋆Assoc p f g) i
+  toYonedaStrictify .F-seq {x = x} {z = z} f g i .PshHomStrict.N-hom =
+    isProp→PathP
+      (λ j → isPropN-hom (C [-, x ]) (C [-, z ]) (λ Γ p → sym (C.⋆Assoc p f g) j))
+      (toYonedaStrictify .F-hom (f C.⋆ g) .PshHomStrict.N-hom)
+      ((toYonedaStrictify .F-hom f ⋆PshHomStrict toYonedaStrictify .F-hom g)
+        .PshHomStrict.N-hom) i
+
+  fromYonedaStrictify : Functor YonedaStrictify C
+  fromYonedaStrictify .F-ob = λ z → z
+  fromYonedaStrictify .F-hom = λ z → z .PshHomStrict.N-ob _ C.id
+  fromYonedaStrictify .F-id = refl
+  fromYonedaStrictify .F-seq f g = sym $ g .PshHomStrict.N-hom _ _ _ C.id _
+    (C.⋆IdR (fromYonedaStrictify .F-hom f))
+
+  to-from-YonedaStrictify : NatIso (toYonedaStrictify ∘F fromYonedaStrictify) Id
+  to-from-YonedaStrictify .NatIso.trans .NatTrans.N-ob = λ _ → idPshHomStrict
+  to-from-YonedaStrictify .NatIso.trans .NatTrans.N-hom {x = x}{y = y} f i .PshHomStrict.N-ob Γ p =
+    f .PshHomStrict.N-hom _ _ _ _ _ (C.⋆IdR p) i
+  to-from-YonedaStrictify .NatIso.trans .NatTrans.N-hom {x = x}{y = y} f i .PshHomStrict.N-hom =
+    isProp→PathP
+      (λ j → isPropN-hom (C [-, x ]) (C [-, y ])
+        (λ Γ p → f .PshHomStrict.N-hom _ _ _ _ _ (C.⋆IdR p) j))
+      ((toYonedaStrictify .F-hom (fromYonedaStrictify .F-hom f) ⋆PshHomStrict idPshHomStrict)
+        .PshHomStrict.N-hom)
+      ((idPshHomStrict ⋆PshHomStrict f) .PshHomStrict.N-hom) i
+  to-from-YonedaStrictify .NatIso.nIso c .isIso.inv = idPshHomStrict
+  to-from-YonedaStrictify .NatIso.nIso c .isIso.sec = refl
+  to-from-YonedaStrictify .NatIso.nIso c .isIso.ret = refl
+
+  from-to-YonedaStrictify : NatIso (fromYonedaStrictify ∘F toYonedaStrictify) Id
+  from-to-YonedaStrictify .NatIso.trans = natTrans (λ x → C.id) (λ _ → C.⋆IdR _)
+  from-to-YonedaStrictify .NatIso.nIso = λ _ → isiso C.id (C.⋆IdL _) (C.⋆IdL _)

--- a/Cubical/Categories/Instances/Strictify.agda
+++ b/Cubical/Categories/Instances/Strictify.agda
@@ -2,6 +2,7 @@ module Cubical.Categories.Instances.Strictify where
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Function
+open import Cubical.Foundations.Equiv
 open import Cubical.Functions.FunExtEquiv
 open import Cubical.Foundations.HLevels
 
@@ -10,6 +11,7 @@ import Cubical.Data.Equality as Eq
 open import Cubical.Categories.Category.Base
 open import Cubical.Categories.Functor.Base
 open import Cubical.Categories.NaturalTransformation
+open import Cubical.Categories.Instances.FullImage
 open import Cubical.Categories.Instances.Sets
 open import Cubical.Categories.Presheaf.Base
 open import Cubical.Categories.Presheaf.More
@@ -27,60 +29,20 @@ module _ (C : Category ℓC ℓC') where
     module C = Category C
 
   YonedaStrictify : Category ℓC (ℓ-max ℓC ℓC')
-  YonedaStrictify .ob = C.ob
-  YonedaStrictify .Hom[_,_] c d = PshHomStrict (C [-, c ]) (C [-, d ])
-  YonedaStrictify .id = idPshHomStrict
-  YonedaStrictify ._⋆_ = _⋆PshHomStrict_
-  YonedaStrictify .⋆IdL = λ _ → refl
-  YonedaStrictify .⋆IdR = λ _ → refl
-  YonedaStrictify .⋆Assoc = λ _ _ _ → refl
-  YonedaStrictify .isSetHom = isSetPshHomStrict _ _
+  YonedaStrictify = FullImage (YOStrict {C = C})
 
-  -- The path fields below (F-id, F-seq, to-from .N-hom) use copatterns
-  -- rather than makePshHomStrictPath so that .N-ob projections reduce.
-  -- The displayed versions in Displayed/Instances/Strictify rely on this
-  -- to apply makePshHomStrictᴰPathP without inlining their own copatterns.
   toYonedaStrictify : Functor C YonedaStrictify
-  toYonedaStrictify .F-ob = λ z → z
-  toYonedaStrictify .F-hom f .PshHomStrict.N-ob = λ c z → z C.⋆ f
-  toYonedaStrictify .F-hom f .PshHomStrict.N-hom _ _ _ _ _ e =
-    (sym $ C.⋆Assoc _ _ _) ∙ C.⟨ e ⟩⋆⟨ refl ⟩
-  toYonedaStrictify .F-id {x = x} i .PshHomStrict.N-ob Γ p = C.⋆IdR p i
-  toYonedaStrictify .F-id {x = x} i .PshHomStrict.N-hom =
-    isProp→PathP (λ j → isPropN-hom (C [-, x ]) (C [-, x ]) (λ Γ p → C.⋆IdR p j))
-      (toYonedaStrictify .F-hom C.id .PshHomStrict.N-hom)
-      (idPshHomStrict {P = C [-, x ]} .PshHomStrict.N-hom) i
-  toYonedaStrictify .F-seq {x = x} {z = z} f g i .PshHomStrict.N-ob Γ p =
-    sym (C.⋆Assoc p f g) i
-  toYonedaStrictify .F-seq {x = x} {z = z} f g i .PshHomStrict.N-hom =
-    isProp→PathP
-      (λ j → isPropN-hom (C [-, x ]) (C [-, z ]) (λ Γ p → sym (C.⋆Assoc p f g) j))
-      (toYonedaStrictify .F-hom (f C.⋆ g) .PshHomStrict.N-hom)
-      ((toYonedaStrictify .F-hom f ⋆PshHomStrict toYonedaStrictify .F-hom g)
-        .PshHomStrict.N-hom) i
+  toYonedaStrictify = ToFullImage YOStrict
 
   fromYonedaStrictify : Functor YonedaStrictify C
-  fromYonedaStrictify .F-ob = λ z → z
-  fromYonedaStrictify .F-hom = λ z → z .PshHomStrict.N-ob _ C.id
-  fromYonedaStrictify .F-id = refl
-  fromYonedaStrictify .F-seq f g = sym $ g .PshHomStrict.N-hom _ _ _ C.id _
-    (C.⋆IdR (fromYonedaStrictify .F-hom f))
+  fromYonedaStrictify = inv isFullyFaithfulYOStrict
 
-  to-from-YonedaStrictify : NatIso (toYonedaStrictify ∘F fromYonedaStrictify) Id
-  to-from-YonedaStrictify .NatIso.trans .NatTrans.N-ob = λ _ → idPshHomStrict
-  to-from-YonedaStrictify .NatIso.trans .NatTrans.N-hom {x = x}{y = y} f i .PshHomStrict.N-ob Γ p =
-    f .PshHomStrict.N-hom _ _ _ _ _ (C.⋆IdR p) i
-  to-from-YonedaStrictify .NatIso.trans .NatTrans.N-hom {x = x}{y = y} f i .PshHomStrict.N-hom =
-    isProp→PathP
-      (λ j → isPropN-hom (C [-, x ]) (C [-, y ])
-        (λ Γ p → f .PshHomStrict.N-hom _ _ _ _ _ (C.⋆IdR p) j))
-      ((toYonedaStrictify .F-hom (fromYonedaStrictify .F-hom f) ⋆PshHomStrict idPshHomStrict)
-        .PshHomStrict.N-hom)
-      ((idPshHomStrict ⋆PshHomStrict f) .PshHomStrict.N-hom) i
-  to-from-YonedaStrictify .NatIso.nIso c .isIso.inv = idPshHomStrict
-  to-from-YonedaStrictify .NatIso.nIso c .isIso.sec = refl
-  to-from-YonedaStrictify .NatIso.nIso c .isIso.ret = refl
+  private
+    Hom≃ : ∀ {x y} → C [ x , y ] ≃ PshHomStrict (C [-, x ]) (C [-, y ])
+    Hom≃ {x}{y} = YOStrict .F-hom , isFullyFaithfulYOStrict x y
 
-  from-to-YonedaStrictify : NatIso (fromYonedaStrictify ∘F toYonedaStrictify) Id
-  from-to-YonedaStrictify .NatIso.trans = natTrans (λ x → C.id) (λ _ → C.⋆IdR _)
-  from-to-YonedaStrictify .NatIso.nIso = λ _ → isiso C.id (C.⋆IdL _) (C.⋆IdL _)
+  fromYonedaStrictify∘toYonedaStrictify≡Id : fromYonedaStrictify ∘F toYonedaStrictify ≡ Id
+  fromYonedaStrictify∘toYonedaStrictify≡Id = Functor≡ (λ _ → refl) (λ f → retEq Hom≃ f)
+
+  toYonedaStrictify∘fromYonedaStrictify≡Id : toYonedaStrictify ∘F fromYonedaStrictify ≡ Id
+  toYonedaStrictify∘fromYonedaStrictify≡Id = Functor≡ (λ _ → refl) (λ f → secEq Hom≃ f)

--- a/Cubical/Categories/Presheaf/Strict.agda
+++ b/Cubical/Categories/Presheaf/Strict.agda
@@ -1,0 +1,95 @@
+{-# OPTIONS --lossy-unification #-}
+module Cubical.Categories.Presheaf.Strict where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Structure
+
+open import Cubical.Categories.Category renaming (isIso to isIsoC)
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.Strictify
+open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.NaturalTransformation hiding (_∘ˡ_; _∘ˡⁱ_)
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.Representable
+open import Cubical.Categories.Presheaf.StrictHom
+import Cubical.Categories.Presheaf.More as PshMore
+
+
+open Functor
+open Iso
+open NatIso
+open NatTrans
+
+private
+  variable
+    ℓ ℓ' ℓP ℓQ ℓS ℓS' ℓS'' : Level
+    ℓC ℓC' ℓD ℓD' : Level
+
+module _ {C : Category ℓ ℓ'} (P : Presheaf C ℓP) where
+  YonedaStrictifyPsh : Presheaf (YonedaStrictify C) _
+  YonedaStrictifyPsh .F-ob c .fst = PshHomStrict (C [-, c ]) P
+  YonedaStrictifyPsh .F-ob c .snd = isSetPshHomStrict _ _
+  YonedaStrictifyPsh .F-hom f p = f ⋆PshHomStrict p
+  YonedaStrictifyPsh .F-id = refl
+  YonedaStrictifyPsh .F-seq = λ _ _ → refl
+
+  -- Does it need to be YonedaStrictify C or can it be in C?
+  -- YonedaStrictifyPsh : Presheaf C _
+  -- YonedaStrictifyPsh .F-ob c .fst = PshHomStrict (C [-, c ]) P
+  -- YonedaStrictifyPsh .F-ob c .snd = isSetPshHomStrict _ _
+  -- YonedaStrictifyPsh .F-hom {x = x}{y = y} f p = compf ⋆PshHomStrict p
+  --   where
+
+  --   compf : PshHomStrict (C [-, y ]) (C [-, x ])
+  --   compf .PshHomStrict.N-ob c = C._⋆ f
+  --   compf .PshHomStrict.N-hom _ _ f g h ≡h = sym (C.⋆Assoc _ _ _) ∙ C.⟨ ≡h ⟩⋆⟨ refl ⟩
+  -- It does need to be YonedaStrictify C for this to be refl
+  -- YonedaStrictifyPsh .F-id = {!refl!}
+  -- YonedaStrictifyPsh .F-seq = λ _ _ → {!!}
+
+  private
+    module P = PshMore.PresheafNotation P
+
+  YonedaStrictifyPsh≅ : PshIsoStrict P (YonedaStrictifyPsh ∘F (toYonedaStrictify C ^opF))
+  YonedaStrictifyPsh≅ .PshIsoStrict.trans .PshHomStrict.N-ob c = yoRecStrict P
+  YonedaStrictifyPsh≅ .PshIsoStrict.trans .PshHomStrict.N-hom _ _ f p p' p≡ =
+    makePshHomStrictPath (funExt λ _ → funExt λ _ → P.⋆Assoc _ _ _ ∙ P.⟨⟩⋆⟨ p≡ ⟩)
+  YonedaStrictifyPsh≅ .PshIsoStrict.nIso c .fst = λ z → z .PshHomStrict.N-ob c (Category.id C)
+  YonedaStrictifyPsh≅ .PshIsoStrict.nIso c .snd .fst b =
+    makePshHomStrictPath (funExt λ _ → funExt λ _ → b .PshHomStrict.N-hom _ c _ _ _ (C .Category.⋆IdR _))
+  YonedaStrictifyPsh≅ .PshIsoStrict.nIso c .snd .snd _ = P.⋆IdL _
+
+module PresheafNotation {ℓo}{ℓh} {C' : Category ℓo ℓh} {ℓp} (P' : Presheaf C' ℓp) where
+  private
+    C = YonedaStrictify C'
+    P = YonedaStrictifyPsh P'
+    module C = Category C
+  p[_] : C.ob → Type _
+  p[ x ] = ⟨ P ⟅ x ⟆ ⟩
+
+  infixr 9 _⋆_
+  _⋆_ : ∀ {x y} (f : C [ x , y ]) (g : p[ y ]) → p[ x ]
+  f ⋆ g = f ⋆PshHomStrict g
+
+  ⋆IdL : ∀ {x} (g : p[ x ]) → C.id ⋆ g ≡ g
+  ⋆IdL = λ _ → refl
+
+  ⋆Assoc : ∀ {x y z} (f : C [ x , y ])(g : C [ y , z ])(h : p[ z ]) →
+    (f C.⋆ g) ⋆ h ≡ f ⋆ (g ⋆ h)
+  ⋆Assoc f g _ = refl
+
+  ⟨_⟩⋆⟨_⟩ : ∀ {x y} {f f' : C [ x , y ]} {g g' : p[ y ]}
+            → f ≡ f' → g ≡ g' → f ⋆ g ≡ f' ⋆ g'
+  ⟨ f≡f' ⟩⋆⟨ g≡g' ⟩ = cong₂ _⋆_ f≡f' g≡g'
+
+  ⟨⟩⋆⟨_⟩ : ∀ {x y} {f : C [ x , y ]} {g g' : p[ y ]}
+            → g ≡ g' → f ⋆ g ≡ f ⋆ g'
+  ⟨⟩⋆⟨_⟩ = ⟨ refl ⟩⋆⟨_⟩
+
+  ⟨_⟩⋆⟨⟩ : ∀ {x y} {f f' : C [ x , y ]} {g : p[ y ]}
+            → f ≡ f' → f ⋆ g ≡ f' ⋆ g
+  ⟨_⟩⋆⟨⟩ = ⟨_⟩⋆⟨ refl ⟩
+
+  isSetPsh : ∀ {x} → isSet (p[ x ])
+  isSetPsh {x} = (P ⟅ x ⟆) .snd

--- a/Cubical/Categories/Presheaf/StrictHom/Base.agda
+++ b/Cubical/Categories/Presheaf/StrictHom/Base.agda
@@ -360,6 +360,16 @@ module _ {C : Category ℓ ℓ'} where
   isFaithfulYOStrict x y f g p =
     (sym $ C.⋆IdL f) ∙ (λ i → p i .N-ob x C.id)  ∙ C.⋆IdL g
 
+  isFullyFaithfulYOStrict : isFullyFaithful YOStrict
+  isFullyFaithfulYOStrict x y = isoToIsEquiv theIso
+    where
+      theIso : Iso (C [ x , y ]) (PshHomStrict (C [-, x ]) (C [-, y ]))
+      theIso .fun = YOStrict .F-hom
+      theIso .inv α = α .N-ob x C.id
+      theIso .sec α = makePshHomStrictPath (funExt₂ λ c g →
+        α .N-hom c x g C.id g (C.⋆IdR g))
+      theIso .ret f = C.⋆IdL f
+
   -- If YOStrict factors as G ∘F F, then F is faithful
   module _ {D : Category ℓD ℓD'}
     {F : Functor C D}{G : Functor D (PRESHEAF C ℓ')}


### PR DESCRIPTION
This defines a strictification operation for a presheaf by replacing the elements of a presheaf `P` at `x` with a `PshHomStrict` between the Yoneda embedding on `x`

This should remain a draft until #255 is merged, then it should be rebased and merged. For readability, I am going to initially base this PR off of `strict`, but this should also be edited to instead be based at `main` when we go to merge