### PR TITLE
Yoneda Strictification of a Displayed Category

### DIFF
--- a/Cubical/Categories/Displayed/Instances/FullImage.agda
+++ b/Cubical/Categories/Displayed/Instances/FullImage.agda
@@ -1,0 +1,144 @@
+{-
+
+The Full Image of a displayed functor.
+
+Displayed analogue of Cubical.Categories.Instances.FullImage. Given
+Fᴰ : Functorᴰ F Cᴰ Dᴰ, the displayed full image is the Categoryᴰ over
+FullImage F whose displayed objects are those of Cᴰ and whose displayed
+homs are reindexed displayed homs of Dᴰ along Fᴰ on objects.
+
+-}
+{-# OPTIONS --lossy-unification #-}
+module Cubical.Categories.Displayed.Instances.FullImage where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.More
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Equiv.Dependent
+open import Cubical.Foundations.Function
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Instances.FullImage
+open import Cubical.Categories.Instances.Fiber
+
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Displayed.Functor.More
+import      Cubical.Categories.Displayed.Reasoning as DispReasoning
+
+private
+  variable
+    ℓC ℓC' ℓD ℓD' ℓCᴰ ℓCᴰ' ℓDᴰ ℓDᴰ' : Level
+
+open Category
+open Categoryᴰ
+open Functor
+open Functorᴰ
+
+module _
+  {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} (F : Functor C D)
+  {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'} {Dᴰ : Categoryᴰ D ℓDᴰ ℓDᴰ'}
+  (Fᴰ : Functorᴰ F Cᴰ Dᴰ)
+  where
+
+  FullImageᴰ : Categoryᴰ (FullImage F) ℓCᴰ ℓDᴰ'
+  FullImageᴰ .ob[_] = Cᴰ .ob[_]
+  FullImageᴰ .Hom[_][_,_] f xᴰ yᴰ =
+    Dᴰ .Hom[_][_,_] f (Fᴰ .F-obᴰ xᴰ) (Fᴰ .F-obᴰ yᴰ)
+  FullImageᴰ .idᴰ = Dᴰ .idᴰ
+  FullImageᴰ ._⋆ᴰ_ = Dᴰ ._⋆ᴰ_
+  FullImageᴰ .⋆IdLᴰ = Dᴰ .⋆IdLᴰ
+  FullImageᴰ .⋆IdRᴰ = Dᴰ .⋆IdRᴰ
+  FullImageᴰ .⋆Assocᴰ = Dᴰ .⋆Assocᴰ
+  FullImageᴰ .isSetHomᴰ = Dᴰ .isSetHomᴰ
+
+  ToFullImageᴰ : Functorᴰ (ToFullImage F) Cᴰ FullImageᴰ
+  ToFullImageᴰ .F-obᴰ xᴰ = xᴰ
+  ToFullImageᴰ .F-homᴰ = Fᴰ .F-homᴰ
+  ToFullImageᴰ .F-idᴰ = Fᴰ .F-idᴰ
+  ToFullImageᴰ .F-seqᴰ = Fᴰ .F-seqᴰ
+
+  FromFullImageᴰ : Functorᴰ (FromFullImage F) FullImageᴰ Dᴰ
+  FromFullImageᴰ .F-obᴰ = Fᴰ .F-obᴰ
+  FromFullImageᴰ .F-homᴰ = λ z → z
+  FromFullImageᴰ .F-idᴰ = refl
+  FromFullImageᴰ .F-seqᴰ _ _ = refl
+
+module _
+  {C : Category ℓC ℓC'} {D : Category ℓD ℓD'} (F : Functor C D)
+  {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'} {Dᴰ : Categoryᴰ D ℓDᴰ ℓDᴰ'}
+  (isFullyFaithfulF : isFullyFaithful F)
+  {Fᴰ : Functorᴰ F Cᴰ Dᴰ}
+  (isFullyFaithfulFᴰ : FullyFaithfulᴰ Fᴰ)
+  where
+
+  private
+    module C = Category C
+    module D = Category D
+    module Cᴰ = Fibers Cᴰ
+    module Dᴰ = Fibers Dᴰ
+
+    FC = FullImage F
+
+    FF≃  : ∀ {x y} → C.Hom[ x , y ] ≃ D.Hom[ F .F-ob x , F .F-ob y ]
+    FF≃ = _ , (isFullyFaithfulF _ _)
+
+    HomᴰMap : ∀ {x y} {xᴰ : Cᴰ.ob[ x ]} {yᴰ : Cᴰ.ob[ y ]} →
+      mapOver (FF≃ {x = x} {y = y} .fst)
+        Cᴰ.Hom[_][ xᴰ , yᴰ ]
+        Dᴰ.Hom[_][ Fᴰ .F-obᴰ xᴰ , Fᴰ .F-obᴰ yᴰ ]
+    HomᴰMap f fᴰ = Fᴰ .F-homᴰ fᴰ
+
+    FF≃ᴰ-isEquiv : ∀ {x y} {xᴰ : Cᴰ.ob[ x ]} {yᴰ : Cᴰ.ob[ y ]}
+      → isEquivOver {P = Cᴰ.Hom[_][ xᴰ , yᴰ ]}
+          {Q = Dᴰ.Hom[_][ Fᴰ .F-obᴰ xᴰ , Fᴰ .F-obᴰ yᴰ ]}
+          (HomᴰMap {x = x} {y = y} {xᴰ = xᴰ} {yᴰ = yᴰ})
+    FF≃ᴰ-isEquiv {xᴰ = xᴰ} {yᴰ = yᴰ} f = isIsoToIsEquiv (isFullyFaithfulFᴰ f xᴰ yᴰ)
+
+    FF≃ᴰ : ∀ {x y} {xᴰ : Cᴰ.ob[ x ]} {yᴰ : Cᴰ.ob[ y ]}
+      → IsoOver (equivToIso (FF≃ {x = x} {y = y}))
+          (Cᴰ.Hom[_][ xᴰ , yᴰ ])
+          (Dᴰ.Hom[_][ Fᴰ .F-obᴰ xᴰ , Fᴰ .F-obᴰ yᴰ ])
+    FF≃ᴰ {xᴰ = xᴰ} {yᴰ = yᴰ} =
+      equivOver→IsoOver FF≃ HomᴰMap (FF≃ᴰ-isEquiv {xᴰ = xᴰ} {yᴰ = yᴰ})
+
+  invᴰ : Functorᴰ (inv isFullyFaithfulF) (FullImageᴰ F Fᴰ) Cᴰ
+  invᴰ .F-obᴰ xᴰ = xᴰ
+  invᴰ .F-homᴰ {f = g} = IsoOver.inv FF≃ᴰ g
+  invᴰ .F-idᴰ {x = x} {xᴰ = xᴰ} =
+    Cᴰ.rectifyOut $
+      (sym $ Cᴰ.≡in $ λ i → IsoOver.inv FF≃ᴰ (F .F-id i) (Fᴰ .F-idᴰ i))
+      ∙ Cᴰ.≡in (IsoOver.leftInv FF≃ᴰ C.id Cᴰ.idᴰ)
+  invᴰ .F-seqᴰ {f = g} {g = h} {xᴰ = xᴰ} {yᴰ = yᴰ} {zᴰ = zᴰ} gᴰ hᴰ =
+    -- This could be a lot cleaner
+    Cᴰ.rectifyOut $
+      (sym $ Cᴰ.≡in $ λ i → IsoOver.inv FF≃ᴰ
+           ((isFullyFaithfulF _ _ .equiv-proof g .fst .snd i) D.⋆
+             (isFullyFaithfulF _ _ .equiv-proof h .fst .snd i))
+           (IsoOver.rightInv FF≃ᴰ g gᴰ i Dᴰ.⋆ᴰ IsoOver.rightInv FF≃ᴰ h hᴰ i))
+      ∙ (sym $ Cᴰ.≡in $ λ i → IsoOver.inv FF≃ᴰ
+        (F .F-seq (isFullyFaithfulF _ _ .equiv-proof g .fst .fst)
+                  (isFullyFaithfulF _ _ .equiv-proof h .fst .fst) i)
+        (Fᴰ .F-seqᴰ (IsoOver.inv FF≃ᴰ g gᴰ) (IsoOver.inv FF≃ᴰ h hᴰ) i))
+      ∙ Cᴰ.≡in (IsoOver.leftInv FF≃ᴰ
+                 (Iso.inv (equivToIso FF≃) g C.⋆ Iso.inv (equivToIso FF≃) h)
+                 (IsoOver.inv FF≃ᴰ g gᴰ Cᴰ.⋆ᴰ IsoOver.inv FF≃ᴰ h hᴰ))
+
+  invᴰ∘ToFullImageᴰ≡Idᴰ
+    : PathP (λ i → Functorᴰ (inv∘ToFullImage≡Id isFullyFaithfulF i) Cᴰ Cᴰ)
+        (invᴰ ∘Fᴰ ToFullImageᴰ F Fᴰ) 𝟙ᴰ⟨ Cᴰ ⟩
+  invᴰ∘ToFullImageᴰ≡Idᴰ =
+    Functorᴰ≡ {H = inv∘ToFullImage≡Id isFullyFaithfulF}
+      (λ _ → refl)
+      (λ {f = f} fᴰ → IsoOver.leftInv FF≃ᴰ f fᴰ)
+
+  ToFullImageᴰ∘invᴰ≡Idᴰ
+    : PathP (λ i → Functorᴰ (ToFullImage∘inv≡Id isFullyFaithfulF i)
+              (FullImageᴰ F Fᴰ) (FullImageᴰ F Fᴰ))
+        (ToFullImageᴰ F Fᴰ ∘Fᴰ invᴰ) 𝟙ᴰ⟨ FullImageᴰ F Fᴰ ⟩
+  ToFullImageᴰ∘invᴰ≡Idᴰ =
+    Functorᴰ≡ {H = ToFullImage∘inv≡Id isFullyFaithfulF}
+      (λ _ → refl)
+      (λ {f = f} fᴰ → IsoOver.rightInv FF≃ᴰ f fᴰ)

--- a/Cubical/Categories/Displayed/Instances/Strictify.agda
+++ b/Cubical/Categories/Displayed/Instances/Strictify.agda
@@ -1,0 +1,96 @@
+{-
+  Yoneda strictification of a displayed category.
+-}
+{-# OPTIONS --lossy-unification #-}
+module Cubical.Categories.Displayed.Instances.Strictify where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Function
+
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.More
+open import Cubical.Categories.Presheaf.StrictHom
+open import Cubical.Categories.Instances.Strictify
+open import Cubical.Categories.Instances.Fiber
+
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Displayed.Functor.More
+open import Cubical.Categories.Displayed.NaturalTransformation
+open import Cubical.Categories.Displayed.NaturalTransformation.More
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Eq.Base
+open import Cubical.Categories.Displayed.Presheaf.StrictHom
+
+private
+  variable
+    ℓC ℓC' ℓCᴰ ℓCᴰ' : Level
+
+open Categoryᴰ
+open Functorᴰ
+open NatTransᴰ
+open NatIsoᴰ
+open isIsoᴰ
+open PshHomStrict
+open PshHomStrictᴰ
+
+module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ') where
+  private
+    module C = Category C
+    module Cᴰf = Fibers Cᴰ
+    module Cᴰ = Categoryᴰ Cᴰ
+
+  YonedaStrictifyᴰ
+    : Categoryᴰ (YonedaStrictify C)
+        ℓCᴰ
+        (ℓ-max (ℓ-max ℓC ℓC') (ℓ-max ℓCᴰ ℓCᴰ'))
+  YonedaStrictifyᴰ .ob[_] = Cᴰ.ob[_]
+  YonedaStrictifyᴰ .Hom[_][_,_] α xᴰ yᴰ =
+    PshHomStrictᴰ α (Cᴰ [-][-, xᴰ ]) (Cᴰ [-][-, yᴰ ])
+  YonedaStrictifyᴰ .idᴰ = idPshHomStrictᴰ
+  YonedaStrictifyᴰ ._⋆ᴰ_ = _⋆PshHomStrictᴰ_
+  YonedaStrictifyᴰ .⋆IdLᴰ _ = refl
+  YonedaStrictifyᴰ .⋆IdRᴰ _ = refl
+  YonedaStrictifyᴰ .⋆Assocᴰ _ _ _ = refl
+  YonedaStrictifyᴰ .isSetHomᴰ = isSetPshHomStrictᴰ _ _ _
+
+  toYonedaStrictifyᴰ : Functorᴰ (toYonedaStrictify C) Cᴰ YonedaStrictifyᴰ
+  toYonedaStrictifyᴰ .F-obᴰ xᴰ = xᴰ
+  toYonedaStrictifyᴰ .F-homᴰ fᴰ .N-obᴰ Γ Γᴰ p pᴰ = pᴰ Cᴰ.⋆ᴰ fᴰ
+  toYonedaStrictifyᴰ .F-homᴰ {f = f} fᴰ .N-homᴰ Δ Γ Δᴰ Γᴰ g p' p gᴰ pᴰ' pᴰ e eᴰ =
+    Cᴰf.rectifyOut $ sym (Cᴰf.≡in (Cᴰ.⋆Assocᴰ gᴰ pᴰ' fᴰ)) ∙ Cᴰf.⟨ Cᴰf.≡in eᴰ ⟩⋆⟨ refl ⟩
+  toYonedaStrictifyᴰ .F-idᴰ =
+    makePshHomStrictᴰPathP (λ i Γ Γᴰ p pᴰ → Cᴰ.⋆IdRᴰ pᴰ i)
+  toYonedaStrictifyᴰ .F-seqᴰ fᴰ gᴰ =
+    makePshHomStrictᴰPathP (λ i Γ Γᴰ p pᴰ → symP (Cᴰ.⋆Assocᴰ pᴰ fᴰ gᴰ) i)
+
+  fromYonedaStrictifyᴰ : Functorᴰ (fromYonedaStrictify C) YonedaStrictifyᴰ Cᴰ
+  fromYonedaStrictifyᴰ .F-obᴰ = λ z → z
+  fromYonedaStrictifyᴰ .F-homᴰ = λ z →
+                                    z .N-obᴰ (fromYonedaStrictify C .Functor.F-ob _)
+                                    (F-obᴰ fromYonedaStrictifyᴰ _) C.id Cᴰ.idᴰ
+  fromYonedaStrictifyᴰ .F-idᴰ = refl
+  fromYonedaStrictifyᴰ .F-seqᴰ f g = Cᴰf.rectifyOut $ sym $ Cᴰf.≡in $
+    g .PshHomStrictᴰ.N-homᴰ _ _ _ _ _ _ _ _ _ _ (C.⋆IdR _) (Cᴰ.⋆IdRᴰ _)
+
+  from-to-YonedaStrictifyᴰ
+    : NatIsoᴰ (from-to-YonedaStrictify C)
+        (fromYonedaStrictifyᴰ ∘Fᴰ toYonedaStrictifyᴰ) Idᴰ
+  from-to-YonedaStrictifyᴰ .transᴰ .N-obᴰ _ = Cᴰ.idᴰ
+  from-to-YonedaStrictifyᴰ .transᴰ .N-homᴰ fᴰ = Cᴰ.⋆IdRᴰ _
+  from-to-YonedaStrictifyᴰ .nIsoᴰ xᴰ .invᴰ = Cᴰ.idᴰ
+  from-to-YonedaStrictifyᴰ .nIsoᴰ xᴰ .secᴰ = Cᴰ.⋆IdLᴰ _
+  from-to-YonedaStrictifyᴰ .nIsoᴰ xᴰ .retᴰ = Cᴰ.⋆IdLᴰ _
+
+  to-from-YonedaStrictifyᴰ
+    : NatIsoᴰ (to-from-YonedaStrictify C)
+        (toYonedaStrictifyᴰ ∘Fᴰ fromYonedaStrictifyᴰ) Idᴰ
+  to-from-YonedaStrictifyᴰ .transᴰ .N-obᴰ _ = idPshHomStrictᴰ
+  to-from-YonedaStrictifyᴰ .transᴰ .N-homᴰ {x = x}{xᴰ = xᴰ} fᴰ =
+    makePshHomStrictᴰPathP (λ i Γ Γᴰ p pᴰ →
+      fᴰ .N-homᴰ Γ x Γᴰ xᴰ p C.id p pᴰ Cᴰ.idᴰ pᴰ (C.⋆IdR p) (Cᴰ.⋆IdRᴰ pᴰ) i)
+  to-from-YonedaStrictifyᴰ .nIsoᴰ xᴰ .invᴰ = idPshHomStrictᴰ
+  to-from-YonedaStrictifyᴰ .nIsoᴰ xᴰ .secᴰ = refl
+  to-from-YonedaStrictifyᴰ .nIsoᴰ xᴰ .retᴰ = refl

--- a/Cubical/Categories/Displayed/Instances/Strictify.agda
+++ b/Cubical/Categories/Displayed/Instances/Strictify.agda
@@ -19,6 +19,9 @@ open import Cubical.Categories.Instances.Fiber
 open import Cubical.Categories.Displayed.Base
 open import Cubical.Categories.Displayed.Functor
 open import Cubical.Categories.Displayed.Functor.More
+open import Cubical.Categories.Displayed.Instances.FullImage
+  hiding (invᴰ)
+import      Cubical.Categories.Displayed.Instances.FullImage as FIᴰ
 open import Cubical.Categories.Displayed.NaturalTransformation
 open import Cubical.Categories.Displayed.NaturalTransformation.More
 open import Cubical.Categories.Displayed.Presheaf.Uncurried.Eq.Base
@@ -46,51 +49,53 @@ module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ') where
     : Categoryᴰ (YonedaStrictify C)
         ℓCᴰ
         (ℓ-max (ℓ-max ℓC ℓC') (ℓ-max ℓCᴰ ℓCᴰ'))
-  YonedaStrictifyᴰ .ob[_] = Cᴰ.ob[_]
-  YonedaStrictifyᴰ .Hom[_][_,_] α xᴰ yᴰ =
-    PshHomStrictᴰ α (Cᴰ [-][-, xᴰ ]) (Cᴰ [-][-, yᴰ ])
-  YonedaStrictifyᴰ .idᴰ = idPshHomStrictᴰ
-  YonedaStrictifyᴰ ._⋆ᴰ_ = _⋆PshHomStrictᴰ_
-  YonedaStrictifyᴰ .⋆IdLᴰ _ = refl
-  YonedaStrictifyᴰ .⋆IdRᴰ _ = refl
-  YonedaStrictifyᴰ .⋆Assocᴰ _ _ _ = refl
-  YonedaStrictifyᴰ .isSetHomᴰ = isSetPshHomStrictᴰ _ _ _
+  YonedaStrictifyᴰ = FullImageᴰ (YOStrict {C = C}) (YOStrictᴰ Cᴰ)
 
   toYonedaStrictifyᴰ : Functorᴰ (toYonedaStrictify C) Cᴰ YonedaStrictifyᴰ
-  toYonedaStrictifyᴰ .F-obᴰ xᴰ = xᴰ
-  toYonedaStrictifyᴰ .F-homᴰ fᴰ .N-obᴰ Γ Γᴰ p pᴰ = pᴰ Cᴰ.⋆ᴰ fᴰ
-  toYonedaStrictifyᴰ .F-homᴰ {f = f} fᴰ .N-homᴰ Δ Γ Δᴰ Γᴰ g p' p gᴰ pᴰ' pᴰ e eᴰ =
-    Cᴰf.rectifyOut $ sym (Cᴰf.≡in (Cᴰ.⋆Assocᴰ gᴰ pᴰ' fᴰ)) ∙ Cᴰf.⟨ Cᴰf.≡in eᴰ ⟩⋆⟨ refl ⟩
-  toYonedaStrictifyᴰ .F-idᴰ =
-    makePshHomStrictᴰPathP (λ i Γ Γᴰ p pᴰ → Cᴰ.⋆IdRᴰ pᴰ i)
-  toYonedaStrictifyᴰ .F-seqᴰ fᴰ gᴰ =
-    makePshHomStrictᴰPathP (λ i Γ Γᴰ p pᴰ → symP (Cᴰ.⋆Assocᴰ pᴰ fᴰ gᴰ) i)
+  toYonedaStrictifyᴰ = ToFullImageᴰ (YOStrict {C = C}) (YOStrictᴰ Cᴰ)
 
   fromYonedaStrictifyᴰ : Functorᴰ (fromYonedaStrictify C) YonedaStrictifyᴰ Cᴰ
-  fromYonedaStrictifyᴰ .F-obᴰ = λ z → z
-  fromYonedaStrictifyᴰ .F-homᴰ = λ z →
-                                    z .N-obᴰ (fromYonedaStrictify C .Functor.F-ob _)
-                                    (F-obᴰ fromYonedaStrictifyᴰ _) C.id Cᴰ.idᴰ
-  fromYonedaStrictifyᴰ .F-idᴰ = refl
-  fromYonedaStrictifyᴰ .F-seqᴰ f g = Cᴰf.rectifyOut $ sym $ Cᴰf.≡in $
-    g .PshHomStrictᴰ.N-homᴰ _ _ _ _ _ _ _ _ _ _ (C.⋆IdR _) (Cᴰ.⋆IdRᴰ _)
+  fromYonedaStrictifyᴰ =
+    FIᴰ.invᴰ (YOStrict {C = C}) isFullyFaithfulYOStrict
+      (isFullyFaithfulYOStrictᴰ Cᴰ)
 
-  from-to-YonedaStrictifyᴰ
-    : NatIsoᴰ (from-to-YonedaStrictify C)
-        (fromYonedaStrictifyᴰ ∘Fᴰ toYonedaStrictifyᴰ) Idᴰ
-  from-to-YonedaStrictifyᴰ .transᴰ .N-obᴰ _ = Cᴰ.idᴰ
-  from-to-YonedaStrictifyᴰ .transᴰ .N-homᴰ fᴰ = Cᴰ.⋆IdRᴰ _
-  from-to-YonedaStrictifyᴰ .nIsoᴰ xᴰ .invᴰ = Cᴰ.idᴰ
-  from-to-YonedaStrictifyᴰ .nIsoᴰ xᴰ .secᴰ = Cᴰ.⋆IdLᴰ _
-  from-to-YonedaStrictifyᴰ .nIsoᴰ xᴰ .retᴰ = Cᴰ.⋆IdLᴰ _
+  fromYonedaStrictifyᴰ∘toYonedaStrictifyᴰ≡Idᴰ
+    : PathP (λ i → Functorᴰ (fromYonedaStrictify∘toYonedaStrictify≡Id C i) Cᴰ Cᴰ)
+        (fromYonedaStrictifyᴰ ∘Fᴰ toYonedaStrictifyᴰ) 𝟙ᴰ⟨ Cᴰ ⟩
+  fromYonedaStrictifyᴰ∘toYonedaStrictifyᴰ≡Idᴰ =
+    invᴰ∘ToFullImageᴰ≡Idᴰ (YOStrict {C = C}) isFullyFaithfulYOStrict
+      (isFullyFaithfulYOStrictᴰ Cᴰ)
 
-  to-from-YonedaStrictifyᴰ
-    : NatIsoᴰ (to-from-YonedaStrictify C)
-        (toYonedaStrictifyᴰ ∘Fᴰ fromYonedaStrictifyᴰ) Idᴰ
-  to-from-YonedaStrictifyᴰ .transᴰ .N-obᴰ _ = idPshHomStrictᴰ
-  to-from-YonedaStrictifyᴰ .transᴰ .N-homᴰ {x = x}{xᴰ = xᴰ} fᴰ =
-    makePshHomStrictᴰPathP (λ i Γ Γᴰ p pᴰ →
-      fᴰ .N-homᴰ Γ x Γᴰ xᴰ p C.id p pᴰ Cᴰ.idᴰ pᴰ (C.⋆IdR p) (Cᴰ.⋆IdRᴰ pᴰ) i)
-  to-from-YonedaStrictifyᴰ .nIsoᴰ xᴰ .invᴰ = idPshHomStrictᴰ
-  to-from-YonedaStrictifyᴰ .nIsoᴰ xᴰ .secᴰ = refl
-  to-from-YonedaStrictifyᴰ .nIsoᴰ xᴰ .retᴰ = refl
+  toYonedaStrictifyᴰ∘fromYonedaStrictifyᴰ≡Idᴰ
+    : PathP (λ i → Functorᴰ (toYonedaStrictify∘fromYonedaStrictify≡Id C i)
+              YonedaStrictifyᴰ YonedaStrictifyᴰ)
+        (toYonedaStrictifyᴰ ∘Fᴰ fromYonedaStrictifyᴰ) 𝟙ᴰ⟨ YonedaStrictifyᴰ ⟩
+  toYonedaStrictifyᴰ∘fromYonedaStrictifyᴰ≡Idᴰ =
+    ToFullImageᴰ∘invᴰ≡Idᴰ (YOStrict {C = C}) isFullyFaithfulYOStrict
+      (isFullyFaithfulYOStrictᴰ Cᴰ)
+
+  YonedaStrictifyᴰ'
+    : Categoryᴰ (YonedaStrictify C)
+        ℓCᴰ
+        (ℓ-max (ℓ-max ℓC ℓC') (ℓ-max ℓCᴰ ℓCᴰ'))
+  YonedaStrictifyᴰ' .ob[_] = Cᴰ.ob[_]
+  YonedaStrictifyᴰ' .Hom[_][_,_] α xᴰ yᴰ =
+    PshHomStrictᴰ α (Cᴰ [-][-, xᴰ ]) (Cᴰ [-][-, yᴰ ])
+  YonedaStrictifyᴰ' .idᴰ = idPshHomStrictᴰ
+  YonedaStrictifyᴰ' ._⋆ᴰ_ = _⋆PshHomStrictᴰ_
+  YonedaStrictifyᴰ' .⋆IdLᴰ _ = refl
+  YonedaStrictifyᴰ' .⋆IdRᴰ _ = refl
+  YonedaStrictifyᴰ' .⋆Assocᴰ _ _ _ = refl
+  YonedaStrictifyᴰ' .isSetHomᴰ = isSetPshHomStrictᴰ _ _ _
+
+  -- FullImageᴰ gives the right definition for YonedaStrictifyᴰ
+  YonedaStrictifyᴰ≡ : YonedaStrictifyᴰ ≡ YonedaStrictifyᴰ'
+  YonedaStrictifyᴰ≡ i .ob[_] = Cᴰ.ob[_]
+  YonedaStrictifyᴰ≡ i .Hom[_][_,_] α xᴰ yᴰ =
+    PshHomStrictᴰ α (Cᴰ [-][-, xᴰ ]) (Cᴰ [-][-, yᴰ ])
+  YonedaStrictifyᴰ≡ i .idᴰ = idPshHomStrictᴰ
+  YonedaStrictifyᴰ≡ i ._⋆ᴰ_ = _⋆PshHomStrictᴰ_
+  YonedaStrictifyᴰ≡ i .⋆IdLᴰ _ = refl
+  YonedaStrictifyᴰ≡ i .⋆IdRᴰ _ = refl
+  YonedaStrictifyᴰ≡ i .⋆Assocᴰ _ _ _ = refl
+  YonedaStrictifyᴰ≡ i .isSetHomᴰ = isSetPshHomStrictᴰ _ _ _

--- a/Cubical/Categories/Displayed/Presheaf/StrictHom.agda
+++ b/Cubical/Categories/Displayed/Presheaf/StrictHom.agda
@@ -7,6 +7,7 @@
 module Cubical.Categories.Displayed.Presheaf.StrictHom where
 
 open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
 open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Structure
@@ -15,11 +16,14 @@ open import Cubical.Data.Sigma
 
 open import Cubical.Categories.Category.Base
 open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.Instances.Fiber
 open import Cubical.Categories.Presheaf.Base
 open import Cubical.Categories.Presheaf.More
 open import Cubical.Categories.Presheaf.StrictHom.Base
 
 open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Displayed.Functor.More
 open import Cubical.Categories.Displayed.Presheaf.Uncurried.Eq.Base
 
 private
@@ -28,6 +32,7 @@ private
     ℓC ℓC' ℓCᴰ ℓCᴰ' : Level
 
 open Functor
+open Functorᴰ
 open Categoryᴰ
 open PshHomStrict
 
@@ -164,3 +169,43 @@ module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ')
   PRESHEAFᴰStrict .⋆IdRᴰ _ = refl
   PRESHEAFᴰStrict .⋆Assocᴰ _ _ _ = refl
   PRESHEAFᴰStrict .isSetHomᴰ = isSetPshHomStrictᴰ _ _ _
+
+module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ') where
+  private
+    module C = Category C
+    module Cᴰ = Categoryᴰ Cᴰ
+    module Cᴰf = Fibers Cᴰ
+
+  YOStrictᴰ : Functorᴰ (YOStrict {C = C}) Cᴰ (PRESHEAFᴰStrict Cᴰ ℓC' ℓCᴰ')
+  YOStrictᴰ .F-obᴰ xᴰ = Cᴰ [-][-, xᴰ ]
+  YOStrictᴰ .F-homᴰ hᴰ .N-obᴰ Γ Γᴰ g gᴰ = gᴰ Cᴰ.⋆ᴰ hᴰ
+  YOStrictᴰ .F-homᴰ hᴰ .N-homᴰ Δ Γ Δᴰ Γᴰ f p' p fᴰ p'ᴰ pᴰ e eᴰ =
+    Cᴰf.rectifyOut $
+      sym (Cᴰf.≡in (Cᴰf.⋆Assocᴰ fᴰ p'ᴰ hᴰ))
+      ∙ Cᴰf.⟨ Cᴰf.≡in eᴰ ⟩⋆⟨ refl ⟩
+  YOStrictᴰ .F-idᴰ =
+    makePshHomStrictᴰPathP (funExt λ _ → funExt λ _ → funExt λ _ → funExt λ _ →
+      Cᴰf.rectifyOut (Cᴰf.≡in $ Cᴰf.⋆IdRᴰ _))
+  YOStrictᴰ .F-seqᴰ h₁ᴰ h₂ᴰ =
+    makePshHomStrictᴰPathP (funExt λ _ → funExt λ _ → funExt λ _ → funExt λ _ →
+      Cᴰf.rectifyOut (sym $ Cᴰf.≡in $ Cᴰf.⋆Assocᴰ _ _ _))
+
+  isFullyFaithfulYOStrictᴰ : FullyFaithfulᴰ YOStrictᴰ
+  isFullyFaithfulYOStrictᴰ {x = x} {y = y} f xᴰ yᴰ = bwd , sec , ret
+    where
+      bwd : PshHomStrictᴰ (YOStrict .F-hom f) (Cᴰ [-][-, xᴰ ]) (Cᴰ [-][-, yᴰ ])
+            → Cᴰ.Hom[ f ][ xᴰ , yᴰ ]
+      bwd αᴰ = Cᴰf.reind (C.⋆IdL f) (αᴰ .N-obᴰ x xᴰ C.id Cᴰ.idᴰ)
+
+      sec : ∀ αᴰ → YOStrictᴰ .F-homᴰ (bwd αᴰ) ≡ αᴰ
+      sec αᴰ = makePshHomStrictᴰPath
+        (funExt λ Γ → funExt λ Γᴰ → funExt λ g → funExt λ gᴰ →
+          Cᴰf.rectifyOut $
+            Cᴰf.⟨ refl ⟩⋆⟨ Cᴰf.reind-filler⁻ (C.⋆IdL f) ⟩
+            ∙ Cᴰf.≡in
+                (αᴰ .N-homᴰ Γ x Γᴰ xᴰ g C.id g gᴰ Cᴰ.idᴰ gᴰ
+                  (C.⋆IdR g) (Cᴰ.⋆IdRᴰ gᴰ)))
+
+      ret : ∀ hᴰ → bwd (YOStrictᴰ .F-homᴰ hᴰ) ≡ hᴰ
+      ret hᴰ = Cᴰf.rectifyOut $
+        Cᴰf.reind-filler⁻ (C.⋆IdL f) ∙ Cᴰf.≡in (Cᴰ.⋆IdLᴰ hᴰ)

--- a/Cubical/Categories/Displayed/Presheaf/StrictHom.agda
+++ b/Cubical/Categories/Displayed/Presheaf/StrictHom.agda
@@ -1,0 +1,166 @@
+{-
+  Strict displayed presheaf homomorphisms.
+
+  Defines PshHomStrictᴰ α Pᴰ Qᴰ as a displayed analogue of PshHomStrict P Q
+-}
+{-# OPTIONS --lossy-unification #-}
+module Cubical.Categories.Displayed.Presheaf.StrictHom where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Structure
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.More
+open import Cubical.Categories.Presheaf.StrictHom.Base
+
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Eq.Base
+
+private
+  variable
+    ℓ ℓ' ℓP ℓQ ℓR ℓPᴰ ℓQᴰ ℓRᴰ : Level
+    ℓC ℓC' ℓCᴰ ℓCᴰ' : Level
+
+open Functor
+open Categoryᴰ
+open PshHomStrict
+
+module _ {C : Category ℓC ℓC'} {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
+  {P : Presheaf C ℓP} {Q : Presheaf C ℓQ}
+  (α : PshHomStrict P Q)
+  (Pᴰ : Presheafᴰ P Cᴰ ℓPᴰ) (Qᴰ : Presheafᴰ Q Cᴰ ℓQᴰ)
+  where
+  private
+    module C = Category C
+    module Cᴰ = Categoryᴰ Cᴰ
+    module P = PresheafNotation P
+    module Q = PresheafNotation Q
+    module Pᴰ = PresheafᴰNotation Pᴰ
+    module Qᴰ = PresheafᴰNotation Qᴰ
+
+  PshHomStrictᴰN-obTy : Type _
+  PshHomStrictᴰN-obTy =
+    ∀ (Γ : C.ob)(Γᴰ : Cᴰ.ob[ Γ ])(p : P.p[ Γ ])
+    → Pᴰ.p[ p ][ Γᴰ ] → Qᴰ.p[ α .N-ob Γ p ][ Γᴰ ]
+
+  PshHomStrictᴰN-homTy : PshHomStrictᴰN-obTy → Type _
+  PshHomStrictᴰN-homTy N-obᴰ =
+    ∀ (Δ Γ : C.ob)(Δᴰ : Cᴰ.ob[ Δ ])(Γᴰ : Cᴰ.ob[ Γ ])
+    (f : C [ Δ , Γ ])(p' : P.p[ Γ ])(p : P.p[ Δ ])
+    (fᴰ : Cᴰ [ f ][ Δᴰ , Γᴰ ])
+    (pᴰ' : Pᴰ.p[ p' ][ Γᴰ ])(pᴰ : Pᴰ.p[ p ][ Δᴰ ])
+    (e : (f P.⋆ p') ≡ p)
+    (eᴰ : PathP (λ i → Pᴰ.p[ e i ][ Δᴰ ]) (fᴰ Pᴰ.⋆ᴰ pᴰ') pᴰ)
+    → PathP (λ i → Qᴰ.p[ α .N-hom Δ Γ f p' p e i ][ Δᴰ ])
+        (fᴰ Qᴰ.⋆ᴰ N-obᴰ Γ Γᴰ p' pᴰ') (N-obᴰ Δ Δᴰ p pᴰ)
+
+  record PshHomStrictᴰ
+    : Type (ℓ-max (ℓ-max (ℓ-max ℓC ℓC') (ℓ-max ℓCᴰ ℓCᴰ'))
+                  (ℓ-max (ℓ-max ℓP ℓPᴰ) ℓQᴰ))
+    where
+    constructor pshhomᴰ
+    field
+      N-obᴰ : PshHomStrictᴰN-obTy
+      N-homᴰ : PshHomStrictᴰN-homTy N-obᴰ
+
+  PshHomStrictᴰΣ : Type _
+  PshHomStrictᴰΣ = Σ PshHomStrictᴰN-obTy PshHomStrictᴰN-homTy
+
+  isPropN-homᴰ : (N-obᴰ : PshHomStrictᴰN-obTy)
+    → isProp (PshHomStrictᴰN-homTy N-obᴰ)
+  isPropN-homᴰ N-obᴰ =
+    isPropΠ λ Δ → isPropΠ λ Γ → isPropΠ λ Δᴰ → isPropΠ λ Γᴰ →
+    isPropΠ λ f → isPropΠ λ p' → isPropΠ λ p →
+    isPropΠ λ fᴰ → isPropΠ λ pᴰ' → isPropΠ λ pᴰ →
+    isPropΠ λ e → isPropΠ λ eᴰ →
+      isOfHLevelPathP' 1 Qᴰ.isSetPshᴰ _ _
+
+  isSetPshHomStrictᴰΣ : isSet PshHomStrictᴰΣ
+  isSetPshHomStrictᴰΣ =
+    isSetΣ (isSetΠ λ Γ → isSetΠ λ Γᴰ → isSetΠ λ p → isSet→ Qᴰ.isSetPshᴰ)
+           λ N-obᴰ → isProp→isSet (isPropN-homᴰ N-obᴰ)
+
+  PshHomStrictᴰΣIso : Iso PshHomStrictᴰ PshHomStrictᴰΣ
+  PshHomStrictᴰΣIso .Iso.fun αᴰ = αᴰ .PshHomStrictᴰ.N-obᴰ , αᴰ .PshHomStrictᴰ.N-homᴰ
+  PshHomStrictᴰΣIso .Iso.inv (a , b) .PshHomStrictᴰ.N-obᴰ = a
+  PshHomStrictᴰΣIso .Iso.inv (a , b) .PshHomStrictᴰ.N-homᴰ = b
+  PshHomStrictᴰΣIso .Iso.sec _ = refl
+  PshHomStrictᴰΣIso .Iso.ret _ = refl
+
+  isSetPshHomStrictᴰ : isSet PshHomStrictᴰ
+  isSetPshHomStrictᴰ =
+    isOfHLevelRetractFromIso 2 PshHomStrictᴰΣIso isSetPshHomStrictᴰΣ
+
+open PshHomStrictᴰ
+
+module _ {C : Category ℓC ℓC'}{Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
+  {P : Presheaf C ℓP}{Q : Presheaf C ℓQ}
+  {α : PshHomStrict P Q}
+  {Pᴰ : Presheafᴰ P Cᴰ ℓPᴰ}{Qᴰ : Presheafᴰ Q Cᴰ ℓQᴰ}
+  where
+  makePshHomStrictᴰPath : ∀ {αᴰ βᴰ : PshHomStrictᴰ α Pᴰ Qᴰ}
+    → αᴰ .N-obᴰ ≡ βᴰ .N-obᴰ
+    → αᴰ ≡ βᴰ
+  makePshHomStrictᴰPath {αᴰ}{βᴰ} N-obᴰ≡ i .N-obᴰ = N-obᴰ≡ i
+  makePshHomStrictᴰPath {αᴰ}{βᴰ} N-obᴰ≡ i .N-homᴰ =
+    isProp→PathP (λ j → isPropN-homᴰ α Pᴰ Qᴰ (N-obᴰ≡ j))
+      (αᴰ .N-homᴰ) (βᴰ .N-homᴰ) i
+
+module _ {C : Category ℓC ℓC'}{Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
+  {P : Presheaf C ℓP}{Q : Presheaf C ℓQ}
+  {Pᴰ : Presheafᴰ P Cᴰ ℓPᴰ}{Qᴰ : Presheafᴰ Q Cᴰ ℓQᴰ}
+  where
+  makePshHomStrictᴰPathP : ∀ {α β : PshHomStrict P Q} {α≡β : α ≡ β}
+    {αᴰ : PshHomStrictᴰ α Pᴰ Qᴰ}{βᴰ : PshHomStrictᴰ β Pᴰ Qᴰ}
+    → PathP (λ i → PshHomStrictᴰN-obTy (α≡β i) Pᴰ Qᴰ) (αᴰ .N-obᴰ) (βᴰ .N-obᴰ)
+    → PathP (λ i → PshHomStrictᴰ (α≡β i) Pᴰ Qᴰ) αᴰ βᴰ
+  makePshHomStrictᴰPathP {αᴰ = αᴰ}{βᴰ = βᴰ} N-obᴰ≡ i .N-obᴰ = N-obᴰ≡ i
+  makePshHomStrictᴰPathP {α≡β = α≡β}{αᴰ = αᴰ}{βᴰ = βᴰ} N-obᴰ≡ i .N-homᴰ =
+    isProp→PathP (λ j → isPropN-homᴰ (α≡β j) Pᴰ Qᴰ (N-obᴰ≡ j))
+      (αᴰ .N-homᴰ) (βᴰ .N-homᴰ) i
+
+module _ {C : Category ℓC ℓC'}{Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
+  {P : Presheaf C ℓP}
+  {Pᴰ : Presheafᴰ P Cᴰ ℓPᴰ}
+  where
+  idPshHomStrictᴰ : PshHomStrictᴰ idPshHomStrict Pᴰ Pᴰ
+  idPshHomStrictᴰ .N-obᴰ Γ Γᴰ p pᴰ = pᴰ
+  idPshHomStrictᴰ .N-homᴰ Δ Γ Δᴰ Γᴰ f p' p fᴰ pᴰ' pᴰ e eᴰ = eᴰ
+
+module _ {C : Category ℓC ℓC'}{Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
+  {P : Presheaf C ℓP}{Q : Presheaf C ℓQ}{R : Presheaf C ℓR}
+  {Pᴰ : Presheafᴰ P Cᴰ ℓPᴰ}
+  {Qᴰ : Presheafᴰ Q Cᴰ ℓQᴰ}
+  {Rᴰ : Presheafᴰ R Cᴰ ℓRᴰ}
+  {α : PshHomStrict P Q}{β : PshHomStrict Q R}
+  where
+  _⋆PshHomStrictᴰ_ : PshHomStrictᴰ α Pᴰ Qᴰ → PshHomStrictᴰ β Qᴰ Rᴰ
+    → PshHomStrictᴰ (α ⋆PshHomStrict β) Pᴰ Rᴰ
+  (αᴰ ⋆PshHomStrictᴰ βᴰ) .N-obᴰ Γ Γᴰ p pᴰ =
+    βᴰ .N-obᴰ Γ Γᴰ _ (αᴰ .N-obᴰ Γ Γᴰ p pᴰ)
+  (αᴰ ⋆PshHomStrictᴰ βᴰ) .N-homᴰ Δ Γ Δᴰ Γᴰ f p' p fᴰ pᴰ' pᴰ e eᴰ =
+    βᴰ .N-homᴰ Δ Γ Δᴰ Γᴰ f _ _ fᴰ
+      (αᴰ .N-obᴰ Γ Γᴰ p' pᴰ')
+      (αᴰ .N-obᴰ Δ Δᴰ p pᴰ)
+      (α .N-hom Δ Γ f p' p e)
+      (αᴰ .N-homᴰ Δ Γ Δᴰ Γᴰ f p' p fᴰ pᴰ' pᴰ e eᴰ)
+  infixr 9 _⋆PshHomStrictᴰ_
+
+module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ')
+  (ℓP : Level)(ℓPᴰ : Level)
+  where
+  PRESHEAFᴰStrict : Categoryᴰ (PRESHEAF C ℓP) _ _
+  PRESHEAFᴰStrict .ob[_] P = Presheafᴰ P Cᴰ ℓPᴰ
+  PRESHEAFᴰStrict .Hom[_][_,_] α Pᴰ Qᴰ = PshHomStrictᴰ α Pᴰ Qᴰ
+  PRESHEAFᴰStrict .idᴰ = idPshHomStrictᴰ
+  PRESHEAFᴰStrict ._⋆ᴰ_ = _⋆PshHomStrictᴰ_
+  PRESHEAFᴰStrict .⋆IdLᴰ _ = refl
+  PRESHEAFᴰStrict .⋆IdRᴰ _ = refl
+  PRESHEAFᴰStrict .⋆Assocᴰ _ _ _ = refl
+  PRESHEAFᴰStrict .isSetHomᴰ = isSetPshHomStrictᴰ _ _ _

--- a/Cubical/Categories/Instances/FiberOverStrictify.agda
+++ b/Cubical/Categories/Instances/FiberOverStrictify.agda
@@ -1,0 +1,169 @@
+{-# OPTIONS --lossy-unification #-}
+module Cubical.Categories.Instances.FiberOverStrictify where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.More
+open import Cubical.Foundations.Function
+
+import Cubical.Data.Equality as Eq
+
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Instances.TotalCategory
+open import Cubical.Categories.Instances.Strictify
+open import Cubical.Categories.NaturalTransformation
+open import Cubical.Categories.Profunctor.General
+
+open import Cubical.Categories.Displayed.Base
+import Cubical.Categories.More as CatReasoning
+
+private
+  variable
+    ℓC ℓC' ℓCᴰ ℓCᴰ' ℓD ℓD' ℓDᴰ ℓDᴰ' : Level
+
+module _ {C' : Category ℓC ℓC'} where
+  private
+    C : Category _ _
+    C = YonedaStrictify C'
+
+  module Fibers (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ') where
+    private
+      module C = Category C
+      module Cᴰ = Categoryᴰ Cᴰ
+      module R {a b : C.ob} {aᴰ : Cᴰ.ob[ a ]}{bᴰ : Cᴰ.ob[ b ]} =
+        hSetReasoning (C [ a , b ] , C.isSetHom) Cᴰ.Hom[_][ aᴰ , bᴰ ]
+        renaming
+          (Prectify to rectify) hiding (_P≡[_]_)
+      module ∫Cᴰ = Category (∫C Cᴰ)
+    open Cᴰ public
+
+    v[_] : C.ob → Category ℓCᴰ ℓCᴰ'
+    v[ x ] .Category.ob = ob[ x ]
+    v[ x ] .Category.Hom[_,_] = Hom[ C.id ][_,_]
+    v[ x ] .Category.id = idᴰ
+    -- Removed a reind here
+    v[ x ] .Category._⋆_ fⱽ gⱽ = fⱽ ⋆ᴰ gⱽ
+    v[ x ] .Category.⋆IdL fⱽ = R.rectifyOut $ ∫Cᴰ.⋆IdL _
+    v[ x ] .Category.⋆IdR fⱽ = R.rectifyOut $ ∫Cᴰ.⋆IdR _
+    v[ x ] .Category.⋆Assoc fⱽ gⱽ hⱽ = R.rectifyOut $ ∫Cᴰ.⋆Assoc _ _ _
+    v[ x ] .Category.isSetHom = isSetHomᴰ
+
+    idⱽ : ∀ {x xᴰ} → v[ x ] [ xᴰ , xᴰ ]
+    idⱽ = v[ _ ] .Category.id
+
+    _⋆ⱽ_ : ∀ {x xᴰ xᴰ' xᴰ''} → v[ x ] [ xᴰ , xᴰ' ] → v[ x ] [ xᴰ' , xᴰ'' ]
+      → v[ x ] [ xᴰ , xᴰ'' ]
+    _⋆ⱽ_ = v[ _ ] .Category._⋆_
+
+    private
+      variable
+        x y z : C.ob
+        xᴰ xᴰ' xᴰ'' yᴰ yᴰ' yᴰ'' zᴰ : ob[ x ]
+        f g h : C [ x , y ]
+        fᴰ fᴰ' gᴰ gᴰ' hᴰ hᴰ' : Cᴰ [ f ][ xᴰ , yᴰ ]
+        fⱽ fⱽ' gⱽ gⱽ' hⱽ hⱽ' : v[ x ] [ xᴰ , xᴰ' ]
+
+    ⋆IdLⱽ : idⱽ ⋆ⱽ fⱽ ≡ fⱽ
+    ⋆IdLⱽ = v[ _ ] .Category.⋆IdL _
+
+    ⋆IdRⱽ : fⱽ ⋆ⱽ idⱽ ≡ fⱽ
+    ⋆IdRⱽ = v[ _ ] .Category.⋆IdR _
+
+    ⋆Assocⱽ : (fⱽ ⋆ⱽ gⱽ) ⋆ⱽ hⱽ ≡ fⱽ ⋆ⱽ (gⱽ ⋆ⱽ hⱽ)
+    ⋆Assocⱽ = v[ _ ] .Category.⋆Assoc _ _ _
+
+    isSetHomⱽ : isSet (v[ x ] [ xᴰ , xᴰ' ])
+    isSetHomⱽ = isSetHomᴰ
+
+    -- Removed a reind here
+    _⋆ᴰⱽ_ : Hom[ f ][ xᴰ , yᴰ ] → v[ y ] [ yᴰ , yᴰ' ] → Hom[ f ][ xᴰ , yᴰ' ]
+    _⋆ᴰⱽ_ {f = f} fᴰ gⱽ = fᴰ ⋆ᴰ gⱽ
+
+    ⋆IdLᴰⱽ : idᴰ ⋆ᴰⱽ fⱽ ≡ fⱽ
+    ⋆IdLᴰⱽ = R.rectifyOut $ ∫Cᴰ.⋆IdL _
+
+    ⋆IdRᴰⱽ : fᴰ ⋆ᴰⱽ idⱽ ≡ fᴰ
+    ⋆IdRᴰⱽ = R.rectifyOut $ ∫Cᴰ.⋆IdR _
+
+    ⋆Assocᴰⱽⱽ : (fᴰ ⋆ᴰⱽ gⱽ) ⋆ᴰⱽ hⱽ ≡ (fᴰ ⋆ᴰⱽ (gⱽ ⋆ⱽ hⱽ))
+    ⋆Assocᴰⱽⱽ = R.rectifyOut $ ∫Cᴰ.⋆Assoc _ _ _
+
+    _⋆ⱽᴰ_ : v[ x ] [ xᴰ , xᴰ' ] → Hom[ f ][ xᴰ' , yᴰ ] → Hom[ f ][ xᴰ , yᴰ ]
+    _⋆ⱽᴰ_ {f = f} gⱽ fᴰ = gⱽ ⋆ᴰ fᴰ
+
+    ⋆IdLⱽᴰ : ∀ (fᴰ : Hom[ f ][ xᴰ , yᴰ ]) → idⱽ ⋆ⱽᴰ fᴰ ≡ fᴰ
+    ⋆IdLⱽᴰ fᴰ = R.rectifyOut $ ∫Cᴰ.⋆IdL _
+
+    ⋆IdRⱽᴰ : ∀ (fⱽ : v[ x ] [ xᴰ , xᴰ' ]) → fⱽ ⋆ⱽᴰ idᴰ ≡ fⱽ
+    ⋆IdRⱽᴰ fⱽ = R.rectifyOut $ ∫Cᴰ.⋆IdR _
+
+    ⋆Assocⱽⱽᴰ : (fⱽ ⋆ⱽ gⱽ) ⋆ⱽᴰ hᴰ ≡ (fⱽ ⋆ⱽᴰ (gⱽ ⋆ⱽᴰ hᴰ))
+    ⋆Assocⱽⱽᴰ = R.rectifyOut $ ∫Cᴰ.⋆Assoc _ _ _
+
+    ⋆Assocⱽᴰⱽ : (fⱽ ⋆ⱽᴰ gᴰ) ⋆ᴰⱽ hⱽ ≡ (fⱽ ⋆ⱽᴰ (gᴰ ⋆ᴰⱽ hⱽ))
+    ⋆Assocⱽᴰⱽ = R.rectifyOut $ ∫Cᴰ.⋆Assoc _ _ _
+
+    ⋆Assocᴰⱽᴰ : (fᴰ ⋆ᴰⱽ gⱽ) ⋆ᴰ hᴰ ≡ (fᴰ ⋆ᴰ (gⱽ ⋆ⱽᴰ hᴰ))
+    ⋆Assocᴰⱽᴰ = R.rectifyOut $ ∫Cᴰ.⋆Assoc _ _ _
+
+    ⋆Assocⱽᴰᴰ : ((fⱽ ⋆ⱽᴰ gᴰ) ⋆ᴰ hᴰ) R.∫≡ (fⱽ ⋆ⱽᴰ (gᴰ ⋆ᴰ hᴰ))
+    ⋆Assocⱽᴰᴰ = ∫Cᴰ.⋆Assoc _ _ _
+
+    ∫⋆Assocᴰⱽᴰ : ((fᴰ ⋆ᴰⱽ gⱽ) ⋆ᴰ hᴰ) R.∫≡ (fᴰ ⋆ᴰ (gⱽ ⋆ⱽᴰ hᴰ))
+    ∫⋆Assocᴰⱽᴰ = R.≡in ⋆Assocᴰⱽᴰ
+
+    open NatTrans
+    HomᴰProf : (f : C [ x , y ]) → Profunctor v[ y ] v[ x ] ℓCᴰ'
+    HomᴰProf f .Functor.F-ob yᴰ .Functor.F-ob xᴰ .fst = Hom[ f ][ xᴰ , yᴰ ]
+    HomᴰProf f .Functor.F-ob yᴰ .Functor.F-ob xᴰ .snd = isSetHomᴰ
+    HomᴰProf f .Functor.F-ob yᴰ .Functor.F-hom gⱽ fᴰ = gⱽ ⋆ⱽᴰ fᴰ
+    HomᴰProf f .Functor.F-ob yᴰ .Functor.F-id = funExt ⋆IdLⱽᴰ
+    HomᴰProf f .Functor.F-ob yᴰ .Functor.F-seq hⱽ gⱽ = funExt λ fᴰ → ⋆Assocⱽⱽᴰ
+    HomᴰProf f .Functor.F-hom gⱽ .N-ob x fᴰ = fᴰ ⋆ᴰⱽ gⱽ
+    HomᴰProf f .Functor.F-hom gⱽ .N-hom fⱽ = funExt λ hᴰ → ⋆Assocⱽᴰⱽ
+    HomᴰProf f .Functor.F-id = makeNatTransPath (funExt (λ _ → funExt λ fᴰ →
+      ⋆IdRᴰⱽ))
+    HomᴰProf f .Functor.F-seq gⱽ hⱽ = makeNatTransPath (funExt λ _ → funExt λ fᴰ →
+      sym $ ⋆Assocᴰⱽⱽ)
+
+    open R public
+    open ∫Cᴰ public
+    open CatReasoning.Reasoning (∫C Cᴰ) public
+
+
+    ⟨_⟩⋆ⱽᴰ⟨_⟩
+      : Path Hom[ _ , _ ] (_ , fⱽ) (_ , fⱽ')
+      → Path Hom[ _ , _ ] (_ , gᴰ) (_ , gᴰ')
+      → Path Hom[ _ , _ ]
+          (_ , fⱽ ⋆ⱽᴰ gᴰ)
+          (_ , fⱽ' ⋆ⱽᴰ gᴰ')
+    ⟨ fⱽ≡fⱽ' ⟩⋆ⱽᴰ⟨ gᴰ≡gᴰ' ⟩ = ⟨ fⱽ≡fⱽ' ⟩⋆⟨ gᴰ≡gᴰ' ⟩
+
+    ⟨⟩⋆ⱽᴰ⟨_⟩
+      : Path Hom[ _ , _ ] (_ , gᴰ) (_ , gᴰ')
+      → Path Hom[ _ , _ ]
+          (_ , fⱽ ⋆ⱽᴰ gᴰ)
+          (_ , fⱽ ⋆ⱽᴰ gᴰ')
+    ⟨⟩⋆ⱽᴰ⟨ gᴰ≡gᴰ' ⟩ = ⟨ refl ⟩⋆ⱽᴰ⟨ gᴰ≡gᴰ' ⟩
+
+    ⟨_⟩⋆ⱽᴰ⟨⟩
+      : Path Hom[ _ , _ ] (_ , fⱽ) (_ , fⱽ')
+      → Path Hom[ _ , _ ]
+          (_ , fⱽ  ⋆ⱽᴰ gᴰ)
+          (_ , fⱽ' ⋆ⱽᴰ gᴰ)
+    ⟨ fⱽ≡fⱽ' ⟩⋆ⱽᴰ⟨⟩ = ⟨ fⱽ≡fⱽ' ⟩⋆ⱽᴰ⟨ refl ⟩
+
+    cong-reind : ∀ {a b : C.ob} {f f' g g' : C [ a , b ]}{aᴰ bᴰ}
+        {fᴰ : Cᴰ [ f ][ aᴰ , bᴰ ]}
+        {fᴰ' : Cᴰ [ f' ][ aᴰ , bᴰ ]}
+        (p : f ≡ g)
+        (p' : f' ≡ g')
+      → fᴰ ∫≡ fᴰ'
+      → reind p fᴰ ∫≡ reind p' fᴰ'
+    cong-reind p p' fᴰ≡fᴰ' = sym (reind-filler _) ∙ fᴰ≡fᴰ' ∙ reind-filler _
+
+module _ {C : Category ℓC ℓC'}
+         (Cᴰ : Categoryᴰ (YonedaStrictify C) ℓCᴰ ℓCᴰ') where
+  open Category
+  fiber : C .ob → Category ℓCᴰ ℓCᴰ'
+  fiber x = Fibers.v[_] Cᴰ x

--- a/Cubical/Categories/Instances/FullImage.agda
+++ b/Cubical/Categories/Instances/FullImage.agda
@@ -70,3 +70,9 @@ module _
   inv .F-seq f g =
     sym (invEq (equivAdjointEquiv FF≃)
     (F .F-seq _ _ ∙ cong₂ (seq' D) (secEq FF≃ _) (secEq FF≃ _)))
+
+  inv∘ToFullImage≡Id : inv ∘F ToFullImage F ≡ Id
+  inv∘ToFullImage≡Id = Functor≡ (λ _ → refl) (λ f → retEq FF≃ f)
+
+  ToFullImage∘inv≡Id : ToFullImage F ∘F inv ≡ Id
+  ToFullImage∘inv≡Id = Functor≡ (λ _ → refl) (λ f → secEq FF≃ f)

--- a/Cubical/Categories/Instances/Strictify.agda
+++ b/Cubical/Categories/Instances/Strictify.agda
@@ -37,12 +37,8 @@ module _ (C : Category ℓC ℓC') where
   fromYonedaStrictify : Functor YonedaStrictify C
   fromYonedaStrictify = inv isFullyFaithfulYOStrict
 
-  private
-    Hom≃ : ∀ {x y} → C [ x , y ] ≃ PshHomStrict (C [-, x ]) (C [-, y ])
-    Hom≃ {x}{y} = YOStrict .F-hom , isFullyFaithfulYOStrict x y
-
   fromYonedaStrictify∘toYonedaStrictify≡Id : fromYonedaStrictify ∘F toYonedaStrictify ≡ Id
-  fromYonedaStrictify∘toYonedaStrictify≡Id = Functor≡ (λ _ → refl) (λ f → retEq Hom≃ f)
+  fromYonedaStrictify∘toYonedaStrictify≡Id = inv∘ToFullImage≡Id isFullyFaithfulYOStrict
 
   toYonedaStrictify∘fromYonedaStrictify≡Id : toYonedaStrictify ∘F fromYonedaStrictify ≡ Id
-  toYonedaStrictify∘fromYonedaStrictify≡Id = Functor≡ (λ _ → refl) (λ f → secEq Hom≃ f)
+  toYonedaStrictify∘fromYonedaStrictify≡Id = ToFullImage∘inv≡Id isFullyFaithfulYOStrict

--- a/Cubical/Categories/Instances/Strictify.agda
+++ b/Cubical/Categories/Instances/Strictify.agda
@@ -1,0 +1,86 @@
+module Cubical.Categories.Instances.Strictify where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Functions.FunExtEquiv
+open import Cubical.Foundations.HLevels
+
+import Cubical.Data.Equality as Eq
+
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.NaturalTransformation
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.More
+open import Cubical.Categories.Presheaf.Representable
+open import Cubical.Categories.Presheaf.StrictHom
+
+private
+  variable ℓ ℓC ℓC' ℓD ℓD' : Level
+
+open Category
+open Functor
+
+module _ (C : Category ℓC ℓC') where
+  private
+    module C = Category C
+
+  YonedaStrictify : Category ℓC (ℓ-max ℓC ℓC')
+  YonedaStrictify .ob = C.ob
+  YonedaStrictify .Hom[_,_] c d = PshHomStrict (C [-, c ]) (C [-, d ])
+  YonedaStrictify .id = idPshHomStrict
+  YonedaStrictify ._⋆_ = _⋆PshHomStrict_
+  YonedaStrictify .⋆IdL = λ _ → refl
+  YonedaStrictify .⋆IdR = λ _ → refl
+  YonedaStrictify .⋆Assoc = λ _ _ _ → refl
+  YonedaStrictify .isSetHom = isSetPshHomStrict _ _
+
+  -- The path fields below (F-id, F-seq, to-from .N-hom) use copatterns
+  -- rather than makePshHomStrictPath so that .N-ob projections reduce.
+  -- The displayed versions in Displayed/Instances/Strictify rely on this
+  -- to apply makePshHomStrictᴰPathP without inlining their own copatterns.
+  toYonedaStrictify : Functor C YonedaStrictify
+  toYonedaStrictify .F-ob = λ z → z
+  toYonedaStrictify .F-hom f .PshHomStrict.N-ob = λ c z → z C.⋆ f
+  toYonedaStrictify .F-hom f .PshHomStrict.N-hom _ _ _ _ _ e =
+    (sym $ C.⋆Assoc _ _ _) ∙ C.⟨ e ⟩⋆⟨ refl ⟩
+  toYonedaStrictify .F-id {x = x} i .PshHomStrict.N-ob Γ p = C.⋆IdR p i
+  toYonedaStrictify .F-id {x = x} i .PshHomStrict.N-hom =
+    isProp→PathP (λ j → isPropN-hom (C [-, x ]) (C [-, x ]) (λ Γ p → C.⋆IdR p j))
+      (toYonedaStrictify .F-hom C.id .PshHomStrict.N-hom)
+      (idPshHomStrict {P = C [-, x ]} .PshHomStrict.N-hom) i
+  toYonedaStrictify .F-seq {x = x} {z = z} f g i .PshHomStrict.N-ob Γ p =
+    sym (C.⋆Assoc p f g) i
+  toYonedaStrictify .F-seq {x = x} {z = z} f g i .PshHomStrict.N-hom =
+    isProp→PathP
+      (λ j → isPropN-hom (C [-, x ]) (C [-, z ]) (λ Γ p → sym (C.⋆Assoc p f g) j))
+      (toYonedaStrictify .F-hom (f C.⋆ g) .PshHomStrict.N-hom)
+      ((toYonedaStrictify .F-hom f ⋆PshHomStrict toYonedaStrictify .F-hom g)
+        .PshHomStrict.N-hom) i
+
+  fromYonedaStrictify : Functor YonedaStrictify C
+  fromYonedaStrictify .F-ob = λ z → z
+  fromYonedaStrictify .F-hom = λ z → z .PshHomStrict.N-ob _ C.id
+  fromYonedaStrictify .F-id = refl
+  fromYonedaStrictify .F-seq f g = sym $ g .PshHomStrict.N-hom _ _ _ C.id _
+    (C.⋆IdR (fromYonedaStrictify .F-hom f))
+
+  to-from-YonedaStrictify : NatIso (toYonedaStrictify ∘F fromYonedaStrictify) Id
+  to-from-YonedaStrictify .NatIso.trans .NatTrans.N-ob = λ _ → idPshHomStrict
+  to-from-YonedaStrictify .NatIso.trans .NatTrans.N-hom {x = x}{y = y} f i .PshHomStrict.N-ob Γ p =
+    f .PshHomStrict.N-hom _ _ _ _ _ (C.⋆IdR p) i
+  to-from-YonedaStrictify .NatIso.trans .NatTrans.N-hom {x = x}{y = y} f i .PshHomStrict.N-hom =
+    isProp→PathP
+      (λ j → isPropN-hom (C [-, x ]) (C [-, y ])
+        (λ Γ p → f .PshHomStrict.N-hom _ _ _ _ _ (C.⋆IdR p) j))
+      ((toYonedaStrictify .F-hom (fromYonedaStrictify .F-hom f) ⋆PshHomStrict idPshHomStrict)
+        .PshHomStrict.N-hom)
+      ((idPshHomStrict ⋆PshHomStrict f) .PshHomStrict.N-hom) i
+  to-from-YonedaStrictify .NatIso.nIso c .isIso.inv = idPshHomStrict
+  to-from-YonedaStrictify .NatIso.nIso c .isIso.sec = refl
+  to-from-YonedaStrictify .NatIso.nIso c .isIso.ret = refl
+
+  from-to-YonedaStrictify : NatIso (fromYonedaStrictify ∘F toYonedaStrictify) Id
+  from-to-YonedaStrictify .NatIso.trans = natTrans (λ x → C.id) (λ _ → C.⋆IdR _)
+  from-to-YonedaStrictify .NatIso.nIso = λ _ → isiso C.id (C.⋆IdL _) (C.⋆IdL _)

--- a/Cubical/Categories/Instances/Strictify.agda
+++ b/Cubical/Categories/Instances/Strictify.agda
@@ -2,6 +2,7 @@ module Cubical.Categories.Instances.Strictify where
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Function
+open import Cubical.Foundations.Equiv
 open import Cubical.Functions.FunExtEquiv
 open import Cubical.Foundations.HLevels
 
@@ -10,6 +11,7 @@ import Cubical.Data.Equality as Eq
 open import Cubical.Categories.Category.Base
 open import Cubical.Categories.Functor.Base
 open import Cubical.Categories.NaturalTransformation
+open import Cubical.Categories.Instances.FullImage
 open import Cubical.Categories.Instances.Sets
 open import Cubical.Categories.Presheaf.Base
 open import Cubical.Categories.Presheaf.More
@@ -27,60 +29,20 @@ module _ (C : Category ℓC ℓC') where
     module C = Category C
 
   YonedaStrictify : Category ℓC (ℓ-max ℓC ℓC')
-  YonedaStrictify .ob = C.ob
-  YonedaStrictify .Hom[_,_] c d = PshHomStrict (C [-, c ]) (C [-, d ])
-  YonedaStrictify .id = idPshHomStrict
-  YonedaStrictify ._⋆_ = _⋆PshHomStrict_
-  YonedaStrictify .⋆IdL = λ _ → refl
-  YonedaStrictify .⋆IdR = λ _ → refl
-  YonedaStrictify .⋆Assoc = λ _ _ _ → refl
-  YonedaStrictify .isSetHom = isSetPshHomStrict _ _
+  YonedaStrictify = FullImage (YOStrict {C = C})
 
-  -- The path fields below (F-id, F-seq, to-from .N-hom) use copatterns
-  -- rather than makePshHomStrictPath so that .N-ob projections reduce.
-  -- The displayed versions in Displayed/Instances/Strictify rely on this
-  -- to apply makePshHomStrictᴰPathP without inlining their own copatterns.
   toYonedaStrictify : Functor C YonedaStrictify
-  toYonedaStrictify .F-ob = λ z → z
-  toYonedaStrictify .F-hom f .PshHomStrict.N-ob = λ c z → z C.⋆ f
-  toYonedaStrictify .F-hom f .PshHomStrict.N-hom _ _ _ _ _ e =
-    (sym $ C.⋆Assoc _ _ _) ∙ C.⟨ e ⟩⋆⟨ refl ⟩
-  toYonedaStrictify .F-id {x = x} i .PshHomStrict.N-ob Γ p = C.⋆IdR p i
-  toYonedaStrictify .F-id {x = x} i .PshHomStrict.N-hom =
-    isProp→PathP (λ j → isPropN-hom (C [-, x ]) (C [-, x ]) (λ Γ p → C.⋆IdR p j))
-      (toYonedaStrictify .F-hom C.id .PshHomStrict.N-hom)
-      (idPshHomStrict {P = C [-, x ]} .PshHomStrict.N-hom) i
-  toYonedaStrictify .F-seq {x = x} {z = z} f g i .PshHomStrict.N-ob Γ p =
-    sym (C.⋆Assoc p f g) i
-  toYonedaStrictify .F-seq {x = x} {z = z} f g i .PshHomStrict.N-hom =
-    isProp→PathP
-      (λ j → isPropN-hom (C [-, x ]) (C [-, z ]) (λ Γ p → sym (C.⋆Assoc p f g) j))
-      (toYonedaStrictify .F-hom (f C.⋆ g) .PshHomStrict.N-hom)
-      ((toYonedaStrictify .F-hom f ⋆PshHomStrict toYonedaStrictify .F-hom g)
-        .PshHomStrict.N-hom) i
+  toYonedaStrictify = ToFullImage YOStrict
 
   fromYonedaStrictify : Functor YonedaStrictify C
-  fromYonedaStrictify .F-ob = λ z → z
-  fromYonedaStrictify .F-hom = λ z → z .PshHomStrict.N-ob _ C.id
-  fromYonedaStrictify .F-id = refl
-  fromYonedaStrictify .F-seq f g = sym $ g .PshHomStrict.N-hom _ _ _ C.id _
-    (C.⋆IdR (fromYonedaStrictify .F-hom f))
+  fromYonedaStrictify = inv isFullyFaithfulYOStrict
 
-  to-from-YonedaStrictify : NatIso (toYonedaStrictify ∘F fromYonedaStrictify) Id
-  to-from-YonedaStrictify .NatIso.trans .NatTrans.N-ob = λ _ → idPshHomStrict
-  to-from-YonedaStrictify .NatIso.trans .NatTrans.N-hom {x = x}{y = y} f i .PshHomStrict.N-ob Γ p =
-    f .PshHomStrict.N-hom _ _ _ _ _ (C.⋆IdR p) i
-  to-from-YonedaStrictify .NatIso.trans .NatTrans.N-hom {x = x}{y = y} f i .PshHomStrict.N-hom =
-    isProp→PathP
-      (λ j → isPropN-hom (C [-, x ]) (C [-, y ])
-        (λ Γ p → f .PshHomStrict.N-hom _ _ _ _ _ (C.⋆IdR p) j))
-      ((toYonedaStrictify .F-hom (fromYonedaStrictify .F-hom f) ⋆PshHomStrict idPshHomStrict)
-        .PshHomStrict.N-hom)
-      ((idPshHomStrict ⋆PshHomStrict f) .PshHomStrict.N-hom) i
-  to-from-YonedaStrictify .NatIso.nIso c .isIso.inv = idPshHomStrict
-  to-from-YonedaStrictify .NatIso.nIso c .isIso.sec = refl
-  to-from-YonedaStrictify .NatIso.nIso c .isIso.ret = refl
+  private
+    Hom≃ : ∀ {x y} → C [ x , y ] ≃ PshHomStrict (C [-, x ]) (C [-, y ])
+    Hom≃ {x}{y} = YOStrict .F-hom , isFullyFaithfulYOStrict x y
 
-  from-to-YonedaStrictify : NatIso (fromYonedaStrictify ∘F toYonedaStrictify) Id
-  from-to-YonedaStrictify .NatIso.trans = natTrans (λ x → C.id) (λ _ → C.⋆IdR _)
-  from-to-YonedaStrictify .NatIso.nIso = λ _ → isiso C.id (C.⋆IdL _) (C.⋆IdL _)
+  fromYonedaStrictify∘toYonedaStrictify≡Id : fromYonedaStrictify ∘F toYonedaStrictify ≡ Id
+  fromYonedaStrictify∘toYonedaStrictify≡Id = Functor≡ (λ _ → refl) (λ f → retEq Hom≃ f)
+
+  toYonedaStrictify∘fromYonedaStrictify≡Id : toYonedaStrictify ∘F fromYonedaStrictify ≡ Id
+  toYonedaStrictify∘fromYonedaStrictify≡Id = Functor≡ (λ _ → refl) (λ f → secEq Hom≃ f)

--- a/Cubical/Categories/Presheaf/StrictHom/Base.agda
+++ b/Cubical/Categories/Presheaf/StrictHom/Base.agda
@@ -360,6 +360,16 @@ module _ {C : Category ℓ ℓ'} where
   isFaithfulYOStrict x y f g p =
     (sym $ C.⋆IdL f) ∙ (λ i → p i .N-ob x C.id)  ∙ C.⋆IdL g
 
+  isFullyFaithfulYOStrict : isFullyFaithful YOStrict
+  isFullyFaithfulYOStrict x y = isoToIsEquiv theIso
+    where
+      theIso : Iso (C [ x , y ]) (PshHomStrict (C [-, x ]) (C [-, y ]))
+      theIso .fun = YOStrict .F-hom
+      theIso .inv α = α .N-ob x C.id
+      theIso .sec α = makePshHomStrictPath (funExt₂ λ c g →
+        α .N-hom c x g C.id g (C.⋆IdR g))
+      theIso .ret f = C.⋆IdL f
+
   -- If YOStrict factors as G ∘F F, then F is faithful
   module _ {D : Category ℓD ℓD'}
     {F : Functor C D}{G : Functor D (PRESHEAF C ℓ')}


### PR DESCRIPTION
This defines a notion of `PshHomStrictᴰ` for uncurried displayed presheaves, which is then used to provide a Yoneda strictification operation on displayed categories

This should remain a draft until #255 is merged, then it should be rebased and merged. For readability, I am going to initially base this PR off of `strict`, but this should also be edited to instead be based at `main` when we go to merge