### PR TITLE
Yoneda strictification of displayed categories using curried presheaves

### DIFF
--- a/Cubical/Categories/Displayed/Instances/Strictify.agda
+++ b/Cubical/Categories/Displayed/Instances/Strictify.agda
@@ -25,7 +25,7 @@ import      Cubical.Categories.Displayed.Instances.FullImage as FIᴰ
 open import Cubical.Categories.Displayed.NaturalTransformation
 open import Cubical.Categories.Displayed.NaturalTransformation.More
 open import Cubical.Categories.Displayed.Presheaf.Uncurried.Eq.Base
-open import Cubical.Categories.Displayed.Presheaf.StrictHom
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.StrictHom
 
 private
   variable

--- a/Cubical/Categories/Displayed/Presheaf/Strict.agda
+++ b/Cubical/Categories/Displayed/Presheaf/Strict.agda
@@ -15,6 +15,7 @@ open import Cubical.Categories.Instances.Strictify
 
 open import Cubical.Categories.Displayed.Base
 open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Displayed.Instances.FullImage
 open import Cubical.Categories.Displayed.Instances.Sets.Base
 open import Cubical.Categories.Displayed.Presheaf.Base
 open import Cubical.Categories.Displayed.Presheaf.StrictHom
@@ -34,17 +35,7 @@ module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ') where
     : Categoryᴰ (YonedaStrictify C)
         ℓCᴰ
         (ℓ-max (ℓ-max ℓC ℓC') (ℓ-max ℓCᴰ ℓCᴰ'))
-
-  -- Using curried pshs instead of uncurried
-  YonedaStrictifyᴰ .ob[_] = Cᴰ .ob[_]
-  YonedaStrictifyᴰ .Hom[_][_,_] α xᴰ yᴰ =
-    PshHomStrictᴰ α (Cᴰ [-][-, xᴰ ]) (Cᴰ [-][-, yᴰ ])
-  YonedaStrictifyᴰ .idᴰ = idPshHomStrictᴰ
-  YonedaStrictifyᴰ ._⋆ᴰ_ = _⋆PshHomStrictᴰ_
-  YonedaStrictifyᴰ .⋆IdLᴰ _ = refl
-  YonedaStrictifyᴰ .⋆IdRᴰ _ = refl
-  YonedaStrictifyᴰ .⋆Assocᴰ _ _ _ = refl
-  YonedaStrictifyᴰ .isSetHomᴰ = isSetPshHomStrictᴰ _ _ _
+  YonedaStrictifyᴰ = FullImageᴰ (YOStrict {C = C}) (YOStrictᴰ Cᴰ)
 
 module _ {C : Category ℓC ℓC'} {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
   {P : Presheaf C ℓP}

--- a/Cubical/Categories/Displayed/Presheaf/Strict.agda
+++ b/Cubical/Categories/Displayed/Presheaf/Strict.agda
@@ -1,0 +1,59 @@
+{-
+  Yoneda strictification of a curried displayed presheaf.
+-}
+{-# OPTIONS --lossy-unification #-}
+module Cubical.Categories.Displayed.Presheaf.Strict where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.StrictHom
+open import Cubical.Categories.Presheaf.Strict
+open import Cubical.Categories.Instances.Strictify
+
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Displayed.Instances.Sets.Base
+open import Cubical.Categories.Displayed.Presheaf.Base
+open import Cubical.Categories.Displayed.Presheaf.StrictHom
+
+private
+  variable
+    ℓP ℓPᴰ : Level
+    ℓC ℓC' ℓCᴰ ℓCᴰ' : Level
+
+open Functor
+open Functorᴰ
+open Categoryᴰ
+open PshHomStrictᴰ
+
+module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ') where
+  YonedaStrictifyᴰ
+    : Categoryᴰ (YonedaStrictify C)
+        ℓCᴰ
+        (ℓ-max (ℓ-max ℓC ℓC') (ℓ-max ℓCᴰ ℓCᴰ'))
+
+  -- Using curried pshs instead of uncurried
+  YonedaStrictifyᴰ .ob[_] = Cᴰ .ob[_]
+  YonedaStrictifyᴰ .Hom[_][_,_] α xᴰ yᴰ =
+    PshHomStrictᴰ α (Cᴰ [-][-, xᴰ ]) (Cᴰ [-][-, yᴰ ])
+  YonedaStrictifyᴰ .idᴰ = idPshHomStrictᴰ
+  YonedaStrictifyᴰ ._⋆ᴰ_ = _⋆PshHomStrictᴰ_
+  YonedaStrictifyᴰ .⋆IdLᴰ _ = refl
+  YonedaStrictifyᴰ .⋆IdRᴰ _ = refl
+  YonedaStrictifyᴰ .⋆Assocᴰ _ _ _ = refl
+  YonedaStrictifyᴰ .isSetHomᴰ = isSetPshHomStrictᴰ _ _ _
+
+module _ {C : Category ℓC ℓC'} {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
+  {P : Presheaf C ℓP}
+  (Pᴰ : Presheafᴰ P Cᴰ ℓPᴰ)
+  where
+
+  YonedaStrictifyPshᴰ : Presheafᴰ (YonedaStrictifyPsh P) (YonedaStrictifyᴰ Cᴰ) _
+  YonedaStrictifyPshᴰ .F-obᴰ cᴰ α .fst = PshHomStrictᴰ α (Cᴰ [-][-, cᴰ ]) Pᴰ
+  YonedaStrictifyPshᴰ .F-obᴰ cᴰ α .snd = isSetPshHomStrictᴰ _ _ _
+  YonedaStrictifyPshᴰ .F-homᴰ fᴰ α pᴰ = fᴰ ⋆PshHomStrictᴰ pᴰ
+  YonedaStrictifyPshᴰ .F-idᴰ = refl
+  YonedaStrictifyPshᴰ .F-seqᴰ fᴰ gᴰ = refl

--- a/Cubical/Categories/Displayed/Presheaf/StrictHom.agda
+++ b/Cubical/Categories/Displayed/Presheaf/StrictHom.agda
@@ -8,6 +8,7 @@
 module Cubical.Categories.Displayed.Presheaf.StrictHom where
 
 open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
 open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Structure
@@ -16,11 +17,15 @@ open import Cubical.Data.Sigma
 
 open import Cubical.Categories.Category.Base
 open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.Instances.Fiber
 open import Cubical.Categories.Presheaf.Base
 open import Cubical.Categories.Presheaf.More
 open import Cubical.Categories.Presheaf.StrictHom.Base
 
 open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Displayed.Functor.More
+open import Cubical.Categories.Displayed.Instances.Sets.Base
 open import Cubical.Categories.Displayed.Presheaf.Base
 
 private
@@ -29,6 +34,7 @@ private
     ℓC ℓC' ℓCᴰ ℓCᴰ' : Level
 
 open Functor
+open Functorᴰ
 open Categoryᴰ
 open PshHomStrict
 
@@ -165,3 +171,43 @@ module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ')
   PRESHEAFᴰStrict .⋆IdRᴰ _ = refl
   PRESHEAFᴰStrict .⋆Assocᴰ _ _ _ = refl
   PRESHEAFᴰStrict .isSetHomᴰ = isSetPshHomStrictᴰ _ _ _
+
+module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ') where
+  private
+    module C = Category C
+    module Cᴰ = Categoryᴰ Cᴰ
+    module Cᴰf = Fibers Cᴰ
+
+  YOStrictᴰ : Functorᴰ (YOStrict {C = C}) Cᴰ (PRESHEAFᴰStrict Cᴰ ℓC' ℓCᴰ')
+  YOStrictᴰ .F-obᴰ xᴰ = Cᴰ [-][-, xᴰ ]
+  YOStrictᴰ .F-homᴰ hᴰ .N-obᴰ Γ Γᴰ g gᴰ = gᴰ Cᴰ.⋆ᴰ hᴰ
+  YOStrictᴰ .F-homᴰ hᴰ .N-homᴰ Δ Γ Δᴰ Γᴰ f p' p fᴰ p'ᴰ pᴰ e eᴰ =
+    Cᴰf.rectifyOut $
+      sym (Cᴰf.≡in (Cᴰf.⋆Assocᴰ fᴰ p'ᴰ hᴰ))
+      ∙ Cᴰf.⟨ Cᴰf.≡in eᴰ ⟩⋆⟨ refl ⟩
+  YOStrictᴰ .F-idᴰ =
+    makePshHomStrictᴰPathP (funExt λ _ → funExt λ _ → funExt λ _ → funExt λ _ →
+      Cᴰf.rectifyOut (Cᴰf.≡in $ Cᴰf.⋆IdRᴰ _))
+  YOStrictᴰ .F-seqᴰ h₁ᴰ h₂ᴰ =
+    makePshHomStrictᴰPathP (funExt λ _ → funExt λ _ → funExt λ _ → funExt λ _ →
+      Cᴰf.rectifyOut (sym $ Cᴰf.≡in $ Cᴰf.⋆Assocᴰ _ _ _))
+
+  isFullyFaithfulYOStrictᴰ : FullyFaithfulᴰ YOStrictᴰ
+  isFullyFaithfulYOStrictᴰ {x = x} {y = y} f xᴰ yᴰ = bwd , sec , ret
+    where
+      bwd : PshHomStrictᴰ (YOStrict .F-hom f) (Cᴰ [-][-, xᴰ ]) (Cᴰ [-][-, yᴰ ])
+            → Cᴰ.Hom[ f ][ xᴰ , yᴰ ]
+      bwd αᴰ = Cᴰf.reind (C.⋆IdL f) (αᴰ .N-obᴰ x xᴰ C.id Cᴰ.idᴰ)
+
+      sec : ∀ αᴰ → YOStrictᴰ .F-homᴰ (bwd αᴰ) ≡ αᴰ
+      sec αᴰ = makePshHomStrictᴰPath
+        (funExt λ Γ → funExt λ Γᴰ → funExt λ g → funExt λ gᴰ →
+          Cᴰf.rectifyOut $
+            Cᴰf.⟨ refl ⟩⋆⟨ Cᴰf.reind-filler⁻ (C.⋆IdL f) ⟩
+            ∙ Cᴰf.≡in
+                (αᴰ .N-homᴰ Γ x Γᴰ xᴰ g C.id g gᴰ Cᴰ.idᴰ gᴰ
+                  (C.⋆IdR g) (Cᴰ.⋆IdRᴰ gᴰ)))
+
+      ret : ∀ hᴰ → bwd (YOStrictᴰ .F-homᴰ hᴰ) ≡ hᴰ
+      ret hᴰ = Cᴰf.rectifyOut $
+        Cᴰf.reind-filler⁻ (C.⋆IdL f) ∙ Cᴰf.≡in (Cᴰ.⋆IdLᴰ hᴰ)

--- a/Cubical/Categories/Displayed/Presheaf/Uncurried/Strict.agda
+++ b/Cubical/Categories/Displayed/Presheaf/Uncurried/Strict.agda
@@ -1,0 +1,66 @@
+{-
+  Yoneda strictification of an uncurried displayed presheaf.
+-}
+{-# OPTIONS --lossy-unification #-}
+module Cubical.Categories.Displayed.Presheaf.Uncurried.Strict where
+
+open import Cubical.Foundations.Prelude
+
+import Cubical.Data.Equality as Eq
+import Cubical.Data.Equality.More as Eq
+
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.StrictHom
+open import Cubical.Categories.Presheaf.Strict
+open import Cubical.Categories.Instances.Strictify
+open import Cubical.Categories.Instances.TotalCategory
+
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.BinProduct
+open import Cubical.Categories.Displayed.Instances.StructureOver
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Eq.Base
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.StrictHom
+open import Cubical.Categories.Displayed.Instances.Strictify
+
+private
+  variable
+    ℓP ℓPᴰ : Level
+    ℓC ℓC' ℓCᴰ ℓCᴰ' : Level
+
+open Functor
+open Categoryᴰ
+open StructureOver
+open PshHomStrictᴰ
+
+module _ {C : Category ℓC ℓC'} (P : Presheaf C ℓP) where
+  private
+    module P = PresheafNotation P
+
+  EqElementStrictStr : StructureOver (YonedaStrictify C) _ _
+  EqElementStrictStr .ob[_] = P.p[_]
+  EqElementStrictStr .Hom[_][_,_] f p q = (f P.⋆ q) Eq.≡ p
+  EqElementStrictStr .idᴰ = Eq.refl
+  EqElementStrictStr ._⋆ᴰ_ Eq.refl Eq.refl = Eq.refl
+  EqElementStrictStr .isPropHomᴰ = Eq.isSet→isSetEq P.isSetPsh
+
+  EqElementStrict : Categoryᴰ (YonedaStrictify C) _ _
+  EqElementStrict = StructureOver→Catᴰ EqElementStrictStr
+
+module _ {C : Category ℓC ℓC'} where
+  _/Strict_ : (Cᴰ : Categoryᴰ (YonedaStrictify C) ℓCᴰ ℓCᴰ') (P : Presheaf C ℓP)
+            → Category _ _
+  Cᴰ /Strict P = ∫C (Cᴰ ×ᴰ EqElementStrict P)
+
+module _ {C : Category ℓC ℓC'} {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
+  {P : Presheaf C ℓP}
+  (Pᴰ : Presheafᴰ P Cᴰ ℓPᴰ)
+  where
+
+  YonedaStrictifyPshᴰ : Presheaf (YonedaStrictifyᴰ Cᴰ /Strict P) _
+  YonedaStrictifyPshᴰ .F-ob (c , cᴰ , α) .fst = PshHomStrictᴰ α (Cᴰ [-][-, cᴰ ]) Pᴰ
+  YonedaStrictifyPshᴰ .F-ob (c , cᴰ , α) .snd = isSetPshHomStrictᴰ _ _ _
+  YonedaStrictifyPshᴰ .F-hom (f , fᴰ , Eq.refl) pᴰ = fᴰ ⋆PshHomStrictᴰ pᴰ
+  YonedaStrictifyPshᴰ .F-id = refl
+  YonedaStrictifyPshᴰ .F-seq (_ , _ , Eq.refl) (_ , _ , Eq.refl) = refl

--- a/Cubical/Categories/Displayed/Presheaf/Uncurried/StrictHom.agda
+++ b/Cubical/Categories/Displayed/Presheaf/Uncurried/StrictHom.agda
@@ -1,13 +1,14 @@
 {-
-  Strict displayed presheaf homomorphisms, curried form.
+  Strict displayed presheaf homomorphisms.
 
   Defines PshHomStrictᴰ α Pᴰ Qᴰ as a displayed analogue of PshHomStrict P Q,
-  for curried displayed presheaves Pᴰ, Qᴰ.
+  for uncurried displayed presheaves Pᴰ, Qᴰ.
 -}
 {-# OPTIONS --lossy-unification #-}
-module Cubical.Categories.Displayed.Presheaf.StrictHom where
+module Cubical.Categories.Displayed.Presheaf.Uncurried.StrictHom where
 
 open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
 open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.Structure
@@ -16,12 +17,15 @@ open import Cubical.Data.Sigma
 
 open import Cubical.Categories.Category.Base
 open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.Instances.Fiber
 open import Cubical.Categories.Presheaf.Base
 open import Cubical.Categories.Presheaf.More
 open import Cubical.Categories.Presheaf.StrictHom.Base
 
 open import Cubical.Categories.Displayed.Base
-open import Cubical.Categories.Displayed.Presheaf.Base
+open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Displayed.Functor.More
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Eq.Base
 
 private
   variable
@@ -29,6 +33,7 @@ private
     ℓC ℓC' ℓCᴰ ℓCᴰ' : Level
 
 open Functor
+open Functorᴰ
 open Categoryᴰ
 open PshHomStrict
 
@@ -165,3 +170,43 @@ module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ')
   PRESHEAFᴰStrict .⋆IdRᴰ _ = refl
   PRESHEAFᴰStrict .⋆Assocᴰ _ _ _ = refl
   PRESHEAFᴰStrict .isSetHomᴰ = isSetPshHomStrictᴰ _ _ _
+
+module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ') where
+  private
+    module C = Category C
+    module Cᴰ = Categoryᴰ Cᴰ
+    module Cᴰf = Fibers Cᴰ
+
+  YOStrictᴰ : Functorᴰ (YOStrict {C = C}) Cᴰ (PRESHEAFᴰStrict Cᴰ ℓC' ℓCᴰ')
+  YOStrictᴰ .F-obᴰ xᴰ = Cᴰ [-][-, xᴰ ]
+  YOStrictᴰ .F-homᴰ hᴰ .N-obᴰ Γ Γᴰ g gᴰ = gᴰ Cᴰ.⋆ᴰ hᴰ
+  YOStrictᴰ .F-homᴰ hᴰ .N-homᴰ Δ Γ Δᴰ Γᴰ f p' p fᴰ p'ᴰ pᴰ e eᴰ =
+    Cᴰf.rectifyOut $
+      sym (Cᴰf.≡in (Cᴰf.⋆Assocᴰ fᴰ p'ᴰ hᴰ))
+      ∙ Cᴰf.⟨ Cᴰf.≡in eᴰ ⟩⋆⟨ refl ⟩
+  YOStrictᴰ .F-idᴰ =
+    makePshHomStrictᴰPathP (funExt λ _ → funExt λ _ → funExt λ _ → funExt λ _ →
+      Cᴰf.rectifyOut (Cᴰf.≡in $ Cᴰf.⋆IdRᴰ _))
+  YOStrictᴰ .F-seqᴰ h₁ᴰ h₂ᴰ =
+    makePshHomStrictᴰPathP (funExt λ _ → funExt λ _ → funExt λ _ → funExt λ _ →
+      Cᴰf.rectifyOut (sym $ Cᴰf.≡in $ Cᴰf.⋆Assocᴰ _ _ _))
+
+  isFullyFaithfulYOStrictᴰ : FullyFaithfulᴰ YOStrictᴰ
+  isFullyFaithfulYOStrictᴰ {x = x} {y = y} f xᴰ yᴰ = bwd , sec , ret
+    where
+      bwd : PshHomStrictᴰ (YOStrict .F-hom f) (Cᴰ [-][-, xᴰ ]) (Cᴰ [-][-, yᴰ ])
+            → Cᴰ.Hom[ f ][ xᴰ , yᴰ ]
+      bwd αᴰ = Cᴰf.reind (C.⋆IdL f) (αᴰ .N-obᴰ x xᴰ C.id Cᴰ.idᴰ)
+
+      sec : ∀ αᴰ → YOStrictᴰ .F-homᴰ (bwd αᴰ) ≡ αᴰ
+      sec αᴰ = makePshHomStrictᴰPath
+        (funExt λ Γ → funExt λ Γᴰ → funExt λ g → funExt λ gᴰ →
+          Cᴰf.rectifyOut $
+            Cᴰf.⟨ refl ⟩⋆⟨ Cᴰf.reind-filler⁻ (C.⋆IdL f) ⟩
+            ∙ Cᴰf.≡in
+                (αᴰ .N-homᴰ Γ x Γᴰ xᴰ g C.id g gᴰ Cᴰ.idᴰ gᴰ
+                  (C.⋆IdR g) (Cᴰ.⋆IdRᴰ gᴰ)))
+
+      ret : ∀ hᴰ → bwd (YOStrictᴰ .F-homᴰ hᴰ) ≡ hᴰ
+      ret hᴰ = Cᴰf.rectifyOut $
+        Cᴰf.reind-filler⁻ (C.⋆IdL f) ∙ Cᴰf.≡in (Cᴰ.⋆IdLᴰ hᴰ)

--- a/Cubical/Categories/Presheaf/Strict.agda
+++ b/Cubical/Categories/Presheaf/Strict.agda
@@ -1,0 +1,95 @@
+{-# OPTIONS --lossy-unification #-}
+module Cubical.Categories.Presheaf.Strict where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Structure
+
+open import Cubical.Categories.Category renaming (isIso to isIsoC)
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.Strictify
+open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.NaturalTransformation hiding (_∘ˡ_; _∘ˡⁱ_)
+open import Cubical.Categories.Presheaf.Base
+open import Cubical.Categories.Presheaf.Representable
+open import Cubical.Categories.Presheaf.StrictHom
+import Cubical.Categories.Presheaf.More as PshMore
+
+
+open Functor
+open Iso
+open NatIso
+open NatTrans
+
+private
+  variable
+    ℓ ℓ' ℓP ℓQ ℓS ℓS' ℓS'' : Level
+    ℓC ℓC' ℓD ℓD' : Level
+
+module _ {C : Category ℓ ℓ'} (P : Presheaf C ℓP) where
+  YonedaStrictifyPsh : Presheaf (YonedaStrictify C) _
+  YonedaStrictifyPsh .F-ob c .fst = PshHomStrict (C [-, c ]) P
+  YonedaStrictifyPsh .F-ob c .snd = isSetPshHomStrict _ _
+  YonedaStrictifyPsh .F-hom f p = f ⋆PshHomStrict p
+  YonedaStrictifyPsh .F-id = refl
+  YonedaStrictifyPsh .F-seq = λ _ _ → refl
+
+  -- Does it need to be YonedaStrictify C or can it be in C?
+  -- YonedaStrictifyPsh : Presheaf C _
+  -- YonedaStrictifyPsh .F-ob c .fst = PshHomStrict (C [-, c ]) P
+  -- YonedaStrictifyPsh .F-ob c .snd = isSetPshHomStrict _ _
+  -- YonedaStrictifyPsh .F-hom {x = x}{y = y} f p = compf ⋆PshHomStrict p
+  --   where
+
+  --   compf : PshHomStrict (C [-, y ]) (C [-, x ])
+  --   compf .PshHomStrict.N-ob c = C._⋆ f
+  --   compf .PshHomStrict.N-hom _ _ f g h ≡h = sym (C.⋆Assoc _ _ _) ∙ C.⟨ ≡h ⟩⋆⟨ refl ⟩
+  -- It does need to be YonedaStrictify C for this to be refl
+  -- YonedaStrictifyPsh .F-id = {!refl!}
+  -- YonedaStrictifyPsh .F-seq = λ _ _ → {!!}
+
+  private
+    module P = PshMore.PresheafNotation P
+
+  YonedaStrictifyPsh≅ : PshIsoStrict P (YonedaStrictifyPsh ∘F (toYonedaStrictify C ^opF))
+  YonedaStrictifyPsh≅ .PshIsoStrict.trans .PshHomStrict.N-ob c = yoRecStrict P
+  YonedaStrictifyPsh≅ .PshIsoStrict.trans .PshHomStrict.N-hom _ _ f p p' p≡ =
+    makePshHomStrictPath (funExt λ _ → funExt λ _ → P.⋆Assoc _ _ _ ∙ P.⟨⟩⋆⟨ p≡ ⟩)
+  YonedaStrictifyPsh≅ .PshIsoStrict.nIso c .fst = λ z → z .PshHomStrict.N-ob c (Category.id C)
+  YonedaStrictifyPsh≅ .PshIsoStrict.nIso c .snd .fst b =
+    makePshHomStrictPath (funExt λ _ → funExt λ _ → b .PshHomStrict.N-hom _ c _ _ _ (C .Category.⋆IdR _))
+  YonedaStrictifyPsh≅ .PshIsoStrict.nIso c .snd .snd _ = P.⋆IdL _
+
+module PresheafNotation {ℓo}{ℓh} {C' : Category ℓo ℓh} {ℓp} (P' : Presheaf C' ℓp) where
+  private
+    C = YonedaStrictify C'
+    P = YonedaStrictifyPsh P'
+    module C = Category C
+  p[_] : C.ob → Type _
+  p[ x ] = ⟨ P ⟅ x ⟆ ⟩
+
+  infixr 9 _⋆_
+  _⋆_ : ∀ {x y} (f : C [ x , y ]) (g : p[ y ]) → p[ x ]
+  f ⋆ g = f ⋆PshHomStrict g
+
+  ⋆IdL : ∀ {x} (g : p[ x ]) → C.id ⋆ g ≡ g
+  ⋆IdL = λ _ → refl
+
+  ⋆Assoc : ∀ {x y z} (f : C [ x , y ])(g : C [ y , z ])(h : p[ z ]) →
+    (f C.⋆ g) ⋆ h ≡ f ⋆ (g ⋆ h)
+  ⋆Assoc f g _ = refl
+
+  ⟨_⟩⋆⟨_⟩ : ∀ {x y} {f f' : C [ x , y ]} {g g' : p[ y ]}
+            → f ≡ f' → g ≡ g' → f ⋆ g ≡ f' ⋆ g'
+  ⟨ f≡f' ⟩⋆⟨ g≡g' ⟩ = cong₂ _⋆_ f≡f' g≡g'
+
+  ⟨⟩⋆⟨_⟩ : ∀ {x y} {f : C [ x , y ]} {g g' : p[ y ]}
+            → g ≡ g' → f ⋆ g ≡ f ⋆ g'
+  ⟨⟩⋆⟨_⟩ = ⟨ refl ⟩⋆⟨_⟩
+
+  ⟨_⟩⋆⟨⟩ : ∀ {x y} {f f' : C [ x , y ]} {g : p[ y ]}
+            → f ≡ f' → f ⋆ g ≡ f' ⋆ g
+  ⟨_⟩⋆⟨⟩ = ⟨_⟩⋆⟨ refl ⟩
+
+  isSetPsh : ∀ {x} → isSet (p[ x ])
+  isSetPsh {x} = (P ⟅ x ⟆) .snd


### PR DESCRIPTION
This is analogous to the additions of #257 but also defines strictification using curried presheaves

This should remain a draft until #257 is merged, then it should be rebased and merged. For readability, I am going to initially base this PR off of `strictD`, but this should also be edited to instead be based at `main` when we go to merge