### PR TITLE
Metatheory for Unary CBPV Enriched in Algebraic Structures

### DIFF
--- a/Cubical/Algebra/Signature/Base.agda
+++ b/Cubical/Algebra/Signature/Base.agda
@@ -433,7 +433,6 @@ record Signature ℓO ℓA : Type (ℓ-max (ℓ-suc ℓO) (ℓ-suc ℓA)) where
         op⟨γ⟩
         (op∘γ≡op⟨γ⟩ : FreeAlgebra X .snd op γ ≡ op⟨γ⟩)
         → |FreeAlgebraᴰ| op⟨γ⟩
-    -- TODO: prove isSet
 
     FreeAlgebraᴰ : Algebraᴰ (FreeAlgebra X) (ℓ-max (ℓ-max (ℓ-max ℓO ℓA) ℓ) ℓᴰ)
     FreeAlgebraᴰ .fst = |FreeAlgebraᴰ|

--- a/Cubical/Algebra/Signature/Base.agda
+++ b/Cubical/Algebra/Signature/Base.agda
@@ -30,8 +30,9 @@ open import Cubical.Foundations.Function
 open import Cubical.Data.Sigma
 open import Cubical.Data.Unit
 
-variable
-  ℓ ℓᴰ ℓᴰᴰ ℓ' ℓᴰ' ℓᴰᴰ' ℓ'' ℓᴰ'' ℓO ℓA ℓE : Level
+private
+  variable
+    ℓ ℓᴰ ℓᴰᴰ ℓ' ℓᴰ' ℓᴰᴰ' ℓ'' ℓᴰ'' ℓO ℓA ℓE : Level
 
 record Signature ℓO ℓA : Type (ℓ-max (ℓ-suc ℓO) (ℓ-suc ℓA)) where
   -- I don't see a reason we would need eta equality for Signatures,
@@ -410,3 +411,132 @@ record Signature ℓO ℓA : Type (ℓ-max (ℓ-suc ℓO) (ℓ-suc ℓA)) where
     recFA-uniq : ∀ (ϕ : Homo (FreeAlgebra X) A) → ϕ .fst ≡ recFA (ϕ .fst ∘ var) .fst
     recFA-uniq ϕ = PathAlgReflection A ϕ (recFA (ϕ .fst ∘ var))
       (elimFA (×intro {A = A}{B = A} ϕ (recFA (ϕ .fst ∘ var)) * PathAlg A) λ _ → refl)
+
+  -- Displayed structure
+  -- Vertical Products
+  module _ {A : Algebra ℓ}(B : Algebraᴰ A ℓᴰ)(B' : Algebraᴰ A ℓᴰ') where
+    _×ⱽ_ : Algebraᴰ A (ℓ-max ℓᴰ ℓᴰ')
+    _×ⱽ_ .fst = λ a → B .fst a × B' .fst a
+    _×ⱽ_ .snd = λ op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ →
+                   B .snd op γ (λ v → γᴰ v .fst) op⟨γ⟩ op∘γ≡op⟨γ⟩ ,
+                   B' .snd op γ (λ v → γᴰ v .snd) op⟨γ⟩ op∘γ≡op⟨γ⟩
+  module _ {A : Algebra ℓ} where
+    ⊤*ⱽ : Algebraᴰ A ℓᴰ
+    ⊤*ⱽ .fst a = Unit*
+    ⊤*ⱽ .snd = λ op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ → tt*
+
+  module _ {X : Type ℓ}(Xᴰ : X → Type ℓᴰ) where
+    data |FreeAlgebraᴰ| : |FreeAlgebra| X → Type (ℓ-max ℓ (ℓ-max ℓA (ℓ-max ℓO ℓᴰ))) where
+      var : ∀ {x} (xᴰ : Xᴰ x) → |FreeAlgebraᴰ| (var x)
+      app : ∀ op γ
+        (γᴰ : (v : Arity op) → |FreeAlgebraᴰ| (γ v))
+        op⟨γ⟩
+        (op∘γ≡op⟨γ⟩ : FreeAlgebra X .snd op γ ≡ op⟨γ⟩)
+        → |FreeAlgebraᴰ| op⟨γ⟩
+    -- TODO: prove isSet
+
+    FreeAlgebraᴰ : Algebraᴰ (FreeAlgebra X) (ℓ-max (ℓ-max (ℓ-max ℓO ℓA) ℓ) ℓᴰ)
+    FreeAlgebraᴰ .fst = |FreeAlgebraᴰ|
+    FreeAlgebraᴰ .snd = app
+
+    module _ (isSetOp : isSet Op) (isSetX : isSet X)
+      (isSetXᴰ : ∀ x → isSet (Xᴰ x)) where
+      private
+        isSetFree : isSet (|FreeAlgebra| X)
+        isSetFree = isSetFreeAlgebra isSetOp isSetX
+
+        FreeShapeᴰ : |FreeAlgebra| X → Type _
+        FreeShapeᴰ t =
+          (Σ[ x ∈ X ] Xᴰ x × (var x ≡ t))
+          ⊎ (Σ[ op ∈ Op ] Σ[ γ ∈ (Arity op → |FreeAlgebra| X) ] app op γ ≡ t)
+
+        FreePositionᴰ : ∀ {t} → FreeShapeᴰ t → Type ℓA
+        FreePositionᴰ (inl _) = Lift ℓA ⊥
+        FreePositionᴰ (inr (op , _)) = Arity op
+
+        FreeIndexᴰ : ∀ t (s : FreeShapeᴰ t) → FreePositionᴰ s → |FreeAlgebra| X
+        FreeIndexᴰ t (inl _) (lift ())
+        FreeIndexᴰ t (inr (op , γ , _)) v = γ v
+
+        FreeIWᴰ : |FreeAlgebra| X → Type _
+        FreeIWᴰ = IW FreeShapeᴰ (λ _ → FreePositionᴰ) FreeIndexᴰ
+
+        FreeAlgebraᴰ→IW : ∀ {t} → |FreeAlgebraᴰ| t → FreeIWᴰ t
+        FreeAlgebraᴰ→IW (var {x = x} xᴰ) =
+          node (inl (x , xᴰ , refl)) λ { (lift ()) }
+        FreeAlgebraᴰ→IW (app op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩) =
+          node (inr (op , γ , op∘γ≡op⟨γ⟩))
+            (λ v → FreeAlgebraᴰ→IW (γᴰ v))
+
+        IW→FreeAlgebraᴰ : ∀ {t} → FreeIWᴰ t → |FreeAlgebraᴰ| t
+        IW→FreeAlgebraᴰ (node (inl (x , xᴰ , p)) γ) =
+          subst |FreeAlgebraᴰ| p (var xᴰ)
+        IW→FreeAlgebraᴰ (node (inr (op , γ , p)) γᴰ) =
+          app op γ (λ v → IW→FreeAlgebraᴰ (γᴰ v)) _ p
+
+        IW→FreeAlgebraᴰ→IW : ∀ {t} (tᴰ : |FreeAlgebraᴰ| t)
+          → IW→FreeAlgebraᴰ (FreeAlgebraᴰ→IW tᴰ) ≡ tᴰ
+        IW→FreeAlgebraᴰ→IW (var xᴰ) =
+          substRefl {B = |FreeAlgebraᴰ|} (|FreeAlgebraᴰ|.var xᴰ)
+        IW→FreeAlgebraᴰ→IW (app op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩) =
+          cong
+            (λ γᴰ' → app op γ γᴰ' op⟨γ⟩ op∘γ≡op⟨γ⟩)
+            (funExt λ v → IW→FreeAlgebraᴰ→IW (γᴰ v))
+
+        isSetFreeShapeᴰ : ∀ t → isSet (FreeShapeᴰ t)
+        isSetFreeShapeᴰ t = isSet⊎
+          (isSetΣ isSetX λ x →
+            isSet× (isSetXᴰ x) (isProp→isSet (isSetFree _ _)))
+          (isSetΣ isSetOp λ op →
+            isSetΣ (isSetΠ λ _ → isSetFree) λ γ →
+              isProp→isSet (isSetFree _ _))
+
+      isSetFreeAlgebraᴰ : ∀ t → isSet (|FreeAlgebraᴰ| t)
+      isSetFreeAlgebraᴰ t =
+        isSetRetract FreeAlgebraᴰ→IW IW→FreeAlgebraᴰ IW→FreeAlgebraᴰ→IW
+          (isOfHLevelSuc-IW 1 isSetFreeShapeᴰ t)
+
+    module _ {A : Algebra ℓ'} (ϕ : Homo (FreeAlgebra X) A)
+      (Aᴰ : Algebraᴰ A ℓᴰ')
+      (ıᴰ : ∀ x → Xᴰ x → Aᴰ .fst (ϕ .fst (var x))) where
+      |recFAᴰ| : ∀ {t} → |FreeAlgebraᴰ| t → Aᴰ .fst (ϕ .fst t)
+      |recFAᴰ| (var {x = x} xᴰ) = ıᴰ x xᴰ
+      |recFAᴰ| (app op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩) =
+        Aᴰ .snd op (ϕ .fst ∘ γ) (λ v → |recFAᴰ| (γᴰ v))
+          (ϕ .fst op⟨γ⟩)
+          (ϕ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩)
+
+      recFAᴰ : Homoᴰ ϕ FreeAlgebraᴰ Aᴰ
+      recFAᴰ .fst _ = |recFAᴰ|
+      recFAᴰ .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ =
+        J
+          (λ op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ →
+            Aᴰ .snd op (ϕ .fst ∘ γ) (λ v → |recFAᴰ| (γᴰ v))
+              (ϕ .fst op⟨γ⟩)
+              (ϕ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩)
+              ≡ |recFAᴰ| op⟨γᴰ⟩)
+          refl
+          op∘γᴰ≡op⟨γᴰ⟩
+
+    module _ {A : Algebra ℓ'} (ϕ : Homo (FreeAlgebra X) A)
+      (Aᴰ : Algebraᴰ A ℓᴰ')
+      (ϕᴰ : Homoᴰ ϕ FreeAlgebraᴰ Aᴰ) where
+      private
+        ıᴰ : ∀ x → Xᴰ x → Aᴰ .fst (ϕ .fst (var x))
+        ıᴰ x xᴰ = ϕᴰ .fst (var x) (var xᴰ)
+
+        |recFAᴰ|-η : ∀ {t} (tᴰ : |FreeAlgebraᴰ| t)
+          → ϕᴰ .fst t tᴰ ≡ |recFAᴰ| ϕ Aᴰ ıᴰ tᴰ
+        |recFAᴰ|-η (var xᴰ) = refl
+        |recFAᴰ|-η (app op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩) =
+          sym (ϕᴰ .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩
+            (app op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩) refl)
+          ∙ cong
+              (λ γᴰ' →
+                Aᴰ .snd op (ϕ .fst ∘ γ) γᴰ'
+                  (ϕ .fst op⟨γ⟩)
+                  (ϕ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩))
+              (funExt λ v → |recFAᴰ|-η (γᴰ v))
+
+      recFAᴰ-η : ϕᴰ .fst ≡ recFAᴰ ϕ Aᴰ ıᴰ .fst
+      recFAᴰ-η = funExt λ t → funExt λ tᴰ → |recFAᴰ|-η tᴰ

--- a/Cubical/Algebra/Signature/Base.agda
+++ b/Cubical/Algebra/Signature/Base.agda
@@ -129,6 +129,14 @@ record Signature ℓO ℓA : Type (ℓ-max (ℓ-suc ℓO) (ℓ-suc ℓA)) where
   _×Alg_ : (A : Algebra ℓ) (B : Algebra ℓ') → Algebra _
   A ×Alg B = ∫Algebra (wkAlg A B)
 
+  ×intro : {Γ : Algebra ℓ}{A : Algebra ℓ'}{B : Algebra ℓ''}
+    → (ϕ : Homo Γ A)
+    → (ψ : Homo Γ B)
+    → Homo Γ (A ×Alg B)
+  ×intro ϕ ψ .fst = λ z → ϕ .fst z , ψ .fst z
+  ×intro ϕ ψ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+    ΣPathP ((ϕ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩) , (ψ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩))
+
   idHomo : {A : Algebra ℓ} → Homo A A
   idHomo .fst = λ a → a
   idHomo .snd f γ op⟨γ⟩ pf = pf
@@ -165,8 +173,6 @@ record Signature ℓO ℓA : Type (ℓ-max (ℓ-suc ℓO) (ℓ-suc ℓA)) where
           (ϕ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ i)
           (λ j → ϕ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ (i ∧ j))))
       i1
-
-
 
   module _ {A : Algebra ℓ} {Aᴰ : Algebraᴰ A ℓᴰ} where
     Fst : Homo (∫Algebra Aᴰ) A
@@ -320,3 +326,87 @@ record Signature ℓO ℓA : Type (ℓ-max (ℓ-suc ℓO) (ℓ-suc ℓA)) where
           (_⋆Hᴰ_ {A = B} {B = C} {C = D}
             {Aᴰ = Bᴰ} {Bᴰ = Cᴰ} {Cᴰ = Dᴰ} ψᴰ χᴰ)
     ⋆HᴰAssoc ϕᴰ ψᴰ χᴰ = refl
+
+  -- Path Algebra
+  module _ (A : Algebra ℓ) where
+    PathAlg : Algebraᴰ (A ×Alg A) ℓ
+    PathAlg .fst (a , a') = a ≡ a'
+    PathAlg .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+      sym (cong fst op∘γ≡op⟨γ⟩)
+      ∙ cong (A .snd op) (funExt γᴰ)
+      ∙ cong snd op∘γ≡op⟨γ⟩
+
+    -- TODO: PathAlg Reflection and derive the uniqueness from the eliminator below
+    PathAlgReflection : {Γ : Algebra ℓ'} (ϕ ψ : Homo Γ A)
+      → Section (×intro {A = A}{B = A} ϕ ψ * PathAlg)
+      → ϕ .fst ≡ ψ .fst
+    PathAlgReflection ϕ ψ ϕ≡ψ i γ = ϕ≡ψ .fst γ i
+
+  -- Free Algebras
+  data |FreeAlgebra| (X : Type ℓ) : Type (ℓ-max ℓ (ℓ-max ℓA ℓO)) where
+    var : X → |FreeAlgebra| X
+    app : (op : Op) → (Arity op → |FreeAlgebra| X) → |FreeAlgebra| X
+
+  FreeAlgebra : (X : Type ℓ) → Algebra (ℓ-max ℓ (ℓ-max ℓA ℓO))
+  FreeAlgebra X = (|FreeAlgebra| X) , app
+
+  private
+    open import Cubical.Data.Empty
+    open import Cubical.Data.Sum
+    open import Cubical.Data.W.Indexed
+    FreeShape : Type ℓ → Type (ℓ-max ℓ ℓO)
+    FreeShape X = X ⊎ Op
+
+    FreePosition : {X : Type ℓ} → FreeShape X → Type ℓA
+    FreePosition (inl _) = Lift ℓA ⊥
+    FreePosition (inr op) = Arity op
+
+    FreeIW : Type ℓ → Type (ℓ-max ℓ (ℓ-max ℓA ℓO))
+    FreeIW X = IW (λ (_ : Unit) → FreeShape X)
+      (λ _ → FreePosition) (λ _ _ _ → tt) tt
+
+    FreeAlgebra→IW : {X : Type ℓ} → |FreeAlgebra| X → FreeIW X
+    FreeAlgebra→IW (var x) = node (inl x) λ { (lift ()) }
+    FreeAlgebra→IW (app op γ) =
+      node (inr op) (λ v → FreeAlgebra→IW (γ v))
+
+    IW→FreeAlgebra : {X : Type ℓ} → FreeIW X → |FreeAlgebra| X
+    IW→FreeAlgebra (node (inl x) γ) = var x
+    IW→FreeAlgebra (node (inr op) γ) =
+      app op (λ v → IW→FreeAlgebra (γ v))
+
+    IW→FreeAlgebra→IW : {X : Type ℓ} (t : |FreeAlgebra| X)
+      → IW→FreeAlgebra (FreeAlgebra→IW t) ≡ t
+    IW→FreeAlgebra→IW (var x) = refl
+    IW→FreeAlgebra→IW (app op γ) =
+      cong (app op) (funExt λ v → IW→FreeAlgebra→IW (γ v))
+
+  isSetFreeAlgebra : {X : Type ℓ} → (isSetOp : isSet Op) → isSet X → isSet (|FreeAlgebra| X)
+  isSetFreeAlgebra isSetOp isSetX =
+    isSetRetract FreeAlgebra→IW IW→FreeAlgebra IW→FreeAlgebra→IW
+      (isOfHLevelSuc-IW 1
+        (λ _ → isSet⊎ isSetX isSetOp) tt)
+
+  module _ {X : Type ℓ} (Aᴰ : Algebraᴰ (FreeAlgebra X) ℓ') (ıᴰ : (x : X) → Aᴰ .fst (var x)) where
+    |elimFA| : ∀ (t : |FreeAlgebra| X) → Aᴰ .fst t
+    -- β reduction is definitional
+    |elimFA| (var x) = ıᴰ x
+    |elimFA| (app op γ) = Aᴰ .snd op γ (|elimFA| ∘ γ) (app op γ) refl
+
+    elimFA : Section Aᴰ
+    elimFA .fst = |elimFA|
+    elimFA .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+      J
+        (λ op⟨γ⟩ op∘γ≡op⟨γ⟩ →
+          Aᴰ .snd op γ (|elimFA| ∘ γ) op⟨γ⟩ op∘γ≡op⟨γ⟩
+            ≡ |elimFA| op⟨γ⟩)
+        refl
+        op∘γ≡op⟨γ⟩
+
+  module _ {X : Type ℓ} (A : Algebra ℓ')  where
+    recFA : (ı : X → A .fst) → Homo (FreeAlgebra X) A
+    recFA ı = elimFA (wkAlg (FreeAlgebra X) A) ı
+
+    recFA-uniq : ∀ (ϕ : Homo (FreeAlgebra X) A) → ϕ .fst ≡ recFA (ϕ .fst ∘ var) .fst
+    recFA-uniq ϕ = PathAlgReflection A ϕ (recFA (ϕ .fst ∘ var))
+      (elimFA (×intro {A = A}{B = A} ϕ (recFA (ϕ .fst ∘ var)) * PathAlg A) λ _ → refl)

--- a/Cubical/Algebra/Signature/Base.agda
+++ b/Cubical/Algebra/Signature/Base.agda
@@ -41,7 +41,6 @@ record Signature ℓO ℓA : Type (ℓ-max (ℓ-suc ℓO) (ℓ-suc ℓA)) where
     Op : Type ℓO
     Arity : Op → Type ℓA
 
-  -- This on the other hand we definitely want to have nice equality
   AlgebraWithCarrier : (X : Type ℓ) → Type (ℓ-max (ℓ-max ℓO ℓA) ℓ)
   AlgebraWithCarrier X = ∀ (f : Op) → (ρ : Arity f → X) → X
 
@@ -57,6 +56,8 @@ record Signature ℓO ℓA : Type (ℓ-max (ℓ-suc ℓO) (ℓ-suc ℓA)) where
   module _ (A : Algebra ℓ) where
     -- Twist on the more obvious definition of displayed Algebra: a
     -- "Yoneda expansion" of the more obvious definition
+
+    -- Should it be an Eq though?
     AlgebraᴰWithCarrier : (A .fst → Type ℓᴰ) → Type _
     AlgebraᴰWithCarrier Xᴰ =
       ∀ (op : Op) (γ : Arity op → A .fst)
@@ -64,26 +65,13 @@ record Signature ℓO ℓA : Type (ℓ-max (ℓ-suc ℓO) (ℓ-suc ℓA)) where
       → (op⟨γ⟩ : A .fst) (op∘γ≡op⟨γ⟩ : A .snd op γ ≡ op⟨γ⟩)
       → Xᴰ op⟨γ⟩
 
-    private
-      -- Equivalence with the more obvious definition
-      AlgebraᴰWithCarrier' : (A .fst → Type ℓᴰ) → Type _
-      AlgebraᴰWithCarrier' Xᴰ =
-        ∀ (f : Op) (γ : Arity f → A .fst)
-          (γᴰ : (v : Arity f) → Xᴰ (γ v))
-        → Xᴰ (A .snd f γ)
-
-      AlgebraᴰWithCarrier'≃AlgebraᴰWithCarrier :
-        (Xᴰ : A .fst → Type ℓᴰ)
-        → AlgebraᴰWithCarrier' Xᴰ ≃ AlgebraᴰWithCarrier Xᴰ
-      AlgebraᴰWithCarrier'≃AlgebraᴰWithCarrier Xᴰ =
-        equivΠCod λ f → equivΠCod λ γ → equivΠCod λ γᴰ →
-          compEquiv
-            (Jequiv (λ f⟨γ⟩ _ → Xᴰ f⟨γ⟩))
-            explicitΠEquiv
-
     Algebraᴰ : ∀ ℓᴰ → Type _
     Algebraᴰ ℓᴰ = Σ[ Xᴰ ∈ (A .fst → Type ℓᴰ) ] AlgebraᴰWithCarrier Xᴰ
 
+    -- This is the downside of the "Yoneda expanded" version of
+    -- displayed algebras: there's nothing analogous in the base so we
+    -- end up instantiating with refl. This leads to the inherent
+    -- nastiness of things like ∫intro below
   ∫Algebra : {A : Algebra ℓ} (Aᴰ : Algebraᴰ A ℓᴰ) → Algebra (ℓ-max ℓ ℓᴰ)
   ∫Algebra Aᴰ .fst = Σ[ a ∈ _ ] Aᴰ .fst a
   ∫Algebra {A = A} Aᴰ .snd f γ .fst =
@@ -95,7 +83,6 @@ record Signature ℓO ℓA : Type (ℓ-max (ℓ-suc ℓO) (ℓ-suc ℓA)) where
     Algebraᴰᴰ : ∀ (Aᴰ : Algebraᴰ A ℓᴰ) ℓᴰᴰ → Type _
     Algebraᴰᴰ Aᴰ ℓᴰᴰ = Algebraᴰ (∫Algebra Aᴰ) ℓᴰᴰ
 
-    -- Is this definition nice enough?
     ∫ᴰAlgebra : {Aᴰ : Algebraᴰ A ℓᴰ} (Aᴰᴰ : Algebraᴰᴰ Aᴰ ℓᴰᴰ) → Algebraᴰ A _
     ∫ᴰAlgebra Aᴰᴰ .fst a = Σ[ aᴰ ∈ _ ] Aᴰᴰ .fst (a , aᴰ)
     ∫ᴰAlgebra {Aᴰ = Aᴰ} Aᴰᴰ .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ .fst =
@@ -115,6 +102,41 @@ record Signature ℓO ℓA : Type (ℓ-max (ℓ-suc ℓO) (ℓ-suc ℓA)) where
 
     Section : (Aᴰ : Algebraᴰ A ℓᴰ) → Type _
     Section Aᴰ = Σ[ f ∈ _ ] isHomo Aᴰ f
+
+  -- comparison to more obvious definition
+  private
+    module _ (A : Algebra ℓ) where
+      -- Equivalence with the more obvious definition
+      AlgebraᴰWithCarrier' : (A .fst → Type ℓᴰ) → Type _
+      AlgebraᴰWithCarrier' Xᴰ =
+        ∀ (f : Op) (γ : Arity f → A .fst)
+          (γᴰ : (v : Arity f) → Xᴰ (γ v))
+        → Xᴰ (A .snd f γ)
+
+      Algebraᴰ' : ∀ ℓᴰ → Type _
+      Algebraᴰ' ℓᴰ = Σ[ Xᴰ ∈ (A .fst → Type ℓᴰ) ] AlgebraᴰWithCarrier' Xᴰ
+
+      AlgebraᴰWithCarrier'≃AlgebraᴰWithCarrier :
+        (Xᴰ : A .fst → Type ℓᴰ)
+        → AlgebraᴰWithCarrier' Xᴰ ≃ AlgebraᴰWithCarrier A Xᴰ
+      AlgebraᴰWithCarrier'≃AlgebraᴰWithCarrier Xᴰ =
+        equivΠCod λ f → equivΠCod λ γ → equivΠCod λ γᴰ →
+          compEquiv
+            (Jequiv (λ f⟨γ⟩ _ → Xᴰ f⟨γ⟩))
+            explicitΠEquiv
+
+      ∫Algebra' : (Aᴰ : Algebraᴰ' ℓᴰ) → Algebra (ℓ-max ℓ ℓᴰ)
+      ∫Algebra' Aᴰ .fst = Σ _ (Aᴰ .fst)
+      ∫Algebra' Aᴰ .snd f ρ .fst = A .snd f (λ z → ρ z .fst)
+      ∫Algebra' Aᴰ .snd f ρ .snd = Aᴰ .snd f (λ z → ρ z .fst) (λ v → ρ v .snd)
+
+    module _ {A : Algebra ℓ} {Aᴰ : Algebraᴰ' A ℓᴰ} where
+      -- This is the advantage of the non-Yoneda expanded version: a
+      -- very nice definition of ∫/∫ᴰ
+      ∫ᴰAlgebra' : (Aᴰᴰ : Algebraᴰ' (∫Algebra' _ Aᴰ) ℓᴰᴰ) → Algebraᴰ' A _
+      ∫ᴰAlgebra' Aᴰᴰ .fst a = Σ[ aᴰ ∈ Aᴰ .fst a ] (Aᴰᴰ .fst (a , aᴰ))
+      ∫ᴰAlgebra' Aᴰᴰ .snd op γ γᴰ .fst = Aᴰ .snd op γ (fst ∘ γᴰ)
+      ∫ᴰAlgebra' Aᴰᴰ .snd op γ γᴰ .snd = Aᴰᴰ .snd op (λ z → γ z , fst (γᴰ z)) (λ v → γᴰ v .snd)
 
   wkAlg : (A : Algebra ℓ) (B : Algebra ℓ') → Algebraᴰ A ℓ'
   wkAlg A B .fst _ = B .fst
@@ -144,6 +166,9 @@ record Signature ℓO ℓA : Type (ℓ-max (ℓ-suc ℓO) (ℓ-suc ℓA)) where
 
   module _ {A : Algebra ℓ}{B : Algebra ℓ'} where
     -- Cartesian Lift, pulling back Algebraᴰ structure along a homomorphism
+
+    -- This turns out to be definitionally functorial (see *∘ and *Id
+    -- below) because of the Yoneda expansion
     _*_ : Homo A B → Algebraᴰ B ℓᴰ → Algebraᴰ A ℓᴰ
     (ϕ * Bᴰ) .fst a = Bᴰ .fst (ϕ .fst a)
     (ϕ * Bᴰ) .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
@@ -438,6 +463,7 @@ record Signature ℓO ℓA : Type (ℓ-max (ℓ-suc ℓO) (ℓ-suc ℓA)) where
     FreeAlgebraᴰ .fst = |FreeAlgebraᴰ|
     FreeAlgebraᴰ .snd = app
 
+    -- would be really nice to have a macro for this...
     module _ (isSetOp : isSet Op) (isSetX : isSet X)
       (isSetXᴰ : ∀ x → isSet (Xᴰ x)) where
       private

--- a/Cubical/Algebra/Signature/Base.agda
+++ b/Cubical/Algebra/Signature/Base.agda
@@ -1,0 +1,322 @@
+-- Signatures of an algebraic structure and their algebras and
+-- displayed algebras, and sections and displayed sections,
+-- homomorphisms and displayed homomorphisms.
+--
+-- We adopt the terminology that "algberas" are simply operations, and
+-- that "models" are algebras that satisfy the equations of a
+-- Theory. For that notion see Cubical.Algebra.Theory.Base.
+--
+-- I've attempted for some minimalism with the notions of homomorphism
+-- and composition but didn't fully succeed. In the end there are two
+-- primitive notions of morphism: a section and a displayed
+-- homomorphism, while ordinary homomorphisms are sections of a
+-- weakened algebra. I also need three primitive kinds of composition:
+-- dependent composition of sections, composition of a section with a
+-- homomorphism and composition of displayed homomorphisms. Other than
+-- the dependent composition, these satisfy definitional unit and
+-- associativity laws.
+module Cubical.Algebra.Signature.Base where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv.Base
+open import Cubical.Foundations.Equiv using (compEquiv; equivΠCod)
+open import Cubical.Foundations.Equiv.More using (explicitΠEquiv)
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.More
+open import Cubical.Foundations.Path using (Jequiv)
+open import Cubical.Foundations.Function
+
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit
+
+variable
+  ℓ ℓᴰ ℓᴰᴰ ℓ' ℓᴰ' ℓᴰᴰ' ℓ'' ℓᴰ'' ℓO ℓA ℓE : Level
+
+record Signature ℓO ℓA : Type (ℓ-max (ℓ-suc ℓO) (ℓ-suc ℓA)) where
+  -- I don't see a reason we would need eta equality for Signatures,
+  no-eta-equality
+  field
+    Op : Type ℓO
+    Arity : Op → Type ℓA
+
+  -- This on the other hand we definitely want to have nice equality
+  AlgebraWithCarrier : (X : Type ℓ) → Type (ℓ-max (ℓ-max ℓO ℓA) ℓ)
+  AlgebraWithCarrier X = ∀ (f : Op) → (ρ : Arity f → X) → X
+
+  Algebra : ∀ ℓ → Type _
+  Algebra ℓ = Σ[ X ∈ Type ℓ ] AlgebraWithCarrier X
+
+  ⊤Algebra : AlgebraWithCarrier Unit
+  ⊤Algebra f ρ = tt
+
+  ⊤*Algebra : AlgebraWithCarrier {ℓ} Unit*
+  ⊤*Algebra f ρ = tt*
+
+  module _ (A : Algebra ℓ) where
+    -- Twist on the more obvious definition of displayed Algebra: a
+    -- "Yoneda expansion" of the more obvious definition
+    AlgebraᴰWithCarrier : (A .fst → Type ℓᴰ) → Type _
+    AlgebraᴰWithCarrier Xᴰ =
+      ∀ (op : Op) (γ : Arity op → A .fst)
+      → (γᴰ : (v : Arity op) → Xᴰ (γ v))
+      → (op⟨γ⟩ : A .fst) (op∘γ≡op⟨γ⟩ : A .snd op γ ≡ op⟨γ⟩)
+      → Xᴰ op⟨γ⟩
+
+    private
+      -- Equivalence with the more obvious definition
+      AlgebraᴰWithCarrier' : (A .fst → Type ℓᴰ) → Type _
+      AlgebraᴰWithCarrier' Xᴰ =
+        ∀ (f : Op) (γ : Arity f → A .fst)
+          (γᴰ : (v : Arity f) → Xᴰ (γ v))
+        → Xᴰ (A .snd f γ)
+
+      AlgebraᴰWithCarrier'≃AlgebraᴰWithCarrier :
+        (Xᴰ : A .fst → Type ℓᴰ)
+        → AlgebraᴰWithCarrier' Xᴰ ≃ AlgebraᴰWithCarrier Xᴰ
+      AlgebraᴰWithCarrier'≃AlgebraᴰWithCarrier Xᴰ =
+        equivΠCod λ f → equivΠCod λ γ → equivΠCod λ γᴰ →
+          compEquiv
+            (Jequiv (λ f⟨γ⟩ _ → Xᴰ f⟨γ⟩))
+            explicitΠEquiv
+
+    Algebraᴰ : ∀ ℓᴰ → Type _
+    Algebraᴰ ℓᴰ = Σ[ Xᴰ ∈ (A .fst → Type ℓᴰ) ] AlgebraᴰWithCarrier Xᴰ
+
+  ∫Algebra : {A : Algebra ℓ} (Aᴰ : Algebraᴰ A ℓᴰ) → Algebra (ℓ-max ℓ ℓᴰ)
+  ∫Algebra Aᴰ .fst = Σ[ a ∈ _ ] Aᴰ .fst a
+  ∫Algebra {A = A} Aᴰ .snd f γ .fst =
+    A .snd f (fst ∘ γ)
+  ∫Algebra {A = A} Aᴰ .snd f γ .snd =
+    Aᴰ .snd f (fst ∘ γ) (snd ∘ γ) (A .snd f (fst ∘ γ)) refl
+
+  module _ {A : Algebra ℓ} where
+    Algebraᴰᴰ : ∀ (Aᴰ : Algebraᴰ A ℓᴰ) ℓᴰᴰ → Type _
+    Algebraᴰᴰ Aᴰ ℓᴰᴰ = Algebraᴰ (∫Algebra Aᴰ) ℓᴰᴰ
+
+    -- Is this definition nice enough?
+    ∫ᴰAlgebra : {Aᴰ : Algebraᴰ A ℓᴰ} (Aᴰᴰ : Algebraᴰᴰ Aᴰ ℓᴰᴰ) → Algebraᴰ A _
+    ∫ᴰAlgebra Aᴰᴰ .fst a = Σ[ aᴰ ∈ _ ] Aᴰᴰ .fst (a , aᴰ)
+    ∫ᴰAlgebra {Aᴰ = Aᴰ} Aᴰᴰ .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ .fst =
+      Aᴰ .snd op γ (λ v → γᴰ v .fst) op⟨γ⟩ op∘γ≡op⟨γ⟩
+    ∫ᴰAlgebra {Aᴰ = Aᴰ} Aᴰᴰ .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ .snd =
+      Aᴰᴰ .snd op _ (snd ∘ γᴰ) _ λ i →
+        (op∘γ≡op⟨γ⟩ i)
+        , (Aᴰ .snd op γ (fst ∘ γᴰ) _ (λ j → op∘γ≡op⟨γ⟩ (i ∧ j)))
+
+    isHomo : (Aᴰ : Algebraᴰ A ℓᴰ)
+      → (f : (a : A .fst) → Aᴰ .fst a)
+      → Type _
+    isHomo Aᴰ f =
+      ∀ (op : Op) (γ : Arity op → A .fst)
+        (op⟨γ⟩ : A .fst) (op∘γ≡op⟨γ⟩ : A .snd op γ ≡ op⟨γ⟩)
+      → Aᴰ .snd op γ (f ∘ γ) op⟨γ⟩ op∘γ≡op⟨γ⟩ ≡ f op⟨γ⟩
+
+    Section : (Aᴰ : Algebraᴰ A ℓᴰ) → Type _
+    Section Aᴰ = Σ[ f ∈ _ ] isHomo Aᴰ f
+
+  wkAlg : (A : Algebra ℓ) (B : Algebra ℓ') → Algebraᴰ A ℓ'
+  wkAlg A B .fst _ = B .fst
+  wkAlg A B .snd f _ γ _ _ = B .snd f γ
+
+  isHomoSimpl : (A : Algebra ℓ) (B : Algebra ℓ') →
+    (A .fst → B .fst) → Type _
+  isHomoSimpl A B = isHomo (wkAlg A B)
+
+  Homo : (A : Algebra ℓ) (B : Algebra ℓ') → Type _
+  Homo A B = Σ[ f ∈ (A .fst → B .fst) ] isHomoSimpl A B f
+
+  _×Alg_ : (A : Algebra ℓ) (B : Algebra ℓ') → Algebra _
+  A ×Alg B = ∫Algebra (wkAlg A B)
+
+  idHomo : {A : Algebra ℓ} → Homo A A
+  idHomo .fst = λ a → a
+  idHomo .snd f γ op⟨γ⟩ pf = pf
+
+  module _ {A : Algebra ℓ}{B : Algebra ℓ'} where
+    -- Cartesian Lift, pulling back Algebraᴰ structure along a homomorphism
+    _*_ : Homo A B → Algebraᴰ B ℓᴰ → Algebraᴰ A ℓᴰ
+    (ϕ * Bᴰ) .fst a = Bᴰ .fst (ϕ .fst a)
+    (ϕ * Bᴰ) .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+      Bᴰ .snd op (λ z → ϕ .fst (γ z)) γᴰ
+        (ϕ .fst op⟨γ⟩)
+        (ϕ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩)
+
+  ∫intro : {Γ : Algebra ℓ}{A : Algebra ℓ'}{B : Algebraᴰ A ℓᴰ'}
+    → (ϕ : Homo Γ A)
+    → (ψ : Section (ϕ * B))
+    → Homo Γ (∫Algebra B)
+  ∫intro ϕ ψ .fst γ .fst = ϕ .fst γ
+  ∫intro ϕ ψ .fst γ .snd = ψ .fst γ
+  ∫intro ϕ ψ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ i .fst =
+    -- To make this definition nice...
+    ϕ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ i
+  ∫intro {B = B} ϕ ψ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ i .snd =
+    -- ...it seems this definition must be nasty
+    hfill
+      (λ j → λ
+        { (i = i0) →
+          B .snd op (λ v → ϕ .fst (γ v)) (λ v → ψ .fst (γ v))
+            (ϕ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ i0) refl
+        ; (i = i1) → ψ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ j
+        })
+      (inS (
+        B .snd op (λ v → ϕ .fst (γ v)) (λ v → ψ .fst (γ v))
+          (ϕ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ i)
+          (λ j → ϕ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ (i ∧ j))))
+      i1
+
+
+
+  module _ {A : Algebra ℓ} {Aᴰ : Algebraᴰ A ℓᴰ} where
+    Fst : Homo (∫Algebra Aᴰ) A
+    Fst .fst = λ z → z .fst
+    Fst .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ i = op∘γ≡op⟨γ⟩ i .fst
+
+    -- Too nasty to be nice to use unfortunately
+    Snd : Section (Fst * Aᴰ)
+    Snd .fst = λ a → a .snd
+    Snd .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+      sym (fromPathP (λ i →
+        Aᴰ .snd op (λ v → γ v .fst) (λ v → γ v .snd)
+          (op∘γ≡op⟨γ⟩ i .fst)
+          (λ j → op∘γ≡op⟨γ⟩ (i ∧ j) .fst)))
+      ∙ fromPathP (λ i → op∘γ≡op⟨γ⟩ i .snd)
+
+  module _ {A : Algebra ℓ} {B : Algebra ℓ'} where
+    SndSimpl : Homo (A ×Alg B) B
+    SndSimpl .fst = λ z → z .snd
+    SndSimpl .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ i = op∘γ≡op⟨γ⟩ i .snd
+
+  module _ {A : Algebra ℓ}{B : Algebraᴰ A ℓᴰ}{C : Algebraᴰᴰ B ℓᴰᴰ} where
+    -- ϕ : (a : A) → B
+    -- need (a : A) → Σ[ a ] B a
+    _⋆S_ : (ϕ : Section B)(ψ : Section C) → Section (∫intro {B = B} (idHomo {A = A}) ϕ * C)
+    (ϕ ⋆S ψ) .fst a = ψ .fst (a , ϕ .fst a)
+    (ϕ ⋆S ψ) .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ = ψ .snd _ _ _ _
+
+  module _ {A : Algebra ℓ}{B : Algebra ℓ'} where
+    module _ {Bᴰ : Algebraᴰ B ℓᴰ} where
+      -- This is so similar this to _⋆S_ but because of the nastiness
+      -- of ∫intro it can't be used definitionally.
+      _⋆HS_ : (ϕ : Homo A B) → Section Bᴰ → Section (ϕ * Bᴰ)
+      (ϕ ⋆HS ψ) .fst a = ψ .fst (ϕ .fst a)
+      (ϕ ⋆HS ψ) .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ = ψ .snd _ _ _ _
+
+  module _ {A : Algebra ℓ}{B : Algebra ℓ'}{C : Algebra ℓ''} where
+    _⋆H_ : Homo A B → Homo B C → Homo A C
+    ϕ ⋆H ψ = _⋆HS_ {Bᴰ = wkAlg _ C} ϕ ψ
+
+  module _ {A : Algebra ℓ}{B : Algebra ℓ'} (ϕ : Homo A B) where
+    ⋆HIdR : _⋆H_ {A = A} {B = B} {C = B} ϕ (idHomo {A = B}) ≡ ϕ
+    ⋆HIdR = refl
+
+  module _ {A : Algebra ℓ}{Aᴰ : Algebraᴰ A ℓᴰ} where
+    ⋆HSIdL : (Ψ : Section Aᴰ) →
+      _⋆HS_ {A = A} {B = A} {Bᴰ = Aᴰ} (idHomo {A = A}) Ψ ≡ Ψ
+    ⋆HSIdL Ψ = refl
+
+    *Id : (idHomo * Aᴰ) ≡ Aᴰ
+    *Id = refl
+
+  module _ {A : Algebra ℓ}{B : Algebra ℓ'}{C : Algebra ℓ''}{Cᴰ : Algebraᴰ C ℓᴰ''} (ϕ : Homo A B)(ψ : Homo B C) where
+    ⋆HHSAssoc : (χ : Section Cᴰ)
+      → _⋆HS_ {A = A} {B = C} {Bᴰ = Cᴰ}
+          (_⋆H_ {A = A} {B = B} {C = C} ϕ ψ) χ
+        ≡ _⋆HS_ {A = A} {B = B} {Bᴰ = ψ * Cᴰ}
+            ϕ (_⋆HS_ {A = B} {B = C} {Bᴰ = Cᴰ} ψ χ)
+    ⋆HHSAssoc χ = refl
+
+    *∘ : ((_⋆H_ {C = C} ϕ ψ) * Cᴰ) ≡ (ϕ * (ψ * Cᴰ))
+    *∘ = refl
+
+  -- This definition doesn't work well
+  private
+    BadHomoᴰ : {A : Algebra ℓ}{B : Algebra ℓ'}
+      (ϕ : Homo A B)(Aᴰ : Algebraᴰ A ℓᴰ)(Bᴰ : Algebraᴰ B ℓᴰ')
+      → Type _
+    BadHomoᴰ ϕ Aᴰ Bᴰ = Section (Fst {Aᴰ = Aᴰ} * (ϕ * Bᴰ))
+
+    module _ {A : Algebra ℓ} {B : Algebra ℓ'} {C : Algebra ℓ''}
+      {Aᴰ : Algebraᴰ A ℓᴰ} {Bᴰ : Algebraᴰ B ℓᴰ'} {Cᴰ : Algebraᴰ C ℓᴰ''}
+      {ϕ : Homo A B} {ψ : Homo B C} where
+      -- because of the nastiness of ∫intro this definition doesn't
+      -- work well
+      _Bad⋆Hᴰ_ : BadHomoᴰ ϕ Aᴰ Bᴰ → BadHomoᴰ ψ Bᴰ Cᴰ
+        → BadHomoᴰ (_⋆H_ {C = C} ϕ ψ) Aᴰ Cᴰ
+      (ϕᴰ Bad⋆Hᴰ ψᴰ) .fst a = ψᴰ .fst (ϕ .fst (a .fst) , ϕᴰ .fst a)
+      (ϕᴰ Bad⋆Hᴰ ψᴰ) .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+        ψᴰ .snd _ _ _
+          (∫ϕᴰ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩)
+        where
+        ∫ϕᴰ : Homo (∫Algebra Aᴰ) (∫Algebra Bᴰ)
+        ∫ϕᴰ =
+          ∫intro {Γ = ∫Algebra Aᴰ} {A = B} {B = Bᴰ}
+            (_⋆H_ {A = ∫Algebra Aᴰ} {B = A} {C = B}
+              (Fst {Aᴰ = Aᴰ}) ϕ)
+            ϕᴰ
+
+  module _ {A : Algebra ℓ}{B : Algebra ℓ'}
+    (ϕ : Homo A B)(Aᴰ : Algebraᴰ A ℓᴰ)(Bᴰ : Algebraᴰ B ℓᴰ')
+    where
+    isHomoᴰSimpl : (∀ (a : A .fst)(aᴰ : Aᴰ .fst a) → Bᴰ .fst (ϕ .fst a)) → Type _
+    isHomoᴰSimpl fᴰ =
+      ∀ (op : Op)(γ : Arity op → A .fst)(γᴰ : ∀ v → Aᴰ .fst (γ v))
+        (op⟨γ⟩ : A .fst) (op∘γ≡op⟨γ⟩ : A .snd op γ ≡ op⟨γ⟩)
+        (op⟨γᴰ⟩ : Aᴰ .fst (op⟨γ⟩)) (op∘γᴰ≡op⟨γᴰ⟩ : Aᴰ .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ ≡ op⟨γᴰ⟩)
+      → Bᴰ .snd op (ϕ .fst ∘ γ) (λ v → fᴰ (γ v) (γᴰ v)) (ϕ .fst op⟨γ⟩) (ϕ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩) ≡ fᴰ op⟨γ⟩ op⟨γᴰ⟩
+
+    Homoᴰ : Type _
+    Homoᴰ = Σ[ fᴰ ∈ _ ] isHomoᴰSimpl fᴰ
+
+  idHomoᴰ : {A : Algebra ℓ}{Aᴰ : Algebraᴰ A ℓᴰ} → Homoᴰ idHomo Aᴰ Aᴰ
+  idHomoᴰ .fst = λ a aᴰ → aᴰ
+  idHomoᴰ .snd = λ op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ → op∘γᴰ≡op⟨γᴰ⟩
+
+  module _ {A : Algebra ℓ} {B : Algebra ℓ'} {C : Algebra ℓ''}
+    {Aᴰ : Algebraᴰ A ℓᴰ} {Bᴰ : Algebraᴰ B ℓᴰ'} {Cᴰ : Algebraᴰ C ℓᴰ''}
+    {ϕ : Homo A B} {ψ : Homo B C} where
+    -- Can this one be implemented using some kind of displayed section composition? Idk
+    _⋆Hᴰ_ : Homoᴰ ϕ Aᴰ Bᴰ → Homoᴰ ψ Bᴰ Cᴰ → Homoᴰ (_⋆H_ {C = C} ϕ ψ) Aᴰ Cᴰ
+    (ϕᴰ ⋆Hᴰ ψᴰ) .fst = λ a aᴰ → ψᴰ .fst (ϕ .fst a) (ϕᴰ .fst a aᴰ)
+    (ϕᴰ ⋆Hᴰ ψᴰ) .snd = λ op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ →
+                          ψᴰ .snd op (λ z → ϕ .fst (γ z)) (λ v → ϕᴰ .fst (γ v) (γᴰ v))
+                          (ϕ .fst op⟨γ⟩) (ϕ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩)
+                          (ϕᴰ .fst op⟨γ⟩ op⟨γᴰ⟩)
+                          (ϕᴰ .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩)
+
+  module _ {A : Algebra ℓ} {B : Algebra ℓ'}
+    {Aᴰ : Algebraᴰ A ℓᴰ} {Bᴰ : Algebraᴰ B ℓᴰ'}
+    {ϕ : Homo A B} where
+    ⋆HᴰIdL : (ϕᴰ : Homoᴰ ϕ Aᴰ Bᴰ) →
+      _⋆Hᴰ_ {A = A} {B = A} {C = B}
+        {Aᴰ = Aᴰ} {Bᴰ = Aᴰ} {Cᴰ = Bᴰ}
+        {ϕ = idHomo} {ψ = ϕ} idHomoᴰ ϕᴰ ≡ ϕᴰ
+    ⋆HᴰIdL ϕᴰ = refl
+
+    ⋆HᴰIdR : (ϕᴰ : Homoᴰ ϕ Aᴰ Bᴰ) →
+      _⋆Hᴰ_ {A = A} {B = B} {C = B}
+        {Aᴰ = Aᴰ} {Bᴰ = Bᴰ} {Cᴰ = Bᴰ}
+        {ϕ = ϕ} {ψ = idHomo} ϕᴰ idHomoᴰ ≡ ϕᴰ
+    ⋆HᴰIdR ϕᴰ = refl
+
+  module _ {A : Algebra ℓ} {B : Algebra ℓ'} {C : Algebra ℓ''}
+    {D : Algebra ℓE}
+    {Aᴰ : Algebraᴰ A ℓᴰ} {Bᴰ : Algebraᴰ B ℓᴰ'}
+    {Cᴰ : Algebraᴰ C ℓᴰ''} {Dᴰ : Algebraᴰ D ℓᴰᴰ}
+    {ϕ : Homo A B} {ψ : Homo B C} {χ : Homo C D} where
+    ⋆HᴰAssoc : (ϕᴰ : Homoᴰ ϕ Aᴰ Bᴰ) (ψᴰ : Homoᴰ ψ Bᴰ Cᴰ)
+      (χᴰ : Homoᴰ χ Cᴰ Dᴰ) →
+      _⋆Hᴰ_ {A = A} {B = C} {C = D}
+        {Aᴰ = Aᴰ} {Bᴰ = Cᴰ} {Cᴰ = Dᴰ}
+        {ϕ = _⋆H_ {C = C} ϕ ψ} {ψ = χ}
+        (_⋆Hᴰ_ {A = A} {B = B} {C = C}
+          {Aᴰ = Aᴰ} {Bᴰ = Bᴰ} {Cᴰ = Cᴰ} ϕᴰ ψᴰ)
+        χᴰ
+      ≡ _⋆Hᴰ_ {A = A} {B = B} {C = D}
+          {Aᴰ = Aᴰ} {Bᴰ = Bᴰ} {Cᴰ = Dᴰ}
+          {ϕ = ϕ} {ψ = _⋆H_ {C = D} ψ χ}
+          ϕᴰ
+          (_⋆Hᴰ_ {A = B} {B = C} {C = D}
+            {Aᴰ = Bᴰ} {Bᴰ = Cᴰ} {Cᴰ = Dᴰ} ψᴰ χᴰ)
+    ⋆HᴰAssoc ϕᴰ ψᴰ χᴰ = refl

--- a/Cubical/Algebra/State.agda
+++ b/Cubical/Algebra/State.agda
@@ -6,6 +6,7 @@ open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Equiv.Dependent
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
 open import Cubical.Foundations.More
 
 open import Cubical.Data.Bool as Bool
@@ -95,6 +96,29 @@ module _ {X : Type ℓ} {X' : Type ℓ'} {X'' : Type ℓ''}
   _⋆Homo_ : Homo (g ∘ f) B B''
   _⋆Homo_ .Homo.rd-hom xt xf rdxtf p = ψ.rd-hom (f xt) (f xf) (f rdxtf) (ϕ.rd-hom xt xf rdxtf p)
   _⋆Homo_ .Homo.wt-hom b x wtbx p = ψ.wt-hom b (f x) (f wtbx) (ϕ.wt-hom b x wtbx p)
+
+module _ {X : Type ℓ} {X' : Type ℓ'}
+  {B : StateAlg X} {B' : StateAlg X'} {f : X → X'} where
+  private
+    module B' = StateAlg B'
+
+  invHomo :
+    (ϕ : Homo f B B') (f⁻ : isIso f) →
+    Homo (f⁻ .fst) B' B
+  invHomo ϕ f⁻ .Homo.rd-hom xt xf rdxtxf p =
+    isoFunInjective (isIsoToIso f⁻) _ _ $
+      f⁻ .snd .fst rdxtxf
+      ∙ p
+      ∙ cong₂ B'.rd
+          (sym $ f⁻ .snd .fst xt)
+          (sym $ f⁻ .snd .fst xf)
+      ∙ sym (Homo.rd-hom' ϕ _ _)
+  invHomo ϕ f⁻ .Homo.wt-hom b x wtbx p =
+    isoFunInjective (isIsoToIso f⁻) _ _ $
+      f⁻ .snd .fst wtbx
+      ∙ p
+      ∙ cong (B'.wt b) (sym $ f⁻ .snd .fst x)
+      ∙ sym (Homo.wt-hom' ϕ _ _)
 
 record StateAlgᴰ {X : Type ℓ} (B : StateAlg X)
   (Xᴰ : X → Type ℓᴰ) : Type (ℓ-max ℓ ℓᴰ) where

--- a/Cubical/Algebra/Theory.agda
+++ b/Cubical/Algebra/Theory.agda
@@ -1,0 +1,391 @@
+module Cubical.Algebra.Theory where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv.Base
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.More
+open import Cubical.Data.Sigma
+
+variable
+  ℓ ℓᴰ ℓ' ℓᴰ' ℓ'' ℓᴰ'' ℓO ℓA ℓE : Level
+
+record Signature ℓO ℓA : Type (ℓ-max (ℓ-suc ℓO) (ℓ-suc ℓA)) where
+  field
+    Op : Type ℓO
+    Arity : Op → Type ℓA
+
+  AlgebraWithCarrier : (X : Type ℓ) → Type (ℓ-max (ℓ-max ℓO ℓA) ℓ)
+  AlgebraWithCarrier X = ∀ (f : Op) → (ρ : Arity f → X) → X
+
+  Algebra : ∀ ℓ → Type _
+  Algebra ℓ = Σ[ X ∈ Type ℓ ] AlgebraWithCarrier X
+
+  module _ (A : Algebra ℓ) where
+    -- Twist on the more obvious definition of displayed Algebra:
+    -- essentially build in a substitution here.
+    AlgebraᴰWithCarrier : (A .fst → Type ℓᴰ) → Type _
+    AlgebraᴰWithCarrier Xᴰ =
+      ∀ (f : Op) (ρ : Arity f → A .fst)
+        (ρᴰ : (v : Arity f) → Xᴰ (ρ v))
+        (f⟨ρ⟩ : A .fst) (f∘ρ≡f⟨ρ⟩ : A .snd f ρ ≡ f⟨ρ⟩)
+      → Xᴰ f⟨ρ⟩
+
+    -- this is the more obvious definition, which is basically "Yoneda Expanded"
+    AlgebraᴰWithCarrier' : (A .fst → Type ℓᴰ) → Type _
+    AlgebraᴰWithCarrier' Xᴰ =
+      ∀ (f : Op) (ρ : Arity f → A .fst)
+        (ρᴰ : (v : Arity f) → Xᴰ (ρ v))
+      → Xᴰ (A .snd f ρ)
+
+    AlgebraᴰWithCarrier'≃AlgebraᴰWithCarrier :
+      (Xᴰ : A .fst → Type ℓᴰ)
+      → AlgebraᴰWithCarrier' Xᴰ ≃ AlgebraᴰWithCarrier Xᴰ
+    AlgebraᴰWithCarrier'≃AlgebraᴰWithCarrier Xᴰ =
+      isoToEquiv (iso generalize specialize generalize-specialize specialize-generalize)
+      where
+      generalize : AlgebraᴰWithCarrier' Xᴰ → AlgebraᴰWithCarrier Xᴰ
+      generalize α f ρ ρᴰ f⟨ρ⟩ f∘ρ≡f⟨ρ⟩ =
+        J (λ f⟨ρ⟩ _ → Xᴰ f⟨ρ⟩) (α f ρ ρᴰ) f∘ρ≡f⟨ρ⟩
+
+      specialize : AlgebraᴰWithCarrier Xᴰ → AlgebraᴰWithCarrier' Xᴰ
+      specialize α f ρ ρᴰ = α f ρ ρᴰ (A .snd f ρ) refl
+
+      generalize-specialize : (d : AlgebraᴰWithCarrier Xᴰ)
+        → generalize (specialize d) ≡ d
+      generalize-specialize d =
+        funExt λ f → funExt λ ρ → funExt λ ρᴰ →
+          funExt λ f⟨ρ⟩ → funExt λ f∘ρ≡f⟨ρ⟩ →
+            J (λ f⟨ρ⟩ f∘ρ≡f⟨ρ⟩ →
+                generalize (specialize d) f ρ ρᴰ f⟨ρ⟩ f∘ρ≡f⟨ρ⟩
+                  ≡ d f ρ ρᴰ f⟨ρ⟩ f∘ρ≡f⟨ρ⟩)
+              (JRefl (λ f⟨ρ⟩ _ → Xᴰ f⟨ρ⟩)
+                (d f ρ ρᴰ (A .snd f ρ) refl))
+              f∘ρ≡f⟨ρ⟩
+
+      specialize-generalize : (d : AlgebraᴰWithCarrier' Xᴰ)
+        → specialize (generalize d) ≡ d
+      specialize-generalize d =
+        funExt λ f → funExt λ ρ → funExt λ ρᴰ →
+          JRefl (λ f⟨ρ⟩ _ → Xᴰ f⟨ρ⟩) (d f ρ ρᴰ)
+
+    Algebraᴰ : ∀ ℓᴰ → Type _
+    Algebraᴰ ℓᴰ = Σ[ Xᴰ ∈ (A .fst → Type ℓᴰ) ] AlgebraᴰWithCarrier Xᴰ
+
+  ∫Algebra : {A : Algebra ℓ} (Aᴰ : Algebraᴰ A ℓᴰ) → Algebra (ℓ-max ℓ ℓᴰ)
+  ∫Algebra Aᴰ .fst = Σ[ a ∈ _ ] Aᴰ .fst a
+  ∫Algebra {A = A} Aᴰ .snd f ρ .fst = A .snd f (λ z → ρ z .fst)
+  ∫Algebra Aᴰ .snd f ρ .snd = Aᴰ .snd _ _ (λ v → ρ v .snd) _ refl
+
+  record Section {A : Algebra ℓ}(Aᴰ : Algebraᴰ A ℓᴰ)
+    : Type (ℓ-max ℓ (ℓ-max ℓᴰ (ℓ-max ℓA ℓO))) where
+    eta-equality
+    field
+      fun : ∀ a → (Aᴰ .fst a)
+      homo : ∀ (f : Op)(γ : Arity f → A .fst) f⟨γ⟩
+        → (f∘γ≡f⟨γ⟩ : A .snd f γ ≡ f⟨γ⟩)
+        → Aᴰ .snd f γ (λ v → fun (γ v)) f⟨γ⟩ f∘γ≡f⟨γ⟩
+            ≡ fun f⟨γ⟩
+
+  wkAlg : (A : Algebra ℓ) (B : Algebra ℓ') → Algebraᴰ A ℓ'
+  wkAlg A B .fst _ = B .fst
+  wkAlg A B .snd f _ ρ _ _ = B .snd f ρ
+
+  Homo : (A : Algebra ℓ) (B : Algebra ℓ') → Type _
+  Homo A B = Section (wkAlg A B)
+
+  idHomo : {A : Algebra ℓ} → Homo A A
+  idHomo .Section.fun = λ a → a
+  idHomo .Section.homo f γ f⟨γ⟩ pf = pf
+
+  module _ {A : Algebra ℓ}{B : Algebra ℓ'} where
+    _*_ : Homo A B → Algebraᴰ B ℓᴰ → Algebraᴰ A ℓᴰ
+    (ϕ * Bᴰ) .fst a = Bᴰ .fst (ϕ .Section.fun a)
+    (ϕ * Bᴰ) .snd f ρ ρᴰ f⟨ρ⟩ f∘ρ≡f⟨ρ⟩ =
+      Bᴰ .snd f (λ z → ϕ .Section.fun (ρ z)) ρᴰ
+        (ϕ .Section.fun f⟨ρ⟩)
+        (ϕ .Section.homo f ρ f⟨ρ⟩ f∘ρ≡f⟨ρ⟩)
+
+    module _ {Bᴰ : Algebraᴰ B ℓᴰ} where
+      _⋆HS_ : (ϕ : Homo A B) → Section Bᴰ → Section (ϕ * Bᴰ)
+      (ϕ ⋆HS Ψ) .Section.fun = λ a → Ψ .Section.fun (ϕ .Section.fun a)
+      (ϕ ⋆HS Ψ) .Section.homo f γ f⟨γ⟩ f∘γ≡f⟨γ⟩ =
+        Ψ .Section.homo f (λ v → ϕ .Section.fun (γ v))
+          (ϕ .Section.fun f⟨γ⟩)
+          (ϕ .Section.homo f γ f⟨γ⟩ f∘γ≡f⟨γ⟩)
+
+    module _ {C : Algebra ℓE} where
+      _⋆H_ : Homo A B → Homo B C → Homo A C
+      ϕ ⋆H Ψ = ϕ ⋆HS Ψ
+
+  module _ {A : Algebra ℓ}{B : Algebra ℓ'} where
+    ⋆HIdR : (ϕ : Homo A B) → ϕ ⋆H idHomo ≡ ϕ
+    ⋆HIdR ϕ = refl
+  module _ {A : Algebra ℓ}{Aᴰ : Algebraᴰ A ℓᴰ} where
+    ⋆HSIdL : (Ψ : Section Aᴰ) → idHomo ⋆HS Ψ ≡ Ψ
+    ⋆HSIdL Ψ = refl
+  module _ {A : Algebra ℓ}{B : Algebra ℓ'}{C : Algebra ℓ''}{Cᴰ : Algebraᴰ C ℓᴰ''} where
+    ⋆HHSAssoc : (ϕ : Homo A B)(ψ : Homo B C)(χ : Section Cᴰ)
+      → (ϕ ⋆H ψ) ⋆HS χ ≡ ϕ ⋆HS (ψ ⋆HS χ)
+    ⋆HHSAssoc ϕ ψ χ = refl
+
+  -- Free Algebras
+  data |FreeAlg| (V : Type ℓ) : Type (ℓ-max (ℓ-max ℓ ℓO) ℓA) where
+    var : V → |FreeAlg| V
+    op : ∀ (f : Op) → (γ : Arity f → |FreeAlg| V) → |FreeAlg| V
+
+  TmAlg : (V : Type ℓ) → Algebra (ℓ-max (ℓ-max ℓO ℓA) ℓ)
+  TmAlg V .fst = |FreeAlg| V
+  TmAlg V .snd = op
+
+  module _ {V : Type ℓ} (Bᴰ : Algebraᴰ (TmAlg V) ℓᴰ) (ı : ∀ (v : V) → Bᴰ .fst (var v)) where
+    elimFreeAlgfun : ∀ (M : |FreeAlg| V) → Bᴰ .fst M
+    elimFreeAlgfun (var x) = ı x
+    elimFreeAlgfun (op f γ) =
+      Bᴰ .snd f γ (λ x → elimFreeAlgfun (γ x)) (op f γ) refl
+
+    elimFreeAlg : Section Bᴰ
+    elimFreeAlg .Section.fun = elimFreeAlgfun
+    elimFreeAlg .Section.homo f γ f⟨γ⟩ f∘γ≡f⟨γ⟩ =
+      J (λ f⟨γ⟩ f∘γ≡f⟨γ⟩ →
+          Bᴰ .snd f γ (λ v → elimFreeAlgfun (γ v))
+              f⟨γ⟩ f∘γ≡f⟨γ⟩
+            ≡ elimFreeAlgfun f⟨γ⟩)
+        refl f∘γ≡f⟨γ⟩
+
+record Theory ℓO ℓA ℓO' ℓA' :
+  Type (ℓ-max (ℓ-max (ℓ-suc ℓO) (ℓ-suc ℓA))
+              (ℓ-max (ℓ-suc ℓO') (ℓ-suc ℓA'))) where
+  field
+    S : Signature ℓO ℓA
+  open Signature S public hiding (Section; _*_)
+  field
+    Eq : Type ℓO'
+    EqArity : Eq → Type ℓA'
+    lhs rhs : ∀ (e : Eq) → |FreeAlg| (EqArity e)
+
+  interp : (A : Algebra ℓ) {V : Type ℓ'} → (V → A .fst) → |FreeAlg| V → A .fst
+  interp A ρ (var v) = ρ v
+  interp A ρ (op f γ) = A .snd f (λ v → interp A ρ (γ v))
+
+  IsModel : Algebra ℓ → Type _
+  IsModel A = ∀ e (ρ : EqArity e → A .fst)
+    → interp A ρ (lhs e) ≡ interp A ρ (rhs e)
+
+  Model : ∀ ℓ → Type _
+  Model ℓ = Σ[ A ∈ Algebra ℓ ]
+    Σ[ _ ∈ IsModel A ] isSet (A .fst)
+
+  interpᴰ : {A : Algebra ℓ} (Aᴰ : Algebraᴰ A ℓᴰ)
+    {V : Type ℓ'} (ρ : V → A .fst)
+    (ρᴰ : (v : V) → Aᴰ .fst (ρ v)) (t : |FreeAlg| V)
+    → Aᴰ .fst (interp A ρ t)
+  interpᴰ Aᴰ ρ ρᴰ (var v) = ρᴰ v
+  interpᴰ {A = A} Aᴰ ρ ρᴰ (op f γ) =
+    Aᴰ .snd f
+      (λ v → interp A ρ (γ v))
+      (λ v → interpᴰ Aᴰ ρ ρᴰ (γ v))
+      (A .snd f (λ v → interp A ρ (γ v))) refl
+
+  Algebraᴰ-op-filler : {A : Algebra ℓ} (Aᴰ : Algebraᴰ A ℓᴰ)
+    (f : Op) (rho : Arity f → A .fst)
+    (rhoᴰ : (v : Arity f) → Aᴰ .fst (rho v))
+    (f⟨rho⟩ : A .fst) (f∘rho≡f⟨rho⟩ : A .snd f rho ≡ f⟨rho⟩)
+    → Path (∫Algebra Aᴰ .fst)
+        ( A .snd f rho
+        , Aᴰ .snd f rho rhoᴰ (A .snd f rho) refl)
+        ( f⟨rho⟩
+        , Aᴰ .snd f rho rhoᴰ f⟨rho⟩ f∘rho≡f⟨rho⟩)
+  Algebraᴰ-op-filler {A = A} Aᴰ f rho rhoᴰ f⟨rho⟩ f∘rho≡f⟨rho⟩ =
+    J (λ f⟨rho⟩ f∘rho≡f⟨rho⟩ →
+        Path (∫Algebra Aᴰ .fst)
+          ( A .snd f rho
+          , Aᴰ .snd f rho rhoᴰ (A .snd f rho) refl)
+          ( f⟨rho⟩
+          , Aᴰ .snd f rho rhoᴰ f⟨rho⟩ f∘rho≡f⟨rho⟩))
+      refl f∘rho≡f⟨rho⟩
+
+  interpPullback : {A : Algebra ℓ} {B : Algebra ℓ'}
+    (phi : Homo A B) (Bᴰ : Algebraᴰ B ℓᴰ)
+    {V : Type ℓ''} (rho : V → A .fst)
+    (rhoᴰ : (v : V) → Bᴰ .fst (phi .Signature.Section.fun (rho v)))
+    (t : |FreeAlg| V)
+    → Path (∫Algebra Bᴰ .fst)
+        ( interp B (λ v → phi .Signature.Section.fun (rho v)) t
+        , interpᴰ Bᴰ (λ v → phi .Signature.Section.fun (rho v)) rhoᴰ t)
+        ( phi .Signature.Section.fun (interp A rho t)
+        , interpᴰ (Signature._*_ S phi Bᴰ) rho rhoᴰ t)
+  interpPullback phi Bᴰ rho rhoᴰ (var v) = refl
+  interpPullback {A = A} phi Bᴰ rho rhoᴰ (op f gamma) =
+    cong (∫Algebra Bᴰ .snd f)
+      (funExt λ v → interpPullback phi Bᴰ rho rhoᴰ (gamma v))
+    ∙ Algebraᴰ-op-filler Bᴰ f
+        (λ v → phi .Signature.Section.fun (interp A rho (gamma v)))
+        (λ v →
+          interpᴰ (Signature._*_ S phi Bᴰ) rho rhoᴰ (gamma v))
+        (phi .Signature.Section.fun (A .snd f (λ v → interp A rho (gamma v))))
+        (phi .Signature.Section.homo f
+          (λ v → interp A rho (gamma v))
+          (A .snd f (λ v → interp A rho (gamma v))) refl)
+
+  IsModelᴰ : (M : Model ℓ) → Algebraᴰ (M .fst) ℓᴰ → Type _
+  IsModelᴰ M Aᴰ =
+    ∀ e (ρ : EqArity e → M .fst .fst)
+      (ρᴰ : (v : EqArity e) → Aᴰ .fst (ρ v))
+    → PathP (λ i → Aᴰ .fst (M .snd .fst e ρ i))
+        (interpᴰ Aᴰ ρ ρᴰ (lhs e))
+        (interpᴰ Aᴰ ρ ρᴰ (rhs e))
+
+  Modelᴰ : Model ℓ → ∀ ℓᴰ → Type _
+  Modelᴰ M ℓᴰ = Σ[ Aᴰ ∈ Algebraᴰ (M .fst) ℓᴰ ]
+    Σ[ _ ∈ IsModelᴰ M Aᴰ ] ((a : M .fst .fst) → isSet (Aᴰ .fst a))
+
+  interp∫ : {A : Algebra ℓ} {Aᴰ : Algebraᴰ A ℓᴰ}
+    {V : Type ℓ'} (ρ : V → ∫Algebra Aᴰ .fst) (t : |FreeAlg| V)
+    → interp (∫Algebra Aᴰ) ρ t ≡
+      ( interp A (λ v → ρ v .fst) t
+      , interpᴰ Aᴰ (λ v → ρ v .fst) (λ v → ρ v .snd) t)
+  interp∫ ρ (var v) = refl
+  interp∫ {Aᴰ = Aᴰ} ρ (op f γ) =
+    cong (∫Algebra Aᴰ .snd f) (funExt λ v → interp∫ ρ (γ v))
+
+  ∫Model : {M : Model ℓ} → Modelᴰ M ℓᴰ → Model (ℓ-max ℓ ℓᴰ)
+  ∫Model Mᴰ .fst = ∫Algebra (Mᴰ .fst)
+  ∫Model {M = M} Mᴰ .snd .fst e ρ =
+    interp∫ ρ (lhs e)
+    ∙ ΣPathP
+        ( M .snd .fst e (λ v → ρ v .fst)
+        , Mᴰ .snd .fst e (λ v → ρ v .fst) (λ v → ρ v .snd))
+    ∙ sym (interp∫ ρ (rhs e))
+  ∫Model {M = M} Mᴰ .snd .snd =
+    isSetΣ (M .snd .snd) (Mᴰ .snd .snd)
+
+  interpᴰwk : (M : Model ℓ) (N : Model ℓ') {V : Type ℓ''}
+    (ρ : V → M .fst .fst) (ρᴰ : V → N .fst .fst) (t : |FreeAlg| V)
+    → interpᴰ (wkAlg (M .fst) (N .fst)) ρ ρᴰ t ≡ interp (N .fst) ρᴰ t
+  interpᴰwk M N ρ ρᴰ (var v) = refl
+  interpᴰwk M N ρ ρᴰ (op f γ) =
+    cong (N .fst .snd f) (funExt λ v → interpᴰwk M N ρ ρᴰ (γ v))
+
+  wkModel : (M : Model ℓ) (N : Model ℓ') → Modelᴰ M ℓ'
+  wkModel M N .fst = wkAlg (M .fst) (N .fst)
+  wkModel M N .snd .fst e ρ ρᴰ =
+    interpᴰwk M N ρ ρᴰ (lhs e)
+    ∙ N .snd .fst e ρᴰ
+    ∙ sym (interpᴰwk M N ρ ρᴰ (rhs e))
+  wkModel M N .snd .snd _ = N .snd .snd
+
+  module _ {M : Model ℓ} {N : Model ℓ'} where
+    _*_ : Homo (M .fst) (N .fst) → Modelᴰ N ℓᴰ → Modelᴰ M ℓᴰ
+    (phi * Nᴰ) .fst = Signature._*_ S phi (Nᴰ .fst)
+    (phi * Nᴰ) .snd .fst e rho rhoᴰ =
+      hSetReasoning.rectifyOut
+        (N .fst .fst , N .snd .snd) (Nᴰ .fst .fst)
+        ( sym (interpPullback phi (Nᴰ .fst) rho rhoᴰ (lhs e))
+          ∙ ΣPathP
+              ( N .snd .fst e
+                  (λ v → phi .Signature.Section.fun (rho v))
+              , Nᴰ .snd .fst e
+                  (λ v → phi .Signature.Section.fun (rho v)) rhoᴰ)
+          ∙ interpPullback phi (Nᴰ .fst) rho rhoᴰ (rhs e))
+    (phi * Nᴰ) .snd .snd a =
+      Nᴰ .snd .snd (phi .Signature.Section.fun a)
+
+  -- Free Models
+  module _ (V : Type ℓ) where
+    data |FreeModel| :
+      Type (ℓ-max (ℓ-max (ℓ-max ℓ ℓO) ℓA) (ℓ-max ℓO' ℓA')) where
+      var : V → |FreeModel|
+      op : ∀ (f : Op) → (γ : Arity f → |FreeModel|) → |FreeModel|
+      freeAlg : ∀ e → |FreeAlg| (EqArity e) → (EqArity e → |FreeModel|) → |FreeModel|
+      freeAlgEqn : ∀ e → (γ : EqArity e → |FreeModel|)
+        → freeAlg e (lhs e) γ ≡ freeAlg e (rhs e) γ
+      freeAlg-var : ∀ e v (γ : EqArity e → |FreeModel|) → γ v ≡ freeAlg e (var v) γ
+      freeAlg-op  : ∀ e f ρ (γ : EqArity e → |FreeModel|)
+        → op f (λ x → freeAlg e (ρ x) γ) ≡ freeAlg e (op f ρ) γ
+      isSetFreeModel : isSet |FreeModel|
+
+    interpFreeAlg : ∀ e (t : |FreeAlg| (EqArity e))
+      (ρ : EqArity e → |FreeModel|)
+      → interp (|FreeModel| , |FreeModel|.op) ρ t ≡ freeAlg e t ρ
+    interpFreeAlg e (|FreeAlg|.var v) ρ = freeAlg-var e v ρ
+    interpFreeAlg e (|FreeAlg|.op f γ) ρ =
+      cong (|FreeModel|.op f) (funExt λ v → interpFreeAlg e (γ v) ρ)
+      ∙ freeAlg-op e f γ ρ
+
+    FreeModel :
+      Model (ℓ-max (ℓ-max (ℓ-max ℓ ℓO) ℓA) (ℓ-max ℓO' ℓA'))
+    FreeModel .fst .fst = |FreeModel|
+    FreeModel .fst .snd = |FreeModel|.op
+    FreeModel .snd .fst e ρ =
+      interpFreeAlg e (lhs e) ρ
+      ∙ freeAlgEqn e ρ
+      ∙ sym (interpFreeAlg e (rhs e) ρ)
+    FreeModel .snd .snd = isSetFreeModel
+
+    module _ (Bᴰ : Modelᴰ FreeModel ℓᴰ)
+      (ı : (v : V) → Bᴰ .fst .fst (|FreeModel|.var v)) where
+      private
+        module BᴰReasoning =
+          hSetReasoning (|FreeModel| , isSetFreeModel) (Bᴰ .fst .fst)
+
+      freeAlgᴰ : ∀ e (t : |FreeAlg| (EqArity e))
+        (ρ : EqArity e → |FreeModel|)
+        (ρᴰ : (v : EqArity e) → Bᴰ .fst .fst (ρ v))
+        → Bᴰ .fst .fst (freeAlg e t ρ)
+      freeAlgᴰ e t ρ ρᴰ =
+        BᴰReasoning.reind (interpFreeAlg e t ρ)
+          (interpᴰ (Bᴰ .fst) ρ ρᴰ t)
+
+      freeAlgᴰ-filler : ∀ e (t : |FreeAlg| (EqArity e))
+        (ρ : EqArity e → |FreeModel|)
+        (ρᴰ : (v : EqArity e) → Bᴰ .fst .fst (ρ v))
+        → Path (∫Algebra (Bᴰ .fst) .fst)
+            ( interp (FreeModel .fst) ρ t
+            , interpᴰ (Bᴰ .fst) ρ ρᴰ t)
+            (freeAlg e t ρ , freeAlgᴰ e t ρ ρᴰ)
+      freeAlgᴰ-filler e t ρ ρᴰ =
+        BᴰReasoning.reind-filler (interpFreeAlg e t ρ)
+
+      elimFreeModelfun : (x : |FreeModel|) → Bᴰ .fst .fst x
+      elimFreeModelfun (|FreeModel|.var v) = ı v
+      elimFreeModelfun (|FreeModel|.op f γ) =
+        Bᴰ .fst .snd f γ (λ v → elimFreeModelfun (γ v))
+          (|FreeModel|.op f γ) refl
+      elimFreeModelfun (freeAlg e t ρ) =
+        freeAlgᴰ e t ρ (λ v → elimFreeModelfun (ρ v))
+      elimFreeModelfun (freeAlgEqn e ρ i) =
+        BᴰReasoning.rectifyOut {e' = freeAlgEqn e ρ}
+          ( sym (freeAlgᴰ-filler e (lhs e) ρ
+              (λ v → elimFreeModelfun (ρ v)))
+            ∙ BᴰReasoning.≡in
+                (Bᴰ .snd .fst e ρ (λ v → elimFreeModelfun (ρ v)))
+            ∙ freeAlgᴰ-filler e (rhs e) ρ
+                (λ v → elimFreeModelfun (ρ v))) i
+      elimFreeModelfun (freeAlg-var e v ρ i) =
+        BᴰReasoning.rectifyOut {e' = freeAlg-var e v ρ}
+          (freeAlgᴰ-filler e (|FreeAlg|.var v) ρ
+            (λ x → elimFreeModelfun (ρ x))) i
+      elimFreeModelfun (freeAlg-op e f σ ρ i) =
+        BᴰReasoning.rectifyOut {e' = freeAlg-op e f σ ρ}
+          ( sym
+              (cong (∫Algebra (Bᴰ .fst) .snd f)
+                (funExt λ v →
+                  freeAlgᴰ-filler e (σ v) ρ
+                    (λ x → elimFreeModelfun (ρ x))))
+            ∙ freeAlgᴰ-filler e (|FreeAlg|.op f σ) ρ
+                (λ x → elimFreeModelfun (ρ x))) i
+      elimFreeModelfun (isSetFreeModel x y p q i j) =
+        isSet→isSetDep (Bᴰ .snd .snd)
+          (elimFreeModelfun x) (elimFreeModelfun y)
+          (cong elimFreeModelfun p) (cong elimFreeModelfun q)
+          (isSetFreeModel x y p q) i j
+
+      elimFreeModel : Signature.Section S (Bᴰ .fst)
+      elimFreeModel .Signature.Section.fun = elimFreeModelfun
+      elimFreeModel .Signature.Section.homo f γ f⟨γ⟩ f∘γ≡f⟨γ⟩ =
+        J (λ f⟨γ⟩ f∘γ≡f⟨γ⟩ →
+            Bᴰ .fst .snd f γ (λ v → elimFreeModelfun (γ v))
+                f⟨γ⟩ f∘γ≡f⟨γ⟩
+              ≡ elimFreeModelfun f⟨γ⟩)
+          refl f∘γ≡f⟨γ⟩

--- a/Cubical/Algebra/Theory/Base.agda
+++ b/Cubical/Algebra/Theory/Base.agda
@@ -1,0 +1,797 @@
+module Cubical.Algebra.Theory.Base where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.More
+open import Cubical.Foundations.HLevels.More
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit
+
+open import Cubical.Algebra.Signature.Base public
+
+variable
+  ℓ ℓᴰ ℓᴰᴰ ℓ' ℓᴰ' ℓᴰᴰ' ℓ'' ℓᴰ'' ℓO ℓA ℓE : Level
+
+record Theory ℓO ℓA ℓO' ℓA' :
+  Type (ℓ-max (ℓ-max (ℓ-suc ℓO) (ℓ-suc ℓA))
+              (ℓ-max (ℓ-suc ℓO') (ℓ-suc ℓA'))) where
+  field
+    S : Signature ℓO ℓA
+  module S = Signature S
+  open Signature S public
+    hiding (_*_; *Id; *∘)
+  field
+    Eq : Type ℓO'
+    EqArity : Eq → Type ℓA'
+    lhs rhs : ∀ (e : Eq) → |FreeAlgebra| (EqArity e)
+
+  IsModel : Algebra ℓ → Type _
+  IsModel A = ∀ e (γ : EqArity e → A .fst)
+    → recFA A γ .fst (lhs e) ≡ recFA A γ .fst (rhs e)
+
+  Model : ∀ ℓ → Type _
+  Model ℓ = Σ[ A ∈ Algebra ℓ ]
+    Σ[ _ ∈ IsModel A ] isSet (A .fst)
+
+  ⊤Model : Model ℓ-zero
+  ⊤Model .fst = Unit , ⊤Algebra
+  ⊤Model .snd .fst e ρ = refl
+  ⊤Model .snd .snd = isSetUnit
+
+  ⊤*Model : Model ℓ
+  ⊤*Model .fst = Unit* , ⊤*Algebra
+  ⊤*Model .snd .fst e ρ = refl
+  ⊤*Model .snd .snd = isSetUnit*
+
+  interp : (A : Algebra ℓ) {V : Type ℓ'}
+    → (V → A .fst) → |FreeAlgebra| V → A .fst
+  interp A ρ = recFA A ρ .fst
+
+  interpᴰ : {A : Algebra ℓ} (Aᴰ : Algebraᴰ A ℓᴰ)
+    {V : Type ℓ'} (ρ : V → A .fst)
+    (ρᴰ : (v : V) → Aᴰ .fst (ρ v)) (t : |FreeAlgebra| V)
+    → Aᴰ .fst (interp A ρ t)
+  interpᴰ {A = A} Aᴰ ρ ρᴰ =
+    elimFA (recFA A ρ S.* Aᴰ) ρᴰ .fst
+
+  Algebraᴰ-op-filler : {A : Algebra ℓ} (Aᴰ : Algebraᴰ A ℓᴰ)
+    (f : Op) (ρ : Arity f → A .fst)
+    (ρᴰ : (v : Arity f) → Aᴰ .fst (ρ v))
+    (f⟨ρ⟩ : A .fst) (f∘ρ≡f⟨ρ⟩ : A .snd f ρ ≡ f⟨ρ⟩)
+    → Path (∫Algebra Aᴰ .fst)
+        ( A .snd f ρ
+        , Aᴰ .snd f ρ ρᴰ (A .snd f ρ) refl)
+        ( f⟨ρ⟩
+        , Aᴰ .snd f ρ ρᴰ f⟨ρ⟩ f∘ρ≡f⟨ρ⟩)
+  Algebraᴰ-op-filler {A = A} Aᴰ f ρ ρᴰ f⟨ρ⟩ f∘ρ≡f⟨ρ⟩ =
+    J (λ f⟨ρ⟩ f∘ρ≡f⟨ρ⟩ →
+        Path (∫Algebra Aᴰ .fst)
+          ( A .snd f ρ
+          , Aᴰ .snd f ρ ρᴰ (A .snd f ρ) refl)
+          ( f⟨ρ⟩
+          , Aᴰ .snd f ρ ρᴰ f⟨ρ⟩ f∘ρ≡f⟨ρ⟩))
+      refl f∘ρ≡f⟨ρ⟩
+
+  interpPullback : {A : Algebra ℓ} {B : Algebra ℓ'}
+    (ϕ : S.Homo A B) (Bᴰ : Algebraᴰ B ℓᴰ)
+    {V : Type ℓ''} (ρ : V → A .fst)
+    (ρᴰ : (v : V) → Bᴰ .fst (ϕ .fst (ρ v)))
+    (t : |FreeAlgebra| V)
+    → Path (∫Algebra Bᴰ .fst)
+        ( interp B (λ v → ϕ .fst (ρ v)) t
+        , interpᴰ Bᴰ (λ v → ϕ .fst (ρ v)) ρᴰ t)
+        ( ϕ .fst (interp A ρ t)
+        , interpᴰ (ϕ S.* Bᴰ) ρ ρᴰ t)
+  interpPullback ϕ Bᴰ ρ ρᴰ (var v) = refl
+  interpPullback {A = A} {B = B} ϕ Bᴰ ρ ρᴰ (app f γ) =
+    sym
+      (Algebraᴰ-op-filler Bᴰ f
+        (λ v → interp B (λ x → ϕ .fst (ρ x)) (γ v))
+        (λ v → interpᴰ Bᴰ (λ x → ϕ .fst (ρ x)) ρᴰ (γ v))
+        (interp B (λ x → ϕ .fst (ρ x)) (app f γ))
+        (recFA B (λ x → ϕ .fst (ρ x)) .snd f γ
+          (app f γ) refl))
+    ∙ cong (∫Algebra Bᴰ .snd f)
+      (funExt λ v → interpPullback ϕ Bᴰ ρ ρᴰ (γ v))
+    ∙ Algebraᴰ-op-filler Bᴰ f
+        (λ v → ϕ .fst (interp A ρ (γ v)))
+        (λ v →
+          interpᴰ (ϕ S.* Bᴰ) ρ ρᴰ (γ v))
+        (ϕ .fst (interp A ρ (app f γ)))
+        (ϕ .snd f
+          (λ v → interp A ρ (γ v))
+          (interp A ρ (app f γ))
+          (recFA A ρ .snd f γ (app f γ) refl))
+
+  interpHomo : {A : Algebra ℓ} {B : Algebra ℓ'}
+    (ϕ : S.Homo A B) {V : Type ℓ''}
+    (ρ : V → A .fst) (t : |FreeAlgebra| V)
+    → interp B (λ v → ϕ .fst (ρ v)) t ≡ ϕ .fst (interp A ρ t)
+  interpHomo ϕ ρ (var v) = refl
+  interpHomo {A = A} {B = B} ϕ ρ (app f γ) =
+    sym
+      (recFA B (λ v → ϕ .fst (ρ v)) .snd f γ
+        (app f γ) refl)
+    ∙ cong (B .snd f) (funExt λ v → interpHomo ϕ ρ (γ v))
+    ∙ ϕ .snd f
+        (λ v → interp A ρ (γ v))
+        (interp A ρ (app f γ))
+        (recFA A ρ .snd f γ (app f γ) refl)
+
+  IsModelᴰ : (M : Model ℓ) → Algebraᴰ (M .fst) ℓᴰ → Type _
+  IsModelᴰ M Aᴰ =
+    ∀ e (ρ : EqArity e → M .fst .fst)
+      (ρᴰ : (v : EqArity e) → Aᴰ .fst (ρ v))
+    → PathP (λ i → Aᴰ .fst (M .snd .fst e ρ i))
+        (interpᴰ Aᴰ ρ ρᴰ (lhs e))
+        (interpᴰ Aᴰ ρ ρᴰ (rhs e))
+
+  ModelᴰWithCarrier : (M : Model ℓ)
+    → (M .fst .fst → Type ℓᴰ) → Type _
+  ModelᴰWithCarrier M Xᴰ =
+    Σ[ αᴰ ∈ AlgebraᴰWithCarrier (M .fst) Xᴰ ]
+      IsModelᴰ M (Xᴰ , αᴰ)
+
+  Modelᴰ : Model ℓ → ∀ ℓᴰ → Type _
+  Modelᴰ M ℓᴰ = Σ[ Aᴰ ∈ Algebraᴰ (M .fst) ℓᴰ ]
+    Σ[ _ ∈ IsModelᴰ M Aᴰ ]
+      ((a : M .fst .fst) → isSet (Aᴰ .fst a))
+
+  isPropModelᴰStructure : (M : Model ℓ) (Aᴰ : Algebraᴰ (M .fst) ℓᴰ)
+    → isProp
+        (Σ[ _ ∈ IsModelᴰ M Aᴰ ]
+          ((a : M .fst .fst) → isSet (Aᴰ .fst a)))
+  isPropModelᴰStructure M Aᴰ (p , pSet) (q , qSet) i .fst e ρ ρᴰ =
+    isOfHLevelPathP' 1 (pSet _) _ _ (p e ρ ρᴰ) (q e ρ ρᴰ) i
+  isPropModelᴰStructure M Aᴰ (p , pSet) (q , qSet) i .snd =
+    isPropΠ (λ _ → isPropIsSet) pSet qSet i
+
+  Modelᴰ≡ : {M : Model ℓ} {Mᴰ Nᴰ : Modelᴰ M ℓᴰ}
+    → Mᴰ .fst ≡ Nᴰ .fst → Mᴰ ≡ Nᴰ
+  Modelᴰ≡ {M = M} = Σ≡Prop (isPropModelᴰStructure M)
+
+  interp∫ : {A : Algebra ℓ} {Aᴰ : Algebraᴰ A ℓᴰ}
+    {V : Type ℓ'} (ρ : V → ∫Algebra Aᴰ .fst) (t : |FreeAlgebra| V)
+    → interp (∫Algebra Aᴰ) ρ t ≡
+      ( interp A (λ v → ρ v .fst) t
+      , interpᴰ Aᴰ (λ v → ρ v .fst) (λ v → ρ v .snd) t)
+  interp∫ ρ (var v) = refl
+  interp∫ {A = A} {Aᴰ = Aᴰ} ρ (app f γ) =
+    sym
+      (recFA (∫Algebra Aᴰ) ρ .snd f γ (app f γ) refl)
+    ∙ cong (∫Algebra Aᴰ .snd f)
+        (funExt λ v → interp∫ {A = A} {Aᴰ = Aᴰ} ρ (γ v))
+    ∙ Algebraᴰ-op-filler Aᴰ f
+        (λ v → interp A (λ x → ρ x .fst) (γ v))
+        (λ v →
+          interpᴰ Aᴰ (λ x → ρ x .fst) (λ x → ρ x .snd) (γ v))
+        (interp A (λ x → ρ x .fst) (app f γ))
+        (recFA A (λ x → ρ x .fst) .snd f γ
+          (app f γ) refl)
+
+  ∫Model : {M : Model ℓ} → Modelᴰ M ℓᴰ → Model (ℓ-max ℓ ℓᴰ)
+  ∫Model Mᴰ .fst = ∫Algebra (Mᴰ .fst)
+  ∫Model {M = M} Mᴰ .snd .fst e ρ =
+    interp∫ {A = M .fst} {Aᴰ = Mᴰ .fst} ρ (lhs e)
+    ∙ ΣPathP
+        ( M .snd .fst e (λ v → ρ v .fst)
+        , Mᴰ .snd .fst e (λ v → ρ v .fst) (λ v → ρ v .snd))
+    ∙ sym (interp∫ {A = M .fst} {Aᴰ = Mᴰ .fst} ρ (rhs e))
+  ∫Model {M = M} Mᴰ .snd .snd =
+    isSetΣ (M .snd .snd) (Mᴰ .snd .snd)
+
+  module _ {M : Model ℓ} where
+    Modelᴰᴰ : (Mᴰ : Modelᴰ M ℓᴰ) → ∀ ℓᴰᴰ → Type _
+    Modelᴰᴰ Mᴰ ℓᴰᴰ = Modelᴰ (∫Model {M = M} Mᴰ) ℓᴰᴰ
+
+    ∫ᴰModel-assoc : {Mᴰ : Modelᴰ M ℓᴰ}
+      (Mᴰᴰ : Modelᴰᴰ Mᴰ ℓᴰᴰ)
+      → ∫Algebra (Mᴰᴰ .fst) .fst
+      → ∫Algebra
+          (S.∫ᴰAlgebra {A = M .fst} {Aᴰ = Mᴰ .fst} (Mᴰᴰ .fst)) .fst
+    ∫ᴰModel-assoc {Mᴰ = Mᴰ} Mᴰᴰ z .fst = z .fst .fst
+    ∫ᴰModel-assoc {Mᴰ = Mᴰ} Mᴰᴰ z .snd .fst = z .fst .snd
+    ∫ᴰModel-assoc {Mᴰ = Mᴰ} Mᴰᴰ z .snd .snd = z .snd
+
+    ∫ᴰModel-assocHomo : {Mᴰ : Modelᴰ M ℓᴰ}
+      (Mᴰᴰ : Modelᴰᴰ Mᴰ ℓᴰᴰ)
+      → S.Homo
+          (∫Algebra (Mᴰᴰ .fst))
+          (∫Algebra
+            (S.∫ᴰAlgebra {A = M .fst} {Aᴰ = Mᴰ .fst} (Mᴰᴰ .fst)))
+    ∫ᴰModel-assocHomo {Mᴰ = Mᴰ} Mᴰᴰ .fst =
+      ∫ᴰModel-assoc {Mᴰ = Mᴰ} Mᴰᴰ
+    ∫ᴰModel-assocHomo {Mᴰ = Mᴰ} Mᴰᴰ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ i .fst =
+      op∘γ≡op⟨γ⟩ i .fst .fst
+    ∫ᴰModel-assocHomo {Mᴰ = Mᴰ} Mᴰᴰ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ i .snd .fst =
+      op∘γ≡op⟨γ⟩ i .fst .snd
+    ∫ᴰModel-assocHomo {Mᴰ = Mᴰ} Mᴰᴰ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ i .snd .snd =
+      op∘γ≡op⟨γ⟩ i .snd
+
+    ∫ᴰModel : {Mᴰ : Modelᴰ M ℓᴰ}
+      → Modelᴰᴰ Mᴰ ℓᴰᴰ → Modelᴰ M (ℓ-max ℓᴰ ℓᴰᴰ)
+    ∫ᴰModel {Mᴰ = Mᴰ} Mᴰᴰ .fst =
+      S.∫ᴰAlgebra {A = M .fst} {Aᴰ = Mᴰ .fst} (Mᴰᴰ .fst)
+    ∫ᴰModel {Mᴰ = Mᴰ} Mᴰᴰ .snd .fst e ρ ρᴰ =
+      hSetReasoning.rectifyOut
+        (M .fst .fst , M .snd .snd)
+        (S.∫ᴰAlgebra {A = M .fst} {Aᴰ = Mᴰ .fst} (Mᴰᴰ .fst) .fst)
+        ( sym
+            (interp∫
+              {A = M .fst}
+              {Aᴰ = S.∫ᴰAlgebra
+                {A = M .fst} {Aᴰ = Mᴰ .fst} (Mᴰᴰ .fst)}
+              (λ v → ρ v , ρᴰ v) (lhs e))
+        ∙ interpHomo
+            (∫ᴰModel-assocHomo {Mᴰ = Mᴰ} Mᴰᴰ)
+            (λ v → (ρ v , ρᴰ v .fst) , ρᴰ v .snd)
+            (lhs e)
+        ∙ cong (∫ᴰModel-assoc {Mᴰ = Mᴰ} Mᴰᴰ)
+            (∫Model
+              {M = ∫Model {M = M} Mᴰ} Mᴰᴰ .snd .fst e
+              (λ v → (ρ v , ρᴰ v .fst) , ρᴰ v .snd))
+        ∙ sym
+            (interpHomo
+              (∫ᴰModel-assocHomo {Mᴰ = Mᴰ} Mᴰᴰ)
+              (λ v → (ρ v , ρᴰ v .fst) , ρᴰ v .snd)
+              (rhs e))
+        ∙ interp∫
+            {A = M .fst}
+            {Aᴰ = S.∫ᴰAlgebra {A = M .fst} {Aᴰ = Mᴰ .fst} (Mᴰᴰ .fst)}
+            (λ v → ρ v , ρᴰ v) (rhs e))
+    ∫ᴰModel {Mᴰ = Mᴰ} Mᴰᴰ .snd .snd a =
+      isSetΣ (Mᴰ .snd .snd a) (λ aᴰ → Mᴰᴰ .snd .snd (a , aᴰ))
+
+  interpᴰwk : (M : Model ℓ) (N : Model ℓ') {V : Type ℓ''}
+    (ρ : V → M .fst .fst) (ρᴰ : V → N .fst .fst) (t : |FreeAlgebra| V)
+    → interpᴰ (wkAlg (M .fst) (N .fst)) ρ ρᴰ t ≡ interp (N .fst) ρᴰ t
+  interpᴰwk M N ρ ρᴰ (var v) = refl
+  interpᴰwk M N ρ ρᴰ (app f γ) =
+    cong (N .fst .snd f) (funExt λ v → interpᴰwk M N ρ ρᴰ (γ v))
+    ∙ recFA (N .fst) ρᴰ .snd f γ (app f γ) refl
+
+  wkModel : (M : Model ℓ) (N : Model ℓ') → Modelᴰ M ℓ'
+  wkModel M N .fst = wkAlg (M .fst) (N .fst)
+  wkModel M N .snd .fst e ρ ρᴰ =
+    interpᴰwk M N ρ ρᴰ (lhs e)
+    ∙ N .snd .fst e ρᴰ
+    ∙ sym (interpᴰwk M N ρ ρᴰ (rhs e))
+  wkModel M N .snd .snd _ = N .snd .snd
+
+  _×Model_ : (M : Model ℓ) (N : Model ℓ') → Model _
+  M ×Model N = ∫Model {M = M} (wkModel M N)
+
+  module _ {M : Model ℓ} {N : Model ℓ'} where
+    _*_ : S.Homo (M .fst) (N .fst) → Modelᴰ N ℓᴰ → Modelᴰ M ℓᴰ
+    (ϕ * Nᴰ) .fst = ϕ S.* (Nᴰ .fst)
+    (ϕ * Nᴰ) .snd .fst e ρ ρᴰ =
+      hSetReasoning.rectifyOut
+        (N .fst .fst , N .snd .snd) (Nᴰ .fst .fst)
+        ( sym (interpPullback ϕ (Nᴰ .fst) ρ ρᴰ (lhs e))
+        ∙ ΣPathP
+            ( N .snd .fst e (λ v → ϕ .fst (ρ v))
+            , Nᴰ .snd .fst e (λ v → ϕ .fst (ρ v)) ρᴰ)
+        ∙ interpPullback ϕ (Nᴰ .fst) ρ ρᴰ (rhs e))
+    (ϕ * Nᴰ) .snd .snd a = Nᴰ .snd .snd (ϕ .fst a)
+
+  module _ {M : Model ℓ} {Mᴰ : Modelᴰ M ℓᴰ} where
+    *Id : _*_ {M = M} {N = M} (S.idHomo {A = M .fst}) Mᴰ ≡ Mᴰ
+    *Id = Modelᴰ≡ {M = M}
+      (S.*Id {A = M .fst} {Aᴰ = Mᴰ .fst})
+
+  module _ {M : Model ℓ} {N : Model ℓ'} {P : Model ℓ''}
+    {Pᴰ : Modelᴰ P ℓᴰ''}
+    (ϕ : S.Homo (M .fst) (N .fst))
+    (ψ : S.Homo (N .fst) (P .fst)) where
+    *∘ : _*_ {M = M} {N = P}
+          (S._⋆H_ {A = M .fst} {B = N .fst} {C = P .fst} ϕ ψ) Pᴰ
+        ≡ _*_ {M = M} {N = N} ϕ
+            (_*_ {M = N} {N = P} ψ Pᴰ)
+    *∘ = Modelᴰ≡ {M = M}
+      (S.*∘
+        {A = M .fst} {B = N .fst} {C = P .fst} {Cᴰ = Pᴰ .fst}
+        ϕ ψ)
+
+  module _ (M : Model ℓ) where
+    PathModel : Modelᴰ (M ×Model M) ℓ
+    PathModel .fst = S.PathAlg (M .fst)
+    PathModel .snd .fst e ρ ρᴰ =
+      isProp→PathP (λ _ → M .snd .snd _ _)
+        (interpᴰ (S.PathAlg (M .fst)) ρ ρᴰ (lhs e))
+        (interpᴰ (S.PathAlg (M .fst)) ρ ρᴰ (rhs e))
+    PathModel .snd .snd (m , n) =
+      isProp→isSet (M .snd .snd m n)
+
+    PathModelReflection : {Γ : Model ℓ'}
+      (ϕ ψ : S.Homo (Γ .fst) (M .fst))
+      → S.Section
+          (S._*_
+            {A = Γ .fst} {B = (M ×Model M) .fst}
+            (S.×intro
+              {Γ = Γ .fst} {A = M .fst} {B = M .fst} ϕ ψ)
+            (PathModel .fst))
+      → ϕ .fst ≡ ψ .fst
+    PathModelReflection {Γ = Γ} ϕ ψ ϕ≡ψ =
+      S.PathAlgReflection (M .fst)
+        {Γ = Γ .fst} ϕ ψ ϕ≡ψ
+
+  -- Free Models
+  module _ (X : Type ℓ) where
+    data |FreeModel| :
+      Type (ℓ-max (ℓ-max (ℓ-max ℓ ℓO) ℓA) (ℓ-max ℓO' ℓA')) where
+      var : X → |FreeModel|
+      app : ∀ (op : Op) → (γ : Arity op → |FreeModel|) → |FreeModel|
+      freeAlg : ∀ e → |FreeAlgebra| (EqArity e) → (EqArity e → |FreeModel|) → |FreeModel|
+      freeAlgEqn : ∀ e (γ : EqArity e → |FreeModel|)
+        → freeAlg e (lhs e) γ ≡ freeAlg e (rhs e) γ
+      freeAlg-var : ∀ e v (γ : EqArity e → |FreeModel|) → γ v ≡ freeAlg e (var v) γ
+      freeAlg-op : ∀ e op γ (γ' : EqArity e → |FreeModel|)
+        → app op (λ v → freeAlg e (γ v) γ') ≡ freeAlg e (app op γ) γ'
+      isSetFreeModel : isSet |FreeModel|
+
+    FreeModelAlgebra : Algebra _
+    FreeModelAlgebra = |FreeModel| , app
+
+    freeAlg≡recFA : ∀ e (t : |FreeAlgebra| (EqArity e))
+      (γ : EqArity e → |FreeModel|)
+      → recFA (|FreeModel| , app) γ .fst t ≡ freeAlg e t γ
+    freeAlg≡recFA e (var x) γ = freeAlg-var e x γ
+    freeAlg≡recFA e (app op γ) γ' =
+      (λ i → app op (λ v → freeAlg≡recFA e (γ v) γ' i))
+      ∙ freeAlg-op e op γ γ'
+
+    FreeModel :
+      Model (ℓ-max (ℓ-max (ℓ-max ℓ ℓO) ℓA) (ℓ-max ℓO' ℓA'))
+    FreeModel .fst = FreeModelAlgebra
+    FreeModel .snd .fst e γ =
+      freeAlg≡recFA e (lhs e) γ
+      ∙ freeAlgEqn e γ
+      ∙ (sym $ freeAlg≡recFA e (rhs e) γ)
+    FreeModel .snd .snd = isSetFreeModel
+
+    module _ (Bᴰ : Modelᴰ FreeModel ℓᴰ) where
+      private
+        module BᴰReasoning =
+          hSetReasoning (|FreeModel| , isSetFreeModel) (Bᴰ .fst .fst)
+
+      freeAlgᴰ : ∀ e (t : |FreeAlgebra| (EqArity e))
+        (ρ : EqArity e → |FreeModel|)
+        (ρᴰ : (v : EqArity e) → Bᴰ .fst .fst (ρ v))
+        → Bᴰ .fst .fst (freeAlg e t ρ)
+      freeAlgᴰ e t ρ ρᴰ =
+        BᴰReasoning.reind (freeAlg≡recFA e t ρ)
+          (interpᴰ (Bᴰ .fst) ρ ρᴰ t)
+
+      freeAlgᴰ-filler : ∀ e (t : |FreeAlgebra| (EqArity e))
+        (ρ : EqArity e → |FreeModel|)
+        (ρᴰ : (v : EqArity e) → Bᴰ .fst .fst (ρ v))
+        → Path (∫Algebra (Bᴰ .fst) .fst)
+            ( interp (FreeModel .fst) ρ t
+            , interpᴰ (Bᴰ .fst) ρ ρᴰ t)
+            (freeAlg e t ρ , freeAlgᴰ e t ρ ρᴰ)
+      freeAlgᴰ-filler e t ρ ρᴰ =
+        BᴰReasoning.reind-filler (freeAlg≡recFA e t ρ)
+
+      module _ (ı : (x : X) → Bᴰ .fst .fst (|FreeModel|.var x)) where
+        elimFreeModelfun : (t : |FreeModel|) → Bᴰ .fst .fst t
+        elimFreeModelfun (var x) = ı x
+        elimFreeModelfun (app op γ) =
+          Bᴰ .fst .snd op γ (λ v → elimFreeModelfun (γ v))
+            (app op γ) refl
+        elimFreeModelfun (freeAlg e t ρ) =
+          freeAlgᴰ e t ρ (λ v → elimFreeModelfun (ρ v))
+        elimFreeModelfun (freeAlgEqn e ρ i) =
+          BᴰReasoning.rectifyOut {e' = freeAlgEqn e ρ}
+            ( sym
+                (freeAlgᴰ-filler e (lhs e) ρ
+                  (λ v → elimFreeModelfun (ρ v)))
+            ∙ BᴰReasoning.≡in
+                (Bᴰ .snd .fst e ρ (λ v → elimFreeModelfun (ρ v)))
+            ∙ freeAlgᴰ-filler e (rhs e) ρ
+                (λ v → elimFreeModelfun (ρ v))) i
+        elimFreeModelfun (freeAlg-var e v ρ i) =
+          BᴰReasoning.rectifyOut {e' = freeAlg-var e v ρ}
+            (freeAlgᴰ-filler e (var v) ρ
+              (λ x → elimFreeModelfun (ρ x))) i
+        elimFreeModelfun (freeAlg-op e op γ ρ i) =
+          BᴰReasoning.rectifyOut {e' = freeAlg-op e op γ ρ}
+            ( sym
+                (cong (∫Algebra (Bᴰ .fst) .snd op)
+                  (funExt λ v →
+                    freeAlgᴰ-filler e (γ v) ρ
+                      (λ x → elimFreeModelfun (ρ x))))
+            ∙ Algebraᴰ-op-filler (Bᴰ .fst) op
+                (λ v → interp (FreeModel .fst) ρ (γ v))
+                (λ v →
+                  interpᴰ (Bᴰ .fst) ρ
+                    (λ x → elimFreeModelfun (ρ x)) (γ v))
+                (interp (FreeModel .fst) ρ (app op γ))
+                (recFA (FreeModel .fst) ρ .snd op γ (app op γ) refl)
+            ∙ freeAlgᴰ-filler e (app op γ) ρ
+                (λ x → elimFreeModelfun (ρ x))) i
+        elimFreeModelfun (isSetFreeModel x y p q i j) =
+          isSet→isSetDep (Bᴰ .snd .snd)
+            (elimFreeModelfun x) (elimFreeModelfun y)
+            (cong elimFreeModelfun p) (cong elimFreeModelfun q)
+            (isSetFreeModel x y p q) i j
+
+        elimFreeModel : S.Section (Bᴰ .fst)
+        elimFreeModel .fst = elimFreeModelfun
+        elimFreeModel .snd f γ f⟨γ⟩ f∘γ≡f⟨γ⟩ =
+          J (λ f⟨γ⟩ f∘γ≡f⟨γ⟩ →
+              Bᴰ .fst .snd f γ (λ v → elimFreeModelfun (γ v))
+                  f⟨γ⟩ f∘γ≡f⟨γ⟩
+                ≡ elimFreeModelfun f⟨γ⟩)
+            refl f∘γ≡f⟨γ⟩
+
+    module _ (B : Model ℓ') where
+      recFM : (X → B .fst .fst) → S.Homo (FreeModel .fst) (B .fst)
+      recFM ı = elimFreeModel (wkModel FreeModel B) ı
+
+      recFM-uniq : (f : S.Homo (FreeModel .fst) (B .fst))
+        → f .fst ≡ recFM (f .fst ∘ var) .fst
+      recFM-uniq f =
+        PathModelReflection B {Γ = FreeModel} f g
+          (elimFreeModel
+            (_*_ {M = FreeModel} {N = B ×Model B}
+              (S.×intro
+                {Γ = FreeModel .fst} {A = B .fst} {B = B .fst} f g)
+              (PathModel B))
+            (λ _ → refl))
+        where
+        g : S.Homo (FreeModel .fst) (B .fst)
+        g = recFM (f .fst ∘ var)
+
+    module _ (Xᴰ : X → Type ℓᴰ) where
+      data |FreeModelᴰ| : |FreeModel| →
+        Type
+          (ℓ-max (ℓ-max (ℓ-max ℓ ℓO) ℓA)
+            (ℓ-max ℓᴰ (ℓ-max ℓO' ℓA'))) where
+        var : ∀ {x} (xᴰ : Xᴰ x) → |FreeModelᴰ| (|FreeModel|.var x)
+        app : ∀ op γ
+          (γᴰ : (v : Arity op) → |FreeModelᴰ| (γ v))
+          op⟨γ⟩
+          (op∘γ≡op⟨γ⟩ : FreeModel .fst .snd op γ ≡ op⟨γ⟩)
+          → |FreeModelᴰ| op⟨γ⟩
+        freeAlg : ∀ e t ρ
+          (ρᴰ : (v : EqArity e) → |FreeModelᴰ| (ρ v))
+          → |FreeModelᴰ| (|FreeModel|.freeAlg e t ρ)
+        freeAlgEqn : ∀ e ρ
+          (ρᴰ : (v : EqArity e) → |FreeModelᴰ| (ρ v))
+          → PathP (λ i →
+              |FreeModelᴰ| (|FreeModel|.freeAlgEqn e ρ i))
+              (freeAlg e (lhs e) ρ ρᴰ)
+              (freeAlg e (rhs e) ρ ρᴰ)
+        freeAlg-var : ∀ e v ρ
+          (ρᴰ : (x : EqArity e) → |FreeModelᴰ| (ρ x))
+          → PathP (λ i →
+              |FreeModelᴰ| (|FreeModel|.freeAlg-var e v ρ i))
+              (ρᴰ v)
+              (freeAlg e (S.var v) ρ ρᴰ)
+        freeAlg-op : ∀ e op γ ρ
+          (ρᴰ : (x : EqArity e) → |FreeModelᴰ| (ρ x))
+          → PathP (λ i →
+              |FreeModelᴰ| (|FreeModel|.freeAlg-op e op γ ρ i))
+              (app op
+                (λ v → |FreeModel|.freeAlg e (γ v) ρ)
+                (λ v → freeAlg e (γ v) ρ ρᴰ)
+                (|FreeModel|.app op
+                  (λ v → |FreeModel|.freeAlg e (γ v) ρ))
+                refl)
+              (freeAlg e (S.app op γ) ρ ρᴰ)
+        isSetFreeModel : isSetᴰ |FreeModel|.isSetFreeModel |FreeModelᴰ|
+
+      isSetFreeModelᴰ : (t : |FreeModel|) → isSet (|FreeModelᴰ| t)
+      isSetFreeModelᴰ =
+        isOfHLevelᴰ→isOfHLevel 2
+          |FreeModel|.isSetFreeModel |FreeModelᴰ|.isSetFreeModel
+
+      FreeModelAlgebraᴰ : Algebraᴰ (FreeModel .fst) _
+      FreeModelAlgebraᴰ .fst = |FreeModelᴰ|
+      FreeModelAlgebraᴰ .snd = |FreeModelᴰ|.app
+
+      private
+        module FreeModelᴰReasoning =
+          hSetReasoning (|FreeModel| , |FreeModel|.isSetFreeModel)
+            |FreeModelᴰ|
+
+      freeAlgᴰ≡interpᴰ : ∀ e (t : |FreeAlgebra| (EqArity e))
+        (ρ : EqArity e → |FreeModel|)
+        (ρᴰ : (v : EqArity e) → |FreeModelᴰ| (ρ v))
+        → Path (∫Algebra FreeModelAlgebraᴰ .fst)
+            ( interp (FreeModel .fst) ρ t
+            , interpᴰ FreeModelAlgebraᴰ ρ ρᴰ t)
+            ( |FreeModel|.freeAlg e t ρ
+            , |FreeModelᴰ|.freeAlg e t ρ ρᴰ)
+      freeAlgᴰ≡interpᴰ e (S.var v) ρ ρᴰ i =
+        |FreeModel|.freeAlg-var e v ρ i
+        , |FreeModelᴰ|.freeAlg-var e v ρ ρᴰ i
+      freeAlgᴰ≡interpᴰ e (S.app op γ) ρ ρᴰ =
+        sym
+          (Algebraᴰ-op-filler FreeModelAlgebraᴰ op
+            (λ v → interp (FreeModel .fst) ρ (γ v))
+            (λ v → interpᴰ FreeModelAlgebraᴰ ρ ρᴰ (γ v))
+            (interp (FreeModel .fst) ρ (S.app op γ))
+            (recFA (FreeModel .fst) ρ .snd op γ (S.app op γ) refl))
+        ∙ cong (∫Algebra FreeModelAlgebraᴰ .snd op)
+          (funExt λ v → freeAlgᴰ≡interpᴰ e (γ v) ρ ρᴰ)
+        ∙ (λ i →
+          |FreeModel|.freeAlg-op e op γ ρ i
+          , |FreeModelᴰ|.freeAlg-op e op γ ρ ρᴰ i)
+
+      FreeModelᴰ : Modelᴰ FreeModel _
+      FreeModelᴰ .fst = FreeModelAlgebraᴰ
+      FreeModelᴰ .snd .fst e ρ ρᴰ =
+        FreeModelᴰReasoning.rectifyOut
+          {e' = FreeModel .snd .fst e ρ}
+          ( freeAlgᴰ≡interpᴰ e (lhs e) ρ ρᴰ
+          ∙ (λ i →
+              |FreeModel|.freeAlgEqn e ρ i
+              , |FreeModelᴰ|.freeAlgEqn e ρ ρᴰ i)
+          ∙ sym (freeAlgᴰ≡interpᴰ e (rhs e) ρ ρᴰ))
+      FreeModelᴰ .snd .snd = isSetFreeModelᴰ
+
+      module _ {A : Model ℓ'}
+        (ϕ : S.Homo (FreeModel .fst) (A .fst))
+        (Aᴰ : Modelᴰ A ℓᴰ')
+        (ıᴰ : ∀ x → Xᴰ x → Aᴰ .fst .fst (ϕ .fst (|FreeModel|.var x)))
+        where
+        private
+          Aᴰ' : Modelᴰ FreeModel ℓᴰ'
+          Aᴰ' = _*_ {M = FreeModel} {N = A} ϕ Aᴰ
+
+          module Aᴰ'Reasoning =
+            hSetReasoning (|FreeModel| , |FreeModel|.isSetFreeModel)
+              (Aᴰ' .fst .fst)
+
+        |recFMᴰ| : ∀ {t} → |FreeModelᴰ| t → Aᴰ' .fst .fst t
+        |recFMᴰ| (|FreeModelᴰ|.var {x = x} xᴰ) = ıᴰ x xᴰ
+        |recFMᴰ| (|FreeModelᴰ|.app
+          op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩) =
+          Aᴰ' .fst .snd op γ (λ v → |recFMᴰ| (γᴰ v))
+            op⟨γ⟩ op∘γ≡op⟨γ⟩
+        |recFMᴰ| (|FreeModelᴰ|.freeAlg e t ρ ρᴰ) =
+          freeAlgᴰ Aᴰ' e t ρ (λ v → |recFMᴰ| (ρᴰ v))
+        |recFMᴰ| (|FreeModelᴰ|.freeAlgEqn e ρ ρᴰ i) =
+          Aᴰ'Reasoning.rectifyOut
+            {e' = |FreeModel|.freeAlgEqn e ρ}
+            ( sym
+                (freeAlgᴰ-filler Aᴰ' e (lhs e) ρ
+                  (λ v → |recFMᴰ| (ρᴰ v)))
+            ∙ Aᴰ'Reasoning.≡in
+                (Aᴰ' .snd .fst e ρ (λ v → |recFMᴰ| (ρᴰ v)))
+            ∙ freeAlgᴰ-filler Aᴰ' e (rhs e) ρ
+                (λ v → |recFMᴰ| (ρᴰ v))) i
+        |recFMᴰ| (|FreeModelᴰ|.freeAlg-var e v ρ ρᴰ i) =
+          Aᴰ'Reasoning.rectifyOut
+            {e' = |FreeModel|.freeAlg-var e v ρ}
+            (freeAlgᴰ-filler Aᴰ' e (S.var v) ρ
+              (λ x → |recFMᴰ| (ρᴰ x))) i
+        |recFMᴰ| (|FreeModelᴰ|.freeAlg-op e op γ ρ ρᴰ i) =
+          Aᴰ'Reasoning.rectifyOut
+            {e' = |FreeModel|.freeAlg-op e op γ ρ}
+            ( sym
+                (cong (∫Algebra (Aᴰ' .fst) .snd op)
+                  (funExt λ v →
+                    freeAlgᴰ-filler Aᴰ' e (γ v) ρ
+                      (λ x → |recFMᴰ| (ρᴰ x))))
+            ∙ Algebraᴰ-op-filler (Aᴰ' .fst) op
+                (λ v → interp (FreeModel .fst) ρ (γ v))
+                (λ v →
+                  interpᴰ (Aᴰ' .fst) ρ
+                    (λ x → |recFMᴰ| (ρᴰ x)) (γ v))
+                (interp (FreeModel .fst) ρ (S.app op γ))
+                (recFA (FreeModel .fst) ρ .snd op γ
+                  (S.app op γ) refl)
+            ∙ freeAlgᴰ-filler Aᴰ' e (S.app op γ) ρ
+                (λ x → |recFMᴰ| (ρᴰ x))) i
+        |recFMᴰ| (|FreeModelᴰ|.isSetFreeModel
+          xᴰ yᴰ pᴰ qᴰ i j) =
+          isSet→isSetDep (Aᴰ' .snd .snd)
+            (|recFMᴰ| xᴰ) (|recFMᴰ| yᴰ)
+            (λ k → |recFMᴰ| (pᴰ k)) (λ k → |recFMᴰ| (qᴰ k))
+            (|FreeModel|.isSetFreeModel _ _ _ _) i j
+
+        recFMᴰ : S.Homoᴰ ϕ (FreeModelᴰ .fst) (Aᴰ .fst)
+        recFMᴰ .fst _ = |recFMᴰ|
+        recFMᴰ .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩
+          op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ =
+          J
+            (λ op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ →
+              Aᴰ .fst .snd op (ϕ .fst ∘ γ)
+                  (λ v → |recFMᴰ| (γᴰ v))
+                  (ϕ .fst op⟨γ⟩)
+                  (ϕ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩)
+                ≡ |recFMᴰ| op⟨γᴰ⟩)
+            refl
+            op∘γᴰ≡op⟨γᴰ⟩
+
+      module _ {A : Model ℓ'}
+        (ϕ : S.Homo (FreeModel .fst) (A .fst))
+        (Aᴰ : Modelᴰ A ℓᴰ')
+        (ϕᴰ : S.Homoᴰ ϕ (FreeModelᴰ .fst) (Aᴰ .fst))
+        where
+        private
+          ıᴰ : ∀ x → Xᴰ x → Aᴰ .fst .fst (ϕ .fst (|FreeModel|.var x))
+          ıᴰ x xᴰ = ϕᴰ .fst _ (|FreeModelᴰ|.var xᴰ)
+
+          baseϕ : S.Homo
+            (∫Algebra (FreeModelᴰ .fst))
+            (A .fst)
+          baseϕ =
+            S._⋆H_
+              {A = ∫Algebra (FreeModelᴰ .fst)}
+              {B = FreeModel .fst} {C = A .fst}
+              (S.Fst {Aᴰ = FreeModelᴰ .fst}) ϕ
+
+          ϕᴰSection : S.Section (baseϕ S.* (Aᴰ .fst))
+          ϕᴰSection .fst z = ϕᴰ .fst (z .fst) (z .snd)
+          ϕᴰSection .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+            ϕᴰ .snd op (fst ∘ γ) (snd ∘ γ)
+              (op⟨γ⟩ .fst) (cong fst op∘γ≡op⟨γ⟩)
+              (op⟨γ⟩ .snd)
+              (S.Snd {Aᴰ = FreeModelᴰ .fst} .snd
+                op γ op⟨γ⟩ op∘γ≡op⟨γ⟩)
+
+          ϕ∫ᴰ : S.Homo
+            (∫Algebra (FreeModelᴰ .fst))
+            (∫Algebra (Aᴰ .fst))
+          ϕ∫ᴰ =
+            S.∫intro
+              {Γ = ∫Algebra (FreeModelᴰ .fst)}
+              {A = A .fst} {B = Aᴰ .fst}
+              baseϕ ϕᴰSection
+
+          interpHomoFMᴰ : {V : Type ℓ''}
+            (ρ : V → |FreeModel|)
+            (ρᴰ : (v : V) → |FreeModelᴰ| (ρ v))
+            (t : |FreeAlgebra| V)
+            → Path (∫Algebra (Aᴰ .fst) .fst)
+                ( interp (A .fst) (ϕ .fst ∘ ρ) t
+                , interpᴰ (Aᴰ .fst) (ϕ .fst ∘ ρ)
+                    (λ v → ϕᴰ .fst (ρ v) (ρᴰ v)) t)
+                ( ϕ .fst (interp (FreeModel .fst) ρ t)
+                , ϕᴰ .fst (interp (FreeModel .fst) ρ t)
+                    (interpᴰ (FreeModelᴰ .fst) ρ ρᴰ t))
+          interpHomoFMᴰ ρ ρᴰ t =
+            sym
+              (interp∫
+                {A = A .fst} {Aᴰ = Aᴰ .fst}
+                (λ v → ϕ .fst (ρ v) , ϕᴰ .fst (ρ v) (ρᴰ v)) t)
+            ∙ interpHomo ϕ∫ᴰ (λ v → ρ v , ρᴰ v) t
+            ∙ cong (ϕ∫ᴰ .fst)
+                (interp∫
+                  {A = FreeModel .fst} {Aᴰ = FreeModelᴰ .fst}
+                  (λ v → ρ v , ρᴰ v) t)
+
+          Aᴰ' : Modelᴰ FreeModel ℓᴰ'
+          Aᴰ' = _*_ {M = FreeModel} {N = A} ϕ Aᴰ
+
+          module AᴰReasoning =
+            hSetReasoning (A .fst .fst , A .snd .snd) (Aᴰ .fst .fst)
+
+          recᴰ : ∀ {t} → |FreeModelᴰ| t → Aᴰ .fst .fst (ϕ .fst t)
+          recᴰ tᴰ = |recFMᴰ| {A = A} ϕ Aᴰ ıᴰ tᴰ
+
+          pullbackTotal : ∫Algebra (Aᴰ' .fst) .fst
+            → ∫Algebra (Aᴰ .fst) .fst
+          pullbackTotal z .fst = ϕ .fst (z .fst)
+          pullbackTotal z .snd = z .snd
+
+          ηType : ∫Algebra (FreeModelᴰ .fst) .fst → Type _
+          ηType z = ϕᴰ .fst (z .fst) (z .snd) ≡ recᴰ (z .snd)
+
+          ηIsProp : (z : ∫Algebra (FreeModelᴰ .fst) .fst)
+            → isProp (ηType z)
+          ηIsProp z =
+            Aᴰ .snd .snd (ϕ .fst (z .fst))
+              (ϕᴰ .fst (z .fst) (z .snd)) (recᴰ (z .snd))
+
+          app-η : ∀ op γ
+            (γᴰ : (v : Arity op) → |FreeModelᴰ| (γ v))
+            op⟨γ⟩ (op∘γ≡op⟨γ⟩ : FreeModel .fst .snd op γ ≡ op⟨γ⟩)
+            → ((v : Arity op) →
+                ϕᴰ .fst (γ v) (γᴰ v) ≡ recᴰ (γᴰ v))
+            → ϕᴰ .fst op⟨γ⟩
+                (|FreeModelᴰ|.app
+                  op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩)
+              ≡ recᴰ
+                (|FreeModelᴰ|.app
+                  op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩)
+          app-η op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ γᴰ-η =
+            sym
+              (ϕᴰ .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩
+                (|FreeModelᴰ|.app
+                  op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩)
+                refl)
+            ∙ cong
+                (λ γᴰ' →
+                  Aᴰ .fst .snd op (ϕ .fst ∘ γ) γᴰ'
+                    (ϕ .fst op⟨γ⟩)
+                    (ϕ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩))
+                (funExt γᴰ-η)
+
+          freeAlg-η : ∀ e t ρ
+            (ρᴰ : (v : EqArity e) → |FreeModelᴰ| (ρ v))
+            → ((v : EqArity e) →
+                ϕᴰ .fst (ρ v) (ρᴰ v) ≡ recᴰ (ρᴰ v))
+            → ϕᴰ .fst (|FreeModel|.freeAlg e t ρ)
+                (|FreeModelᴰ|.freeAlg e t ρ ρᴰ)
+              ≡ recᴰ (|FreeModelᴰ|.freeAlg e t ρ ρᴰ)
+          freeAlg-η e t ρ ρᴰ ρᴰ-η =
+            AᴰReasoning.rectifyOut {e' = refl}
+              ( sym
+                  (cong (ϕ∫ᴰ .fst)
+                    (freeAlgᴰ≡interpᴰ e t ρ ρᴰ))
+              ∙ sym (interpHomoFMᴰ ρ ρᴰ t)
+              ∙ cong
+                  (λ ρᴰ' →
+                    interp (A .fst) (ϕ .fst ∘ ρ) t
+                    , interpᴰ (Aᴰ .fst) (ϕ .fst ∘ ρ) ρᴰ' t)
+                  (funExt ρᴰ-η)
+              ∙ interpPullback ϕ (Aᴰ .fst) ρ (λ v → recᴰ (ρᴰ v)) t
+              ∙ cong pullbackTotal
+                  (freeAlgᴰ-filler Aᴰ' e t ρ
+                    (λ v → recᴰ (ρᴰ v))))
+
+          |recFMᴰ|-η : ∀ {t} (tᴰ : |FreeModelᴰ| t)
+            → ϕᴰ .fst t tᴰ ≡ recᴰ tᴰ
+          |recFMᴰ|-η (|FreeModelᴰ|.var xᴰ) = refl
+          |recFMᴰ|-η (|FreeModelᴰ|.app
+            op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩) =
+            app-η op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩
+              (λ v → |recFMᴰ|-η (γᴰ v))
+          |recFMᴰ|-η (|FreeModelᴰ|.freeAlg e t ρ ρᴰ) =
+            freeAlg-η e t ρ ρᴰ (λ v → |recFMᴰ|-η (ρᴰ v))
+          |recFMᴰ|-η (|FreeModelᴰ|.freeAlgEqn e ρ ρᴰ i) =
+            isOfHLevel→isOfHLevelDep 1 {B = ηType} ηIsProp
+              (freeAlg-η e (lhs e) ρ ρᴰ
+                (λ v → |recFMᴰ|-η (ρᴰ v)))
+              (freeAlg-η e (rhs e) ρ ρᴰ
+                (λ v → |recFMᴰ|-η (ρᴰ v)))
+              (λ k →
+                |FreeModel|.freeAlgEqn e ρ k
+                , |FreeModelᴰ|.freeAlgEqn e ρ ρᴰ k)
+              i
+          |recFMᴰ|-η (|FreeModelᴰ|.freeAlg-var e v ρ ρᴰ i) =
+            isOfHLevel→isOfHLevelDep 1 {B = ηType} ηIsProp
+              (|recFMᴰ|-η (ρᴰ v))
+              (freeAlg-η e (S.var v) ρ ρᴰ
+                (λ x → |recFMᴰ|-η (ρᴰ x)))
+              (λ k →
+                |FreeModel|.freeAlg-var e v ρ k
+                , |FreeModelᴰ|.freeAlg-var e v ρ ρᴰ k)
+              i
+          |recFMᴰ|-η (|FreeModelᴰ|.freeAlg-op e op γ ρ ρᴰ i) =
+            isOfHLevel→isOfHLevelDep 1 {B = ηType} ηIsProp
+              (app-η op
+                (λ v → |FreeModel|.freeAlg e (γ v) ρ)
+                (λ v → |FreeModelᴰ|.freeAlg e (γ v) ρ ρᴰ)
+                (|FreeModel|.app op
+                  (λ v → |FreeModel|.freeAlg e (γ v) ρ))
+                refl
+                (λ v →
+                  freeAlg-η e (γ v) ρ ρᴰ
+                    (λ x → |recFMᴰ|-η (ρᴰ x))))
+              (freeAlg-η e (S.app op γ) ρ ρᴰ
+                (λ x → |recFMᴰ|-η (ρᴰ x)))
+              (λ k →
+                |FreeModel|.freeAlg-op e op γ ρ k
+                , |FreeModelᴰ|.freeAlg-op e op γ ρ ρᴰ k)
+              i
+          |recFMᴰ|-η (|FreeModelᴰ|.isSetFreeModel
+            xᴰ yᴰ pᴰ qᴰ i j) =
+            isOfHLevel→isOfHLevelDep 2 {B = ηType}
+              (λ z → isProp→isSet (ηIsProp z))
+              (|recFMᴰ|-η xᴰ) (|recFMᴰ|-η yᴰ)
+              (λ k → |recFMᴰ|-η (pᴰ k))
+              (λ k → |recFMᴰ|-η (qᴰ k))
+              (λ k l →
+                |FreeModel|.isSetFreeModel _ _ _ _ k l
+                , |FreeModelᴰ|.isSetFreeModel xᴰ yᴰ pᴰ qᴰ k l)
+              i j
+
+        recFMᴰ-η : ϕᴰ .fst ≡ recFMᴰ {A = A} ϕ Aᴰ ıᴰ .fst
+        recFMᴰ-η =
+          funExt λ t → funExt λ tᴰ → |recFMᴰ|-η tᴰ

--- a/Cubical/Algebra/Theory/Instances/Monoid.agda
+++ b/Cubical/Algebra/Theory/Instances/Monoid.agda
@@ -1,0 +1,679 @@
+-- The algebraic theory of monoids and its concrete free list model.
+module Cubical.Algebra.Theory.Instances.Monoid where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.More
+
+open import Cubical.Data.Bool
+open import Cubical.Data.Empty
+open import Cubical.Data.List
+open import Cubical.Data.List.Dependent as ListP
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit
+
+open import Cubical.Algebra.Theory.Base
+
+private
+  variable
+    ℓV ℓX ℓB ℓD ℓD' : Level
+
+data MonoidOp : Type ℓ-zero where
+  unitOp multOp : MonoidOp
+
+MonoidSignature : Signature ℓ-zero ℓ-zero
+MonoidSignature .Signature.Op = MonoidOp
+MonoidSignature .Signature.Arity unitOp = ⊥
+MonoidSignature .Signature.Arity multOp = Bool
+
+module MonoidSignature where
+  open Signature MonoidSignature public
+
+private
+  module S = Signature MonoidSignature
+
+  emptyBranches : {A : Type ℓX} → ⊥ → A
+  emptyBranches ()
+
+  boolBranches : {A : Type ℓX} → A → A → Bool → A
+  boolBranches x y false = x
+  boolBranches x y true = y
+
+unitTm : ∀ {V : Type ℓX} → S.|FreeAlgebra| V
+unitTm = S.app unitOp emptyBranches
+
+multTm : ∀ {V : Type ℓX} →
+  S.|FreeAlgebra| V → S.|FreeAlgebra| V → S.|FreeAlgebra| V
+multTm x y = S.app multOp (boolBranches x y)
+
+data AssocVar : Type ℓ-zero where
+  leftVar middleVar rightVar : AssocVar
+
+data MonoidEq : Type ℓ-zero where
+  unit-lEq unit-rEq assocEq : MonoidEq
+
+MonoidEqArity : MonoidEq → Type ℓ-zero
+MonoidEqArity unit-lEq = Unit
+MonoidEqArity unit-rEq = Unit
+MonoidEqArity assocEq = AssocVar
+
+MonoidLhs : (e : MonoidEq) →
+  S.|FreeAlgebra| (MonoidEqArity e)
+MonoidLhs unit-lEq = multTm unitTm (S.var tt)
+MonoidLhs unit-rEq = multTm (S.var tt) unitTm
+MonoidLhs assocEq =
+  multTm (S.var leftVar)
+    (multTm (S.var middleVar) (S.var rightVar))
+
+MonoidRhs : (e : MonoidEq) →
+  S.|FreeAlgebra| (MonoidEqArity e)
+MonoidRhs unit-lEq = S.var tt
+MonoidRhs unit-rEq = S.var tt
+MonoidRhs assocEq =
+  multTm (multTm (S.var leftVar) (S.var middleVar))
+    (S.var rightVar)
+
+MonoidTheory : Theory ℓ-zero ℓ-zero ℓ-zero ℓ-zero
+MonoidTheory .Theory.S = MonoidSignature
+MonoidTheory .Theory.Eq = MonoidEq
+MonoidTheory .Theory.EqArity = MonoidEqArity
+MonoidTheory .Theory.lhs = MonoidLhs
+MonoidTheory .Theory.rhs = MonoidRhs
+
+module MonoidTheory where
+  open Theory MonoidTheory public
+
+module _ (B : Theory.Model MonoidTheory ℓB) where
+  private
+    module T = Theory MonoidTheory
+
+  MonoidModelUnit : B .fst .fst
+  MonoidModelUnit = B .fst .snd unitOp emptyBranches
+
+  MonoidModelMult : B .fst .fst → B .fst .fst → B .fst .fst
+  MonoidModelMult x y = B .fst .snd multOp (boolBranches x y)
+
+  MonoidInterpUnit : {V : Type ℓV} (ρ : V → B .fst .fst) →
+    T.interp (B .fst) ρ unitTm ≡ MonoidModelUnit
+  MonoidInterpUnit ρ =
+    sym
+      (T.recFA (B .fst) ρ .snd unitOp emptyBranches unitTm refl)
+    ∙ cong (B .fst .snd unitOp) (funExt λ ())
+
+  MonoidInterpMult : {V : Type ℓV} (ρ : V → B .fst .fst)
+    (x y : T.|FreeAlgebra| V) →
+    T.interp (B .fst) ρ (multTm x y) ≡
+      MonoidModelMult
+        (T.interp (B .fst) ρ x) (T.interp (B .fst) ρ y)
+  MonoidInterpMult ρ x y =
+    sym
+      (T.recFA (B .fst) ρ .snd multOp
+        (boolBranches x y) (multTm x y) refl)
+    ∙ cong (B .fst .snd multOp)
+        (funExt λ { false → refl ; true → refl })
+
+  MonoidModelUnitL : (x : B .fst .fst) →
+    MonoidModelMult MonoidModelUnit x ≡ x
+  MonoidModelUnitL x =
+    cong (λ u → MonoidModelMult u x)
+      (sym (MonoidInterpUnit (λ _ → x)))
+    ∙ sym (MonoidInterpMult (λ _ → x) unitTm (S.var tt))
+    ∙ B .snd .fst unit-lEq (λ _ → x)
+
+  MonoidModelUnitR : (x : B .fst .fst) →
+    MonoidModelMult x MonoidModelUnit ≡ x
+  MonoidModelUnitR x =
+    cong (MonoidModelMult x)
+      (sym (MonoidInterpUnit (λ _ → x)))
+    ∙ sym (MonoidInterpMult (λ _ → x) (S.var tt) unitTm)
+    ∙ B .snd .fst unit-rEq (λ _ → x)
+
+  MonoidModelAssoc : (x y z : B .fst .fst) →
+    MonoidModelMult x (MonoidModelMult y z) ≡
+      MonoidModelMult (MonoidModelMult x y) z
+  MonoidModelAssoc x y z =
+    cong (MonoidModelMult x)
+      (sym (MonoidInterpMult valuation
+        (S.var middleVar) (S.var rightVar)))
+    ∙ sym (MonoidInterpMult valuation
+        (S.var leftVar)
+        (multTm (S.var middleVar) (S.var rightVar)))
+    ∙ B .snd .fst assocEq valuation
+    ∙ MonoidInterpMult valuation
+        (multTm (S.var leftVar) (S.var middleVar))
+        (S.var rightVar)
+    ∙ cong (λ xy → MonoidModelMult xy z)
+        (MonoidInterpMult valuation
+          (S.var leftVar) (S.var middleVar))
+    where
+    valuation : AssocVar → B .fst .fst
+    valuation leftVar = x
+    valuation middleVar = y
+    valuation rightVar = z
+
+module _ (X : hSet ℓX) where
+  private
+    module T = Theory MonoidTheory
+
+  ListFreeModel : T.Model ℓX
+  ListFreeModel .fst .fst = List (X .fst)
+  ListFreeModel .fst .snd unitOp γ = []
+  ListFreeModel .fst .snd multOp γ = γ false ++ γ true
+  ListFreeModel .snd .fst unit-lEq ρ = refl
+  ListFreeModel .snd .fst unit-rEq ρ = ++-unit-r (ρ tt)
+  ListFreeModel .snd .fst assocEq ρ =
+    sym (++-assoc (ρ leftVar) (ρ middleVar) (ρ rightVar))
+  ListFreeModel .snd .snd = isOfHLevelList 0 (X .snd)
+
+  ListFreeModelη : X .fst → ListFreeModel .fst .fst
+  ListFreeModelη x = [ x ]
+
+  module _ (B : T.Model ℓB) (f : X .fst → B .fst .fst) where
+    ListFreeModelRec-fun : List (X .fst) → B .fst .fst
+    ListFreeModelRec-fun =
+      foldr (λ x b → MonoidModelMult B (f x) b) (MonoidModelUnit B)
+
+    ListFreeModelRec-++ : (xs ys : List (X .fst)) →
+      ListFreeModelRec-fun (xs ++ ys) ≡
+        MonoidModelMult B
+          (ListFreeModelRec-fun xs) (ListFreeModelRec-fun ys)
+    ListFreeModelRec-++ [] ys =
+      sym (MonoidModelUnitL B (ListFreeModelRec-fun ys))
+    ListFreeModelRec-++ (x ∷ xs) ys =
+      cong (MonoidModelMult B (f x)) (ListFreeModelRec-++ xs ys)
+      ∙ MonoidModelAssoc B (f x)
+          (ListFreeModelRec-fun xs) (ListFreeModelRec-fun ys)
+
+    ListFreeModelRec : T.Homo (ListFreeModel .fst) (B .fst)
+    ListFreeModelRec .fst = ListFreeModelRec-fun
+    ListFreeModelRec .snd unitOp γ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+      cong (B .fst .snd unitOp) (funExt λ ())
+      ∙ cong ListFreeModelRec-fun op∘γ≡op⟨γ⟩
+    ListFreeModelRec .snd multOp γ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+      cong (B .fst .snd multOp)
+        (funExt λ { false → refl ; true → refl })
+      ∙ sym (ListFreeModelRec-++ (γ false) (γ true))
+      ∙ cong ListFreeModelRec-fun op∘γ≡op⟨γ⟩
+
+    ListFreeModelRec-β : (x : X .fst) →
+      ListFreeModelRec .fst (ListFreeModelη x) ≡ f x
+    ListFreeModelRec-β x = MonoidModelUnitR B (f x)
+
+  ListFreeModelRec-uniq :
+    (B : T.Model ℓB)
+    (h : T.Homo (ListFreeModel .fst) (B .fst))
+    → h .fst ≡
+      ListFreeModelRec B (λ x → h .fst (ListFreeModelη x)) .fst
+  ListFreeModelRec-uniq B h = funExt go
+    where
+    go : (xs : List (X .fst)) →
+      h .fst xs ≡
+        ListFreeModelRec B
+          (λ x → h .fst (ListFreeModelη x)) .fst xs
+    go [] =
+      sym (h .snd unitOp (λ ()) [] refl)
+      ∙ cong (B .fst .snd unitOp) (funExt λ ())
+    go (x ∷ xs) =
+      sym
+        (h .snd multOp
+          (λ { false → ListFreeModelη x ; true → xs })
+          (x ∷ xs) refl)
+      ∙ cong (B .fst .snd multOp)
+          (funExt λ { false → refl ; true → refl })
+      ∙ cong (MonoidModelMult B (h .fst (ListFreeModelη x))) (go xs)
+
+  ListFreeModelUniversal : (B : T.Model ℓB) →
+    isEquiv
+      (λ (h : T.Homo (ListFreeModel .fst) (B .fst)) x →
+        h .fst (ListFreeModelη x))
+  ListFreeModelUniversal B = isIsoToIsEquiv
+    ( ListFreeModelRec B
+    , (λ f → funExt (ListFreeModelRec-β B f))
+    , (λ h → Σ≡Prop
+        (λ _ → isPropΠ4 λ _ _ _ _ → B .snd .snd _ _)
+        (sym (ListFreeModelRec-uniq B h)))
+    )
+
+  module _ (Xᴰ : X .fst → hSet ℓD) where
+    private
+      module R = hSetReasoning
+        (ListFreeModel .fst .fst , ListFreeModel .snd .snd)
+        (λ xs → ListP (λ x → Xᴰ x .fst) xs)
+
+    appendListP : {xs ys : List (X .fst)} →
+      ListP (λ x → Xᴰ x .fst) xs →
+      ListP (λ x → Xᴰ x .fst) ys →
+      ListP (λ x → Xᴰ x .fst) (xs ++ ys)
+    appendListP ListP.[] ysᴰ = ysᴰ
+    appendListP (ListP._∷_ xᴰ xsᴰ) ysᴰ =
+      ListP._∷_ xᴰ (appendListP xsᴰ ysᴰ)
+
+    ListFreeAlgebraᴰ :
+      T.Algebraᴰ (ListFreeModel .fst) (ℓ-max ℓX ℓD)
+    ListFreeAlgebraᴰ .fst xs = ListP (λ x → Xᴰ x .fst) xs
+    ListFreeAlgebraᴰ .snd unitOp γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+      R.reind op∘γ≡op⟨γ⟩ ListP.[]
+    ListFreeAlgebraᴰ .snd multOp γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+      R.reind op∘γ≡op⟨γ⟩
+        (appendListP (γᴰ false) (γᴰ true))
+
+    ListUnitNormalize :
+      (γ : ⊥ → ListFreeModel .fst .fst)
+      (γᴰ : (v : ⊥) → ListFreeAlgebraᴰ .fst (γ v)) →
+      Path (T.∫Algebra ListFreeAlgebraᴰ .fst)
+        ( ListFreeModel .fst .snd unitOp γ
+        , ListFreeAlgebraᴰ .snd unitOp γ γᴰ _ refl)
+        ([] , ListP.[])
+    ListUnitNormalize γ γᴰ = R.reind-filler⁻ refl
+
+    ListMultNormalize :
+      (γ : Bool → ListFreeModel .fst .fst)
+      (γᴰ : (v : Bool) → ListFreeAlgebraᴰ .fst (γ v)) →
+      Path (T.∫Algebra ListFreeAlgebraᴰ .fst)
+        ( ListFreeModel .fst .snd multOp γ
+        , ListFreeAlgebraᴰ .snd multOp γ γᴰ _ refl)
+        ( γ false ++ γ true
+        , appendListP (γᴰ false) (γᴰ true))
+    ListMultNormalize γ γᴰ = R.reind-filler⁻ refl
+
+    ListAppFiller : {V : Type ℓV}
+      (op : MonoidOp)
+      (ρ : V → ListFreeModel .fst .fst)
+      (ρᴰ : (v : V) → ListFreeAlgebraᴰ .fst (ρ v))
+      (γ : T.Arity op → T.|FreeAlgebra| V) →
+      Path (T.∫Algebra ListFreeAlgebraᴰ .fst)
+        ( ListFreeModel .fst .snd op
+            (λ v → T.interp (ListFreeModel .fst) ρ (γ v))
+        , ListFreeAlgebraᴰ .snd op
+            (λ v → T.interp (ListFreeModel .fst) ρ (γ v))
+            (λ v → T.interpᴰ ListFreeAlgebraᴰ ρ ρᴰ (γ v))
+            _ refl)
+        ( T.interp (ListFreeModel .fst) ρ (T.S.app op γ)
+        , T.interpᴰ ListFreeAlgebraᴰ ρ ρᴰ (T.S.app op γ))
+    ListAppFiller op ρ ρᴰ γ =
+      T.Algebraᴰ-op-filler ListFreeAlgebraᴰ op
+        (λ v → T.interp (ListFreeModel .fst) ρ (γ v))
+        (λ v → T.interpᴰ ListFreeAlgebraᴰ ρ ρᴰ (γ v))
+        (T.interp (ListFreeModel .fst) ρ (T.S.app op γ))
+        (T.recFA (ListFreeModel .fst) ρ .snd op γ
+          (T.S.app op γ) refl)
+
+    ListUnitInterpPath : {V : Type ℓV}
+      (ρ : V → ListFreeModel .fst .fst)
+      (ρᴰ : (v : V) → ListFreeAlgebraᴰ .fst (ρ v)) →
+      Path (T.∫Algebra ListFreeAlgebraᴰ .fst)
+        ( T.interp (ListFreeModel .fst) ρ unitTm
+        , T.interpᴰ ListFreeAlgebraᴰ ρ ρᴰ unitTm)
+        ([] , ListP.[])
+    ListUnitInterpPath ρ ρᴰ =
+      sym (ListAppFiller unitOp ρ ρᴰ emptyBranches)
+      ∙ ListUnitNormalize
+          (λ v → T.interp (ListFreeModel .fst) ρ (emptyBranches v))
+          (λ v → T.interpᴰ ListFreeAlgebraᴰ ρ ρᴰ
+            (emptyBranches v))
+
+    ListMultInterpPath : {V : Type ℓV}
+      (ρ : V → ListFreeModel .fst .fst)
+      (ρᴰ : (v : V) → ListFreeAlgebraᴰ .fst (ρ v))
+      (x y : T.|FreeAlgebra| V) →
+      Path (T.∫Algebra ListFreeAlgebraᴰ .fst)
+        ( T.interp (ListFreeModel .fst) ρ (multTm x y)
+        , T.interpᴰ ListFreeAlgebraᴰ ρ ρᴰ (multTm x y))
+        ( T.interp (ListFreeModel .fst) ρ x ++
+            T.interp (ListFreeModel .fst) ρ y
+        , appendListP
+            (T.interpᴰ ListFreeAlgebraᴰ ρ ρᴰ x)
+            (T.interpᴰ ListFreeAlgebraᴰ ρ ρᴰ y))
+    ListMultInterpPath ρ ρᴰ x y =
+      sym (ListAppFiller multOp ρ ρᴰ (boolBranches x y))
+      ∙ ListMultNormalize
+          (λ v → T.interp (ListFreeModel .fst) ρ
+            (boolBranches x y v))
+          (λ v → T.interpᴰ ListFreeAlgebraᴰ ρ ρᴰ
+            (boolBranches x y v))
+
+    ListPAppendTotal :
+      T.∫Algebra ListFreeAlgebraᴰ .fst →
+      T.∫Algebra ListFreeAlgebraᴰ .fst →
+      T.∫Algebra ListFreeAlgebraᴰ .fst
+    ListPAppendTotal (xs , xsᴰ) (ys , ysᴰ) =
+      xs ++ ys , appendListP xsᴰ ysᴰ
+
+    ListPAppendUnitR : {xs : List (X .fst)}
+      (xsᴰ : ListP (λ x → Xᴰ x .fst) xs) →
+      Path (T.∫Algebra ListFreeAlgebraᴰ .fst)
+        (ListPAppendTotal (xs , xsᴰ) ([] , ListP.[]))
+        (xs , xsᴰ)
+    ListPAppendUnitR {xs = []} ListP.[] = refl
+    ListPAppendUnitR {xs = x ∷ xs} (ListP._∷_ xᴰ xsᴰ) =
+      cong (λ z → x ∷ z .fst , ListP._∷_ xᴰ (z .snd))
+        (ListPAppendUnitR xsᴰ)
+
+    ListPAppendAssoc : {xs ys zs : List (X .fst)}
+      (xsᴰ : ListP (λ x → Xᴰ x .fst) xs)
+      (ysᴰ : ListP (λ x → Xᴰ x .fst) ys)
+      (zsᴰ : ListP (λ x → Xᴰ x .fst) zs) →
+      Path (T.∫Algebra ListFreeAlgebraᴰ .fst)
+        (ListPAppendTotal (xs , xsᴰ)
+          (ListPAppendTotal (ys , ysᴰ) (zs , zsᴰ)))
+        (ListPAppendTotal
+          (ListPAppendTotal (xs , xsᴰ) (ys , ysᴰ)) (zs , zsᴰ))
+    ListPAppendAssoc {xs = []} ListP.[] ysᴰ zsᴰ = refl
+    ListPAppendAssoc {xs = x ∷ xs}
+      (ListP._∷_ xᴰ xsᴰ) ysᴰ zsᴰ =
+      cong (λ z → x ∷ z .fst , ListP._∷_ xᴰ (z .snd))
+        (ListPAppendAssoc xsᴰ ysᴰ zsᴰ)
+
+    ListFreeModelᴰ :
+      T.Modelᴰ ListFreeModel (ℓ-max ℓX ℓD)
+    ListFreeModelᴰ .fst = ListFreeAlgebraᴰ
+    ListFreeModelᴰ .snd .fst unit-lEq ρ ρᴰ =
+      R.rectifyOut {e' = ListFreeModel .snd .fst unit-lEq ρ}
+        ( ListMultInterpPath ρ ρᴰ unitTm (T.S.var tt)
+        ∙ cong (λ z → ListPAppendTotal z (ρ tt , ρᴰ tt))
+            (ListUnitInterpPath ρ ρᴰ))
+    ListFreeModelᴰ .snd .fst unit-rEq ρ ρᴰ =
+      R.rectifyOut {e' = ListFreeModel .snd .fst unit-rEq ρ}
+        ( ListMultInterpPath ρ ρᴰ (T.S.var tt) unitTm
+        ∙ cong (ListPAppendTotal (ρ tt , ρᴰ tt))
+            (ListUnitInterpPath ρ ρᴰ)
+        ∙ ListPAppendUnitR (ρᴰ tt))
+    ListFreeModelᴰ .snd .fst assocEq ρ ρᴰ =
+      R.rectifyOut {e' = ListFreeModel .snd .fst assocEq ρ}
+        ( ListMultInterpPath ρ ρᴰ (T.S.var leftVar)
+            (multTm (T.S.var middleVar) (T.S.var rightVar))
+        ∙ cong (ListPAppendTotal (ρ leftVar , ρᴰ leftVar))
+            (ListMultInterpPath ρ ρᴰ
+              (T.S.var middleVar) (T.S.var rightVar))
+        ∙ ListPAppendAssoc
+            (ρᴰ leftVar) (ρᴰ middleVar) (ρᴰ rightVar)
+        ∙ cong (λ z → ListPAppendTotal z (ρ rightVar , ρᴰ rightVar))
+            (sym (ListMultInterpPath ρ ρᴰ
+              (T.S.var leftVar) (T.S.var middleVar)))
+        ∙ sym (ListMultInterpPath ρ ρᴰ
+            (multTm (T.S.var leftVar) (T.S.var middleVar))
+            (T.S.var rightVar)))
+    ListFreeModelᴰ .snd .snd xs =
+      isOfHLevelSucSuc-ListP 0 (λ x → Xᴰ x .snd)
+
+    ListFreeModelηᴰ : (x : X .fst) → Xᴰ x .fst →
+      ListFreeModelᴰ .fst .fst (ListFreeModelη x)
+    ListFreeModelηᴰ x xᴰ = ListP._∷_ xᴰ ListP.[]
+
+    module _
+      (Bᴰ : T.Modelᴰ ListFreeModel ℓD')
+      (fᴰ : (x : X .fst) → Xᴰ x .fst →
+        Bᴰ .fst .fst (ListFreeModelη x))
+      where
+      private
+        TargetModel : T.Model (ℓ-max ℓX ℓD')
+        TargetModel = T.∫Model {M = ListFreeModel} Bᴰ
+
+        module BᴰR = hSetReasoning
+          (ListFreeModel .fst .fst , ListFreeModel .snd .snd)
+          (Bᴰ .fst .fst)
+
+      ListFreeModelRecᴰ-fun :
+        (xs : ListFreeModel .fst .fst) →
+        ListFreeAlgebraᴰ .fst xs → Bᴰ .fst .fst xs
+      ListFreeModelRecᴰ-fun [] ListP.[] =
+        MonoidModelUnit TargetModel .snd
+      ListFreeModelRecᴰ-fun (x ∷ xs) (ListP._∷_ xᴰ xsᴰ) =
+        MonoidModelMult TargetModel
+          (ListFreeModelη x , fᴰ x xᴰ)
+          (xs , ListFreeModelRecᴰ-fun xs xsᴰ) .snd
+
+      private
+        RecᴰTotal : T.∫Algebra ListFreeAlgebraᴰ .fst →
+          TargetModel .fst .fst
+        RecᴰTotal (xs , xsᴰ) = xs , ListFreeModelRecᴰ-fun xs xsᴰ
+
+      ListFreeModelRecᴰ-++ : {xs ys : List (X .fst)}
+        (xsᴰ : ListP (λ x → Xᴰ x .fst) xs)
+        (ysᴰ : ListP (λ x → Xᴰ x .fst) ys) →
+        Path (TargetModel .fst .fst)
+          ( RecᴰTotal
+              (xs ++ ys , appendListP xsᴰ ysᴰ))
+          ( MonoidModelMult TargetModel
+              (RecᴰTotal (xs , xsᴰ)) (RecᴰTotal (ys , ysᴰ)))
+      ListFreeModelRecᴰ-++ ListP.[] ysᴰ =
+        sym (MonoidModelUnitL TargetModel (RecᴰTotal (_ , ysᴰ)))
+      ListFreeModelRecᴰ-++
+        (ListP._∷_ {x = x} xᴰ xsᴰ) ysᴰ =
+        cong (MonoidModelMult TargetModel
+          (ListFreeModelη x , fᴰ x xᴰ))
+          (ListFreeModelRecᴰ-++ xsᴰ ysᴰ)
+        ∙ MonoidModelAssoc TargetModel
+            (ListFreeModelη x , fᴰ x xᴰ)
+            (RecᴰTotal (_ , xsᴰ)) (RecᴰTotal (_ , ysᴰ))
+
+      ListFreeModelRecᴰ-β : (x : X .fst) (xᴰ : Xᴰ x .fst) →
+        ListFreeModelRecᴰ-fun
+          (ListFreeModelη x) (ListFreeModelηᴰ x xᴰ) ≡ fᴰ x xᴰ
+      ListFreeModelRecᴰ-β x xᴰ = BᴰR.rectifyOut {e' = refl}
+        (MonoidModelUnitR TargetModel (ListFreeModelη x , fᴰ x xᴰ))
+
+      private
+        ListFreeModelRecᴰ-pres-unit :
+          (γ : ⊥ → ListFreeModel .fst .fst)
+          (γᴰ : (v : ⊥) → ListFreeAlgebraᴰ .fst (γ v)) →
+          Path (TargetModel .fst .fst)
+            ( ListFreeModel .fst .snd unitOp γ
+            , Bᴰ .fst .snd unitOp γ
+                (λ v → ListFreeModelRecᴰ-fun (γ v) (γᴰ v))
+                _ refl)
+            (RecᴰTotal
+              ( ListFreeModel .fst .snd unitOp γ
+              , ListFreeAlgebraᴰ .snd unitOp γ γᴰ _ refl))
+        ListFreeModelRecᴰ-pres-unit γ γᴰ =
+          cong (T.∫Algebra (Bᴰ .fst) .snd unitOp) (funExt λ ())
+          ∙ cong RecᴰTotal (sym (ListUnitNormalize γ γᴰ))
+
+        ListFreeModelRecᴰ-pres-mult :
+          (γ : Bool → ListFreeModel .fst .fst)
+          (γᴰ : (v : Bool) → ListFreeAlgebraᴰ .fst (γ v)) →
+          Path (TargetModel .fst .fst)
+            ( ListFreeModel .fst .snd multOp γ
+            , Bᴰ .fst .snd multOp γ
+                (λ v → ListFreeModelRecᴰ-fun (γ v) (γᴰ v))
+                _ refl)
+            (RecᴰTotal
+              ( ListFreeModel .fst .snd multOp γ
+              , ListFreeAlgebraᴰ .snd multOp γ γᴰ _ refl))
+        ListFreeModelRecᴰ-pres-mult γ γᴰ =
+          cong (T.∫Algebra (Bᴰ .fst) .snd multOp)
+            (funExt λ { false → refl ; true → refl })
+          ∙ sym (ListFreeModelRecᴰ-++ (γᴰ false) (γᴰ true))
+          ∙ cong RecᴰTotal (sym (ListMultNormalize γ γᴰ))
+
+      ListFreeModelRecᴰ :
+        T.Homoᴰ (T.idHomo {A = ListFreeModel .fst})
+          ListFreeAlgebraᴰ (Bᴰ .fst)
+      ListFreeModelRecᴰ .fst = ListFreeModelRecᴰ-fun
+      ListFreeModelRecᴰ .snd unitOp γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩
+        op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ =
+          BᴰR.rectifyOut {e' = refl}
+            ( sym (T.Algebraᴰ-op-filler (Bᴰ .fst) unitOp γ
+                (λ v → ListFreeModelRecᴰ-fun (γ v) (γᴰ v))
+                op⟨γ⟩ op∘γ≡op⟨γ⟩)
+            ∙ ListFreeModelRecᴰ-pres-unit γ γᴰ
+            ∙ cong RecᴰTotal sourcePath)
+        where
+        sourcePath : Path (T.∫Algebra ListFreeAlgebraᴰ .fst)
+          ( ListFreeModel .fst .snd unitOp γ
+          , ListFreeAlgebraᴰ .snd unitOp γ γᴰ _ refl)
+          (op⟨γ⟩ , op⟨γᴰ⟩)
+        sourcePath =
+          T.Algebraᴰ-op-filler ListFreeAlgebraᴰ unitOp γ γᴰ
+            op⟨γ⟩ op∘γ≡op⟨γ⟩
+          ∙ R.≡in {pth = refl} op∘γᴰ≡op⟨γᴰ⟩
+      ListFreeModelRecᴰ .snd multOp γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩
+        op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ =
+          BᴰR.rectifyOut {e' = refl}
+            ( sym (T.Algebraᴰ-op-filler (Bᴰ .fst) multOp γ
+                (λ v → ListFreeModelRecᴰ-fun (γ v) (γᴰ v))
+                op⟨γ⟩ op∘γ≡op⟨γ⟩)
+            ∙ ListFreeModelRecᴰ-pres-mult γ γᴰ
+            ∙ cong RecᴰTotal sourcePath)
+        where
+        sourcePath : Path (T.∫Algebra ListFreeAlgebraᴰ .fst)
+          ( ListFreeModel .fst .snd multOp γ
+          , ListFreeAlgebraᴰ .snd multOp γ γᴰ _ refl)
+          (op⟨γ⟩ , op⟨γᴰ⟩)
+        sourcePath =
+          T.Algebraᴰ-op-filler ListFreeAlgebraᴰ multOp γ γᴰ
+            op⟨γ⟩ op∘γ≡op⟨γ⟩
+          ∙ R.≡in {pth = refl} op∘γᴰ≡op⟨γᴰ⟩
+
+    ListFreeModelRecᴰ-uniq :
+      (Bᴰ : T.Modelᴰ ListFreeModel ℓD')
+      (hᴰ : T.Homoᴰ (T.idHomo {A = ListFreeModel .fst})
+        ListFreeAlgebraᴰ (Bᴰ .fst)) →
+      hᴰ .fst ≡
+        ListFreeModelRecᴰ Bᴰ
+          (λ x xᴰ → hᴰ .fst
+            (ListFreeModelη x) (ListFreeModelηᴰ x xᴰ)) .fst
+    ListFreeModelRecᴰ-uniq Bᴰ hᴰ =
+      funExt λ xs → funExt λ xsᴰ →
+        BᴰR.rectifyOut {e' = refl} (totalPath xs xsᴰ)
+      where
+      TargetModel : T.Model _
+      TargetModel = T.∫Model {M = ListFreeModel} Bᴰ
+
+      module BᴰR = hSetReasoning
+        (ListFreeModel .fst .fst , ListFreeModel .snd .snd)
+        (Bᴰ .fst .fst)
+
+      HomoᴰTotal : T.Homo
+        (T.∫Algebra ListFreeAlgebraᴰ)
+        (TargetModel .fst)
+      HomoᴰTotal .fst z = z .fst , hᴰ .fst (z .fst) (z .snd)
+      HomoᴰTotal .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+        T.Algebraᴰ-op-filler (Bᴰ .fst) op
+          (λ v → γ v .fst)
+          (λ v → hᴰ .fst (γ v .fst) (γ v .snd))
+          (op⟨γ⟩ .fst) basePath
+        ∙ BᴰR.≡in {pth = refl}
+            (hᴰ .snd op
+              (λ v → γ v .fst) (λ v → γ v .snd)
+              (op⟨γ⟩ .fst) basePath (op⟨γ⟩ .snd) sourceᴰ≡)
+        where
+        basePath : ListFreeModel .fst .snd op (λ v → γ v .fst) ≡
+          op⟨γ⟩ .fst
+        basePath i = op∘γ≡op⟨γ⟩ i .fst
+
+        sourceᴰ≡ :
+          ListFreeAlgebraᴰ .snd op
+            (λ v → γ v .fst) (λ v → γ v .snd)
+            (op⟨γ⟩ .fst) basePath
+          ≡ op⟨γ⟩ .snd
+        sourceᴰ≡ = R.rectifyOut {e' = refl}
+          ( sym (T.Algebraᴰ-op-filler ListFreeAlgebraᴰ op
+              (λ v → γ v .fst) (λ v → γ v .snd)
+              (op⟨γ⟩ .fst) basePath)
+          ∙ op∘γ≡op⟨γ⟩)
+
+      generator : (x : X .fst) (xᴰ : Xᴰ x .fst) →
+        T.∫Algebra ListFreeAlgebraᴰ .fst
+      generator x xᴰ = ListFreeModelη x , ListFreeModelηᴰ x xᴰ
+
+      totalPath : (xs : List (X .fst))
+        (xsᴰ : ListFreeAlgebraᴰ .fst xs) →
+        Path (TargetModel .fst .fst)
+          (xs , hᴰ .fst xs xsᴰ)
+          ( xs
+          , ListFreeModelRecᴰ Bᴰ
+              (λ x xᴰ → hᴰ .fst
+                (ListFreeModelη x) (ListFreeModelηᴰ x xᴰ))
+              .fst xs xsᴰ)
+      totalPath [] ListP.[] =
+        sym (HomoᴰTotal .snd unitOp emptySource
+          ([] , ListP.[]) unitSourcePath)
+        ∙ cong (TargetModel .fst .snd unitOp) (funExt λ ())
+        where
+        emptySource : ⊥ → T.∫Algebra ListFreeAlgebraᴰ .fst
+        emptySource = emptyBranches
+
+        unitSourcePath :
+          T.∫Algebra ListFreeAlgebraᴰ .snd unitOp emptySource ≡
+            ([] , ListP.[])
+        unitSourcePath = ListUnitNormalize
+          (λ v → emptySource v .fst) (λ v → emptySource v .snd)
+      totalPath (x ∷ xs) (ListP._∷_ xᴰ xsᴰ) =
+        sym (HomoᴰTotal .snd multOp sourceBranches
+          (x ∷ xs , ListP._∷_ xᴰ xsᴰ) sourceNormalize)
+        ∙ cong (TargetModel .fst .snd multOp)
+            (funExt λ { false → refl ; true → refl })
+        ∙ cong (MonoidModelMult TargetModel
+            (ListFreeModelη x , hᴰ .fst
+              (ListFreeModelη x) (ListFreeModelηᴰ x xᴰ)))
+            (totalPath xs xsᴰ)
+        where
+        sourceBranches : Bool → T.∫Algebra ListFreeAlgebraᴰ .fst
+        sourceBranches = boolBranches (generator x xᴰ) (xs , xsᴰ)
+
+        sourceNormalize :
+          T.∫Algebra ListFreeAlgebraᴰ .snd multOp sourceBranches ≡
+            (x ∷ xs , ListP._∷_ xᴰ xsᴰ)
+        sourceNormalize = ListMultNormalize
+          (λ v → sourceBranches v .fst)
+          (λ v → sourceBranches v .snd)
+
+    ListFreeModelUniversalᴰ :
+      (Bᴰ : T.Modelᴰ ListFreeModel ℓD') →
+      isEquiv
+        (λ (hᴰ : T.Homoᴰ (T.idHomo {A = ListFreeModel .fst})
+            ListFreeAlgebraᴰ (Bᴰ .fst)) x xᴰ →
+          hᴰ .fst (ListFreeModelη x) (ListFreeModelηᴰ x xᴰ))
+    ListFreeModelUniversalᴰ Bᴰ = isIsoToIsEquiv
+      ( ListFreeModelRecᴰ Bᴰ
+      , (λ fᴰ → funExt λ x → funExt λ xᴰ →
+          ListFreeModelRecᴰ-β Bᴰ fᴰ x xᴰ)
+      , (λ hᴰ → Σ≡Prop
+          (λ _ → isPropΠ6 λ _ _ _ _ _ _ →
+            isPropΠ λ _ → Bᴰ .snd .snd _ _ _)
+          (sym (ListFreeModelRecᴰ-uniq Bᴰ hᴰ)))
+      )
+
+    module _ {B : T.Model ℓB}
+      (ϕ : T.Homo (ListFreeModel .fst) (B .fst))
+      (Bᴰ : T.Modelᴰ B ℓD')
+      (fᴰ : (x : X .fst) → Xᴰ x .fst →
+        Bᴰ .fst .fst (ϕ .fst (ListFreeModelη x)))
+      where
+      ListFreeModelRecOverᴰ :
+        T.Homoᴰ ϕ ListFreeAlgebraᴰ (Bᴰ .fst)
+      ListFreeModelRecOverᴰ =
+        ListFreeModelRecᴰ
+          (T._*_ {M = ListFreeModel} {N = B} ϕ Bᴰ) fᴰ
+
+      ListFreeModelRecOverᴰ-β :
+        (x : X .fst) (xᴰ : Xᴰ x .fst) →
+        ListFreeModelRecOverᴰ .fst
+          (ListFreeModelη x) (ListFreeModelηᴰ x xᴰ) ≡ fᴰ x xᴰ
+      ListFreeModelRecOverᴰ-β =
+        ListFreeModelRecᴰ-β
+          (T._*_ {M = ListFreeModel} {N = B} ϕ Bᴰ) fᴰ
+
+    ListFreeModelRecOverᴰ-uniq : {B : T.Model ℓB}
+      (ϕ : T.Homo (ListFreeModel .fst) (B .fst))
+      (Bᴰ : T.Modelᴰ B ℓD')
+      (hᴰ : T.Homoᴰ ϕ ListFreeAlgebraᴰ (Bᴰ .fst)) →
+      hᴰ .fst ≡ ListFreeModelRecOverᴰ {B = B} ϕ Bᴰ
+        (λ x xᴰ → hᴰ .fst
+          (ListFreeModelη x) (ListFreeModelηᴰ x xᴰ)) .fst
+    ListFreeModelRecOverᴰ-uniq {B = B} ϕ Bᴰ =
+      ListFreeModelRecᴰ-uniq
+        (T._*_ {M = ListFreeModel} {N = B} ϕ Bᴰ)
+
+    ListFreeModelUniversalOverᴰ : {B : T.Model ℓB}
+      (ϕ : T.Homo (ListFreeModel .fst) (B .fst))
+      (Bᴰ : T.Modelᴰ B ℓD') →
+      isEquiv
+        (λ (hᴰ : T.Homoᴰ ϕ ListFreeAlgebraᴰ (Bᴰ .fst)) x xᴰ →
+          hᴰ .fst (ListFreeModelη x) (ListFreeModelηᴰ x xᴰ))
+    ListFreeModelUniversalOverᴰ {B = B} ϕ Bᴰ =
+      ListFreeModelUniversalᴰ
+        (T._*_ {M = ListFreeModel} {N = B} ϕ Bᴰ)

--- a/Cubical/Algebra/Theory/Instances/Reader.agda
+++ b/Cubical/Algebra/Theory/Instances/Reader.agda
@@ -1,0 +1,392 @@
+-- The algebraic theory of a read-only environment.
+module Cubical.Algebra.Theory.Instances.Reader where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.More
+
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit
+
+open import Cubical.Algebra.Theory.Base
+
+private
+  variable
+    ℓR ℓV ℓX ℓB ℓD ℓD' : Level
+
+data ReaderOp : Type ℓ-zero where
+  ask : ReaderOp
+
+ReaderSignature : (Env : Type ℓR) → Signature ℓ-zero ℓR
+ReaderSignature Env .Signature.Op = ReaderOp
+ReaderSignature Env .Signature.Arity ask = Env
+
+module ReaderSignature {r : Level} (Env : Type r) where
+  open Signature (ReaderSignature Env) public
+
+module _ (Env : Type ℓR) where
+  private
+    module S = Signature (ReaderSignature Env)
+
+  askTm : ∀ {V : Type ℓV}
+    → (Env → S.|FreeAlgebra| V) → S.|FreeAlgebra| V
+  askTm γ = S.app ask γ
+
+  data ReaderEq : Type ℓ-zero where
+    ask-constEq : ReaderEq
+    ask-askEq : ReaderEq
+
+  ReaderEqArity : ReaderEq → Type ℓR
+  ReaderEqArity ask-constEq = Unit*
+  ReaderEqArity ask-askEq = Env × Env
+
+  ReaderLhs : (e : ReaderEq) → S.|FreeAlgebra| (ReaderEqArity e)
+  ReaderLhs ask-constEq = askTm (λ _ → S.var tt*)
+  ReaderLhs ask-askEq =
+    askTm (λ r → askTm (λ r' → S.var (r , r')))
+
+  ReaderRhs : (e : ReaderEq) → S.|FreeAlgebra| (ReaderEqArity e)
+  ReaderRhs ask-constEq = S.var tt*
+  ReaderRhs ask-askEq = askTm (λ r → S.var (r , r))
+
+  ReaderTheory : Theory ℓ-zero ℓR ℓ-zero ℓR
+  ReaderTheory .Theory.S = ReaderSignature Env
+  ReaderTheory .Theory.Eq = ReaderEq
+  ReaderTheory .Theory.EqArity = ReaderEqArity
+  ReaderTheory .Theory.lhs = ReaderLhs
+  ReaderTheory .Theory.rhs = ReaderRhs
+
+module ReaderTheory {r : Level} (Env : Type r) where
+  open Theory (ReaderTheory Env) public
+
+module _ (Env : Type ℓR) (X : hSet ℓX) where
+  private
+    module T = Theory (ReaderTheory Env)
+
+  ReaderFreeModel : T.Model (ℓ-max ℓR ℓX)
+  ReaderFreeModel .fst .fst = Env → X .fst
+  ReaderFreeModel .fst .snd ask γ r = γ r r
+  ReaderFreeModel .snd .fst ask-constEq ρ =
+    funExt λ _ → refl
+  ReaderFreeModel .snd .fst ask-askEq ρ =
+    funExt λ _ → refl
+  ReaderFreeModel .snd .snd = isSetΠ λ _ → X .snd
+
+  ReaderFreeModelη : X .fst → ReaderFreeModel .fst .fst
+  ReaderFreeModelη x _ = x
+
+  module _ (B : T.Model ℓB) (f : X .fst → B .fst .fst) where
+    ReaderFreeModelRec : T.Homo (ReaderFreeModel .fst) (B .fst)
+    ReaderFreeModelRec .fst g =
+      B .fst .snd ask (λ r → f (g r))
+    ReaderFreeModelRec .snd ask γ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+      B .snd .fst ask-askEq
+        (λ { (r , r') → f (γ r r') })
+      ∙ cong (ReaderFreeModelRec .fst) op∘γ≡op⟨γ⟩
+
+    ReaderFreeModelRec-β : (x : X .fst) →
+      ReaderFreeModelRec .fst (ReaderFreeModelη x) ≡ f x
+    ReaderFreeModelRec-β x =
+      B .snd .fst ask-constEq (λ _ → f x)
+
+  ReaderFreeModelRec-uniq :
+    (B : T.Model ℓB)
+    (f : T.Homo (ReaderFreeModel .fst) (B .fst))
+    → f .fst ≡
+      ReaderFreeModelRec B (λ x → f .fst (ReaderFreeModelη x)) .fst
+  ReaderFreeModelRec-uniq B f = funExt λ g →
+    sym
+      (f .snd ask (λ r → ReaderFreeModelη (g r)) g refl)
+
+  ReaderFreeModelUniversal : (B : T.Model ℓB) →
+    isEquiv
+      (λ (f : T.Homo (ReaderFreeModel .fst) (B .fst)) x →
+        f .fst (ReaderFreeModelη x))
+  ReaderFreeModelUniversal B = isIsoToIsEquiv
+    ( ReaderFreeModelRec B
+    , (λ f → funExt (ReaderFreeModelRec-β B f))
+    , (λ f → Σ≡Prop
+        (λ _ → isPropΠ4 λ _ _ _ _ → B .snd .snd _ _)
+        (sym (ReaderFreeModelRec-uniq B f)))
+    )
+
+  module _ (Xᴰ : X .fst → hSet ℓD) where
+    private
+      module R = hSetReasoning
+        (ReaderFreeModel .fst .fst , ReaderFreeModel .snd .snd)
+        (λ g → (r : Env) → Xᴰ (g r) .fst)
+
+    ReaderFreeAlgebraᴰ :
+      T.Algebraᴰ (ReaderFreeModel .fst) (ℓ-max ℓR ℓD)
+    ReaderFreeAlgebraᴰ .fst g =
+      (r : Env) → Xᴰ (g r) .fst
+    ReaderFreeAlgebraᴰ .snd ask γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+      R.reind op∘γ≡op⟨γ⟩ (λ r → γᴰ r r)
+
+    ReaderOpNormalize :
+      (γ : Env → ReaderFreeModel .fst .fst)
+      (γᴰ : (r : Env) → ReaderFreeAlgebraᴰ .fst (γ r))
+      → Path (T.∫Algebra ReaderFreeAlgebraᴰ .fst)
+          ( ReaderFreeModel .fst .snd ask γ
+          , ReaderFreeAlgebraᴰ .snd ask γ γᴰ _ refl)
+          ( ReaderFreeModel .fst .snd ask γ
+          , λ r → γᴰ r r)
+    ReaderOpNormalize γ γᴰ = R.reind-filler⁻ refl
+
+    ReaderAppFiller : {V : Type ℓV}
+      ( ρ : V → ReaderFreeModel .fst .fst)
+      (ρᴰ : (v : V) → ReaderFreeAlgebraᴰ .fst (ρ v))
+      (γ : Env → T.|FreeAlgebra| V)
+      → Path (T.∫Algebra ReaderFreeAlgebraᴰ .fst)
+          ( ReaderFreeModel .fst .snd ask
+              (λ r → T.interp (ReaderFreeModel .fst) ρ (γ r))
+          , ReaderFreeAlgebraᴰ .snd ask
+              (λ r → T.interp (ReaderFreeModel .fst) ρ (γ r))
+              (λ r → T.interpᴰ ReaderFreeAlgebraᴰ ρ ρᴰ (γ r))
+              _ refl)
+          ( T.interp (ReaderFreeModel .fst) ρ (T.S.app ask γ)
+          , T.interpᴰ ReaderFreeAlgebraᴰ ρ ρᴰ (T.S.app ask γ))
+    ReaderAppFiller ρ ρᴰ γ =
+      T.Algebraᴰ-op-filler ReaderFreeAlgebraᴰ ask
+        (λ r → T.interp (ReaderFreeModel .fst) ρ (γ r))
+        (λ r → T.interpᴰ ReaderFreeAlgebraᴰ ρ ρᴰ (γ r))
+        (T.interp (ReaderFreeModel .fst) ρ (T.S.app ask γ))
+        (T.recFA (ReaderFreeModel .fst) ρ .snd ask γ
+          (T.S.app ask γ) refl)
+
+    ReaderFreeModelᴰ :
+      T.Modelᴰ ReaderFreeModel (ℓ-max ℓR ℓD)
+    ReaderFreeModelᴰ .fst = ReaderFreeAlgebraᴰ
+    ReaderFreeModelᴰ .snd .fst ask-constEq ρ ρᴰ =
+      R.rectifyOut
+        ( sym (ReaderAppFiller ρ ρᴰ (λ _ → T.S.var tt*))
+        ∙ ReaderOpNormalize (λ _ → ρ tt*) (λ _ → ρᴰ tt*)
+        ∙ etaPath)
+      where
+      etaPath : Path (T.∫Algebra ReaderFreeAlgebraᴰ .fst)
+        ( ReaderFreeModel .fst .snd ask (λ _ → ρ tt*)
+        , λ r → ρᴰ tt* r)
+        (ρ tt* , ρᴰ tt*)
+      etaPath i .fst r = ρ tt* r
+      etaPath i .snd r = ρᴰ tt* r
+    ReaderFreeModelᴰ .snd .fst ask-askEq ρ ρᴰ =
+      R.rectifyOut
+        ( sym (ReaderAppFiller ρ ρᴰ
+            (λ r → T.S.app ask (λ r' → T.S.var (r , r'))))
+        ∙ ReaderOpNormalize
+            (λ r → T.interp (ReaderFreeModel .fst) ρ
+              (T.S.app ask (λ r' → T.S.var (r , r'))))
+            (λ r → T.interpᴰ ReaderFreeAlgebraᴰ ρ ρᴰ
+              (T.S.app ask (λ r' → T.S.var (r , r'))))
+        ∙ middlePath
+        ∙ sym (ReaderOpNormalize
+            (λ r → ρ (r , r)) (λ r → ρᴰ (r , r)))
+        ∙ ReaderAppFiller ρ ρᴰ (λ r → T.S.var (r , r)))
+      where
+      innerPath : (r : Env) →
+        Path (T.∫Algebra ReaderFreeAlgebraᴰ .fst)
+          ( T.interp (ReaderFreeModel .fst) ρ
+              (T.S.app ask (λ r' → T.S.var (r , r')))
+          , T.interpᴰ ReaderFreeAlgebraᴰ ρ ρᴰ
+              (T.S.app ask (λ r' → T.S.var (r , r'))))
+          ( ReaderFreeModel .fst .snd ask (λ r' → ρ (r , r'))
+          , λ r' → ρᴰ (r , r') r')
+      innerPath r =
+        sym (ReaderAppFiller ρ ρᴰ (λ r' → T.S.var (r , r')))
+        ∙ ReaderOpNormalize (λ r' → ρ (r , r'))
+            (λ r' → ρᴰ (r , r'))
+
+      middlePath : Path (T.∫Algebra ReaderFreeAlgebraᴰ .fst)
+        ( ReaderFreeModel .fst .snd ask
+            (λ r → T.interp (ReaderFreeModel .fst) ρ
+              (T.S.app ask (λ r' → T.S.var (r , r'))))
+        , λ r → T.interpᴰ ReaderFreeAlgebraᴰ ρ ρᴰ
+            (T.S.app ask (λ r' → T.S.var (r , r'))) r)
+        ( ReaderFreeModel .fst .snd ask (λ r → ρ (r , r))
+        , λ r → ρᴰ (r , r) r)
+      middlePath i .fst r = innerPath r i .fst r
+      middlePath i .snd r = innerPath r i .snd r
+    ReaderFreeModelᴰ .snd .snd g =
+      isSetΠ λ r → Xᴰ (g r) .snd
+
+    ReaderFreeModelηᴰ : (x : X .fst) → Xᴰ x .fst →
+      ReaderFreeModelᴰ .fst .fst (ReaderFreeModelη x)
+    ReaderFreeModelηᴰ x xᴰ _ = xᴰ
+
+    module _
+      (Bᴰ : T.Modelᴰ ReaderFreeModel ℓD')
+      (fᴰ : (x : X .fst) → Xᴰ x .fst →
+        Bᴰ .fst .fst (ReaderFreeModelη x))
+      where
+      private
+        module BᴰR = hSetReasoning
+          (ReaderFreeModel .fst .fst , ReaderFreeModel .snd .snd)
+          (Bᴰ .fst .fst)
+
+      ReaderFreeModelRecᴰ-fun :
+        (g : ReaderFreeModel .fst .fst) →
+        ReaderFreeAlgebraᴰ .fst g → Bᴰ .fst .fst g
+      ReaderFreeModelRecᴰ-fun g gᴰ =
+        Bᴰ .fst .snd ask
+          (λ r → ReaderFreeModelη (g r))
+          (λ r → fᴰ (g r) (gᴰ r))
+          g refl
+
+      TargetAppFiller : {V : Type ℓV}
+        ( ρ : V → ReaderFreeModel .fst .fst)
+        (ρᴰ : (v : V) → Bᴰ .fst .fst (ρ v))
+        (γ : Env → T.|FreeAlgebra| V)
+        → Path (T.∫Algebra (Bᴰ .fst) .fst)
+            ( ReaderFreeModel .fst .snd ask
+                (λ r → T.interp (ReaderFreeModel .fst) ρ (γ r))
+            , Bᴰ .fst .snd ask
+                (λ r → T.interp (ReaderFreeModel .fst) ρ (γ r))
+                (λ r → T.interpᴰ (Bᴰ .fst) ρ ρᴰ (γ r))
+                _ refl)
+            ( T.interp (ReaderFreeModel .fst) ρ (T.S.app ask γ)
+            , T.interpᴰ (Bᴰ .fst) ρ ρᴰ (T.S.app ask γ))
+      TargetAppFiller ρ ρᴰ γ =
+        T.Algebraᴰ-op-filler (Bᴰ .fst) ask
+          (λ r → T.interp (ReaderFreeModel .fst) ρ (γ r))
+          (λ r → T.interpᴰ (Bᴰ .fst) ρ ρᴰ (γ r))
+          (T.interp (ReaderFreeModel .fst) ρ (T.S.app ask γ))
+          (T.recFA (ReaderFreeModel .fst) ρ .snd ask γ
+            (T.S.app ask γ) refl)
+
+      ReaderFreeModelRecᴰ-β : (x : X .fst) (xᴰ : Xᴰ x .fst) →
+        ReaderFreeModelRecᴰ-fun
+          (ReaderFreeModelη x) (ReaderFreeModelηᴰ x xᴰ) ≡ fᴰ x xᴰ
+      ReaderFreeModelRecᴰ-β x xᴰ = BᴰR.rectifyOut {e' = refl}
+        ( TargetAppFiller
+            (λ (_ : Unit* {ℓR}) → ReaderFreeModelη x)
+            (λ (_ : Unit* {ℓR}) → fᴰ x xᴰ)
+            (λ (_ : Env) → T.S.var tt*)
+        ∙ ΣPathP
+            ( ReaderFreeModel .snd .fst ask-constEq
+                (λ _ → ReaderFreeModelη x)
+            , Bᴰ .snd .fst ask-constEq
+                (λ _ → ReaderFreeModelη x) (λ _ → fᴰ x xᴰ)))
+
+      private
+        RecᴰTotal : T.∫Algebra ReaderFreeAlgebraᴰ .fst →
+          T.∫Algebra (Bᴰ .fst) .fst
+        RecᴰTotal z = z .fst , ReaderFreeModelRecᴰ-fun (z .fst) (z .snd)
+
+      ReaderFreeModelRecᴰ :
+        T.Homoᴰ (T.idHomo {A = ReaderFreeModel .fst})
+          ReaderFreeAlgebraᴰ (Bᴰ .fst)
+      ReaderFreeModelRecᴰ .fst = ReaderFreeModelRecᴰ-fun
+      ReaderFreeModelRecᴰ .snd ask γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩
+        op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ =
+          BᴰR.rectifyOut {e' = refl}
+            ( sym (T.Algebraᴰ-op-filler (Bᴰ .fst) ask γ
+                (λ r → ReaderFreeModelRecᴰ-fun (γ r) (γᴰ r))
+                op⟨γ⟩ op∘γ≡op⟨γ⟩)
+            ∙ cong (T.∫Algebra (Bᴰ .fst) .snd ask)
+                (funExt λ r → TargetAppFiller valuation valuationᴰ
+                  (λ r' → T.S.var (r , r')))
+            ∙ TargetAppFiller valuation valuationᴰ
+                (λ r → T.S.app ask (λ r' → T.S.var (r , r')))
+            ∙ ΣPathP
+                ( ReaderFreeModel .snd .fst ask-askEq valuation
+                , Bᴰ .snd .fst ask-askEq valuation valuationᴰ)
+            ∙ sym (TargetAppFiller valuation valuationᴰ
+                (λ r → T.S.var (r , r)))
+            ∙ cong RecᴰTotal sourcePath)
+          where
+          valuation : Env × Env → ReaderFreeModel .fst .fst
+          valuation (r , r') = ReaderFreeModelη (γ r r')
+
+          valuationᴰ : (rr' : Env × Env) →
+            Bᴰ .fst .fst (valuation rr')
+          valuationᴰ (r , r') = fᴰ (γ r r') (γᴰ r r')
+
+          sourcePath : Path (T.∫Algebra ReaderFreeAlgebraᴰ .fst)
+            (ReaderFreeModel .fst .snd ask γ , λ r → γᴰ r r)
+            (op⟨γ⟩ , op⟨γᴰ⟩)
+          sourcePath =
+            R.reind-filler op∘γ≡op⟨γ⟩ ∙ R.≡in op∘γᴰ≡op⟨γᴰ⟩
+
+    ReaderFreeModelRecᴰ-uniq :
+      (Bᴰ : T.Modelᴰ ReaderFreeModel ℓD')
+      (hᴰ : T.Homoᴰ (T.idHomo {A = ReaderFreeModel .fst})
+        ReaderFreeAlgebraᴰ (Bᴰ .fst))
+      → hᴰ .fst ≡
+        ReaderFreeModelRecᴰ Bᴰ
+          (λ x xᴰ → hᴰ .fst
+            (ReaderFreeModelη x) (ReaderFreeModelηᴰ x xᴰ)) .fst
+    ReaderFreeModelRecᴰ-uniq Bᴰ hᴰ =
+      funExt λ g → funExt λ gᴰ →
+        sym
+          (hᴰ .snd ask
+            (λ r → ReaderFreeModelη (g r))
+            (λ r → ReaderFreeModelηᴰ (g r) (gᴰ r))
+            g refl gᴰ (sourceᴰ≡ g gᴰ))
+      where
+      sourceᴰ≡ : (g : ReaderFreeModel .fst .fst)
+        (gᴰ : ReaderFreeAlgebraᴰ .fst g) →
+        ReaderFreeAlgebraᴰ .snd ask
+          (λ r → ReaderFreeModelη (g r))
+          (λ r → ReaderFreeModelηᴰ (g r) (gᴰ r))
+          g refl
+        ≡ gᴰ
+      sourceᴰ≡ g gᴰ = R.rectifyOut {e' = refl} (R.reind-filler⁻ refl)
+
+    ReaderFreeModelUniversalᴰ :
+      (Bᴰ : T.Modelᴰ ReaderFreeModel ℓD') →
+      isEquiv
+        (λ (hᴰ : T.Homoᴰ (T.idHomo {A = ReaderFreeModel .fst})
+            ReaderFreeAlgebraᴰ (Bᴰ .fst)) x xᴰ →
+          hᴰ .fst (ReaderFreeModelη x) (ReaderFreeModelηᴰ x xᴰ))
+    ReaderFreeModelUniversalᴰ Bᴰ = isIsoToIsEquiv
+      ( ReaderFreeModelRecᴰ Bᴰ
+      , (λ fᴰ → funExt λ x → funExt λ xᴰ →
+          ReaderFreeModelRecᴰ-β Bᴰ fᴰ x xᴰ)
+      , (λ hᴰ → Σ≡Prop
+          (λ _ → isPropΠ6 λ _ _ _ _ _ _ →
+            isPropΠ λ _ → Bᴰ .snd .snd _ _ _)
+          (sym (ReaderFreeModelRecᴰ-uniq Bᴰ hᴰ)))
+      )
+
+    module _ {B : T.Model ℓB}
+      (ϕ : T.Homo (ReaderFreeModel .fst) (B .fst))
+      (Bᴰ : T.Modelᴰ B ℓD')
+      (fᴰ : (x : X .fst) → Xᴰ x .fst →
+        Bᴰ .fst .fst (ϕ .fst (ReaderFreeModelη x)))
+      where
+      ReaderFreeModelRecOverᴰ :
+        T.Homoᴰ ϕ ReaderFreeAlgebraᴰ (Bᴰ .fst)
+      ReaderFreeModelRecOverᴰ =
+        ReaderFreeModelRecᴰ
+          (T._*_ {M = ReaderFreeModel} {N = B} ϕ Bᴰ) fᴰ
+
+      ReaderFreeModelRecOverᴰ-β :
+        (x : X .fst) (xᴰ : Xᴰ x .fst) →
+        ReaderFreeModelRecOverᴰ .fst
+          (ReaderFreeModelη x) (ReaderFreeModelηᴰ x xᴰ) ≡ fᴰ x xᴰ
+      ReaderFreeModelRecOverᴰ-β =
+        ReaderFreeModelRecᴰ-β
+          (T._*_ {M = ReaderFreeModel} {N = B} ϕ Bᴰ) fᴰ
+
+    ReaderFreeModelRecOverᴰ-uniq : {B : T.Model ℓB}
+      (ϕ : T.Homo (ReaderFreeModel .fst) (B .fst))
+      (Bᴰ : T.Modelᴰ B ℓD')
+      (hᴰ : T.Homoᴰ ϕ ReaderFreeAlgebraᴰ (Bᴰ .fst))
+      → hᴰ .fst ≡ ReaderFreeModelRecOverᴰ {B = B} ϕ Bᴰ
+          (λ x xᴰ → hᴰ .fst
+            (ReaderFreeModelη x) (ReaderFreeModelηᴰ x xᴰ)) .fst
+    ReaderFreeModelRecOverᴰ-uniq {B = B} ϕ Bᴰ =
+      ReaderFreeModelRecᴰ-uniq
+        (T._*_ {M = ReaderFreeModel} {N = B} ϕ Bᴰ)
+
+    ReaderFreeModelUniversalOverᴰ : {B : T.Model ℓB}
+      (ϕ : T.Homo (ReaderFreeModel .fst) (B .fst))
+      (Bᴰ : T.Modelᴰ B ℓD') →
+      isEquiv
+        (λ (hᴰ : T.Homoᴰ ϕ ReaderFreeAlgebraᴰ (Bᴰ .fst)) x xᴰ →
+          hᴰ .fst (ReaderFreeModelη x) (ReaderFreeModelηᴰ x xᴰ))
+    ReaderFreeModelUniversalOverᴰ {B = B} ϕ Bᴰ =
+      ReaderFreeModelUniversalᴰ
+        (T._*_ {M = ReaderFreeModel} {N = B} ϕ Bᴰ)

--- a/Cubical/Algebra/Theory/Instances/State.agda
+++ b/Cubical/Algebra/Theory/Instances/State.agda
@@ -1,0 +1,646 @@
+-- The algebraic theory of a single mutable store.
+module Cubical.Algebra.Theory.Instances.State where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.More
+
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit
+
+open import Cubical.Algebra.Theory.Base
+
+private
+  variable
+    ℓS ℓV ℓX ℓB ℓD ℓD' : Level
+
+data StateOp {s : Level} (Store : Type s) : Type s where
+  read : StateOp Store
+  write : Store → StateOp Store
+
+StateSignature : (Store : Type ℓS) → Signature ℓS ℓS
+StateSignature Store .Signature.Op = StateOp Store
+StateSignature Store .Signature.Arity read = Store
+StateSignature Store .Signature.Arity (write _) = Unit*
+
+module StateSignature {s : Level} (Store : Type s) where
+  open Signature (StateSignature Store) public
+
+module _ (Store : Type ℓS) where
+  private
+    module S = Signature (StateSignature Store)
+
+  readTm : ∀ {V : Type ℓV}
+    → (Store → S.|FreeAlgebra| V) → S.|FreeAlgebra| V
+  readTm γ = S.app read γ
+
+  writeTm : ∀ {V : Type ℓV}
+    → Store → S.|FreeAlgebra| V → S.|FreeAlgebra| V
+  writeTm s t = S.app (write s) (λ _ → t)
+
+  data StateEq : Type ℓS where
+    wt-rdEq : Store → StateEq
+    rd-wtEq : StateEq
+    wt-wtEq : Store → Store → StateEq
+
+  StateEqArity : StateEq → Type ℓS
+  StateEqArity (wt-rdEq _) = Store
+  StateEqArity rd-wtEq = Unit*
+  StateEqArity (wt-wtEq _ _) = Unit*
+
+  StateLhs : (e : StateEq) → S.|FreeAlgebra| (StateEqArity e)
+  StateLhs (wt-rdEq s) =
+    writeTm s (readTm S.var)
+  StateLhs rd-wtEq = S.var tt*
+  StateLhs (wt-wtEq s s') =
+    writeTm s (writeTm s' (S.var tt*))
+
+  StateRhs : (e : StateEq) → S.|FreeAlgebra| (StateEqArity e)
+  StateRhs (wt-rdEq s) = writeTm s (S.var s)
+  StateRhs rd-wtEq = readTm (λ s → writeTm s (S.var tt*))
+  StateRhs (wt-wtEq _ s') = writeTm s' (S.var tt*)
+
+  StateTheory : Theory ℓS ℓS ℓS ℓS
+  StateTheory .Theory.S = StateSignature Store
+  StateTheory .Theory.Eq = StateEq
+  StateTheory .Theory.EqArity = StateEqArity
+  StateTheory .Theory.lhs = StateLhs
+  StateTheory .Theory.rhs = StateRhs
+
+module StateTheory {s : Level} (Store : Type s) where
+  open Theory (StateTheory Store) public
+
+module _ (Store : Type ℓS) (B : Theory.Model (StateTheory Store) ℓB) where
+  StateModelRead : (Store → B .fst .fst) → B .fst .fst
+  StateModelRead γ = B .fst .snd read γ
+
+  StateModelWrite : Store → B .fst .fst → B .fst .fst
+  StateModelWrite s x = B .fst .snd (write s) (λ _ → x)
+
+  StateModelWriteRead : (s : Store) (γ : Store → B .fst .fst) →
+    StateModelWrite s (StateModelRead γ) ≡ StateModelWrite s (γ s)
+  StateModelWriteRead s γ =
+    B .snd .fst (wt-rdEq s) γ
+
+  StateModelReadWrite : (x : B .fst .fst) →
+    x ≡ StateModelRead (λ s → StateModelWrite s x)
+  StateModelReadWrite x =
+    B .snd .fst rd-wtEq (λ _ → x)
+
+  StateModelWriteWrite : (s s' : Store) (x : B .fst .fst) →
+    StateModelWrite s (StateModelWrite s' x) ≡ StateModelWrite s' x
+  StateModelWriteWrite s s' x =
+    B .snd .fst (wt-wtEq s s') (λ _ → x)
+
+  StateModelReadRead : (γ : Store → Store → B .fst .fst) →
+    StateModelRead (λ s → StateModelRead (γ s)) ≡
+      StateModelRead (λ s → γ s s)
+  StateModelReadRead γ =
+    StateModelReadWrite (StateModelRead (λ s → StateModelRead (γ s)))
+    ∙ cong StateModelRead
+        (funExt λ s →
+          StateModelWriteRead s (λ s' → StateModelRead (γ s'))
+          ∙ StateModelWriteRead s (γ s)
+          ∙ sym (StateModelWriteRead s (λ s' → γ s' s')))
+    ∙ sym (StateModelReadWrite (StateModelRead (λ s → γ s s)))
+
+  StateModelReadIdempotent : (x : B .fst .fst) →
+    StateModelRead (λ _ → x) ≡ x
+  StateModelReadIdempotent x =
+    StateModelReadWrite (StateModelRead (λ _ → x))
+    ∙ cong StateModelRead
+        (funExt λ s → StateModelWriteRead s (λ _ → x))
+    ∙ sym (StateModelReadWrite x)
+
+module _ (Store : hSet ℓS) (X : hSet ℓX) where
+  private
+    module T = Theory (StateTheory (Store .fst))
+
+  StateFreeModel : T.Model (ℓ-max ℓS ℓX)
+  StateFreeModel .fst .fst = Store .fst → Store .fst × X .fst
+  StateFreeModel .fst .snd read γ s = γ s s
+  StateFreeModel .fst .snd (write s) γ _ = γ tt* s
+  StateFreeModel .snd .fst (wt-rdEq s) ρ =
+    funExt λ _ → refl
+  StateFreeModel .snd .fst rd-wtEq ρ =
+    funExt λ _ → refl
+  StateFreeModel .snd .fst (wt-wtEq s s') ρ =
+    funExt λ _ → refl
+  StateFreeModel .snd .snd =
+    isSetΠ λ _ → isSet× (Store .snd) (X .snd)
+
+  StateFreeModelη : X .fst → StateFreeModel .fst .fst
+  StateFreeModelη x s = s , x
+
+  module _ (B : T.Model ℓB) (f : X .fst → B .fst .fst) where
+    StateFreeModelRec : T.Homo (StateFreeModel .fst) (B .fst)
+    StateFreeModelRec .fst q =
+      StateModelRead (Store .fst) B λ s →
+        StateModelWrite (Store .fst) B (q s .fst) (f (q s .snd))
+    StateFreeModelRec .snd read γ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+      StateModelReadRead (Store .fst) B
+        (λ s s' →
+          StateModelWrite (Store .fst) B
+            (γ s s' .fst) (f (γ s s' .snd)))
+      ∙ cong (StateFreeModelRec .fst) op∘γ≡op⟨γ⟩
+    StateFreeModelRec .snd (write s) γ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+      StateModelWriteRead (Store .fst) B s
+        (λ s' →
+          StateModelWrite (Store .fst) B
+            (γ tt* s' .fst) (f (γ tt* s' .snd)))
+      ∙ StateModelWriteWrite (Store .fst) B s (γ tt* s .fst)
+          (f (γ tt* s .snd))
+      ∙ sym
+          (StateModelReadIdempotent (Store .fst) B
+            (StateModelWrite (Store .fst) B
+              (γ tt* s .fst) (f (γ tt* s .snd))))
+      ∙ cong (StateFreeModelRec .fst) op∘γ≡op⟨γ⟩
+
+    StateFreeModelRec-β : (x : X .fst) →
+      StateFreeModelRec .fst (StateFreeModelη x) ≡ f x
+    StateFreeModelRec-β x =
+      sym (StateModelReadWrite (Store .fst) B (f x))
+
+  StateFreeModelRec-uniq :
+    (B : T.Model ℓB)
+    (f : T.Homo (StateFreeModel .fst) (B .fst))
+    → f .fst ≡
+      StateFreeModelRec B (λ x → f .fst (StateFreeModelη x)) .fst
+  StateFreeModelRec-uniq B f = funExt λ q →
+    sym
+      ( cong (StateModelRead (Store .fst) B)
+          (funExt λ s →
+            f .snd (write (q s .fst))
+              (λ _ → StateFreeModelη (q s .snd))
+              (branch q s) refl)
+      ∙ f .snd read (branch q) q refl)
+    where
+    branch : StateFreeModel .fst .fst →
+      Store .fst → StateFreeModel .fst .fst
+    branch q s =
+      StateFreeModel .fst .snd (write (q s .fst))
+        (λ _ → StateFreeModelη (q s .snd))
+
+  StateFreeModelUniversal : (B : T.Model ℓB) →
+    isEquiv
+      (λ (f : T.Homo (StateFreeModel .fst) (B .fst)) x →
+        f .fst (StateFreeModelη x))
+  StateFreeModelUniversal B = isIsoToIsEquiv
+    ( StateFreeModelRec B
+    , (λ f → funExt (StateFreeModelRec-β B f))
+    , (λ f → Σ≡Prop
+        (λ _ → isPropΠ4 λ _ _ _ _ → B .snd .snd _ _)
+        (sym (StateFreeModelRec-uniq B f)))
+    )
+
+  module _ (Xᴰ : X .fst → hSet ℓD) where
+    private
+      module R = hSetReasoning
+        (StateFreeModel .fst .fst , StateFreeModel .snd .snd)
+        (λ q → (s : Store .fst) → Xᴰ (q s .snd) .fst)
+
+    StateFreeAlgebraᴰ :
+      T.Algebraᴰ (StateFreeModel .fst) (ℓ-max ℓS ℓD)
+    StateFreeAlgebraᴰ .fst q =
+      (s : Store .fst) → Xᴰ (q s .snd) .fst
+    StateFreeAlgebraᴰ .snd read γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+      R.reind op∘γ≡op⟨γ⟩ (λ s → γᴰ s s)
+    StateFreeAlgebraᴰ .snd (write s) γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+      R.reind op∘γ≡op⟨γ⟩ (λ _ → γᴰ tt* s)
+
+    StateReadNormalize :
+      (γ : Store .fst → StateFreeModel .fst .fst)
+      (γᴰ : (s : Store .fst) → StateFreeAlgebraᴰ .fst (γ s))
+      → Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
+          ( StateFreeModel .fst .snd read γ
+          , StateFreeAlgebraᴰ .snd read γ γᴰ _ refl)
+          ( StateFreeModel .fst .snd read γ
+          , λ s → γᴰ s s)
+    StateReadNormalize γ γᴰ = R.reind-filler⁻ refl
+
+    StateWriteNormalize :
+      (s : Store .fst)
+      (γ : Unit* → StateFreeModel .fst .fst)
+      (γᴰ : (u : Unit*) → StateFreeAlgebraᴰ .fst (γ u))
+      → Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
+          ( StateFreeModel .fst .snd (write s) γ
+          , StateFreeAlgebraᴰ .snd (write s) γ γᴰ _ refl)
+          ( StateFreeModel .fst .snd (write s) γ
+          , λ _ → γᴰ tt* s)
+    StateWriteNormalize s γ γᴰ = R.reind-filler⁻ refl
+
+    StateReadAppFiller : {V : Type ℓV}
+      (ρ : V → StateFreeModel .fst .fst)
+      (ρᴰ : (v : V) → StateFreeAlgebraᴰ .fst (ρ v))
+      (γ : Store .fst → T.|FreeAlgebra| V)
+      → Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
+          ( StateFreeModel .fst .snd read
+              (λ s → T.interp (StateFreeModel .fst) ρ (γ s))
+          , StateFreeAlgebraᴰ .snd read
+              (λ s → T.interp (StateFreeModel .fst) ρ (γ s))
+              (λ s → T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ (γ s))
+              _ refl)
+          ( T.interp (StateFreeModel .fst) ρ (T.S.app read γ)
+          , T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ (T.S.app read γ))
+    StateReadAppFiller ρ ρᴰ γ =
+      T.Algebraᴰ-op-filler StateFreeAlgebraᴰ read
+        (λ s → T.interp (StateFreeModel .fst) ρ (γ s))
+        (λ s → T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ (γ s))
+        (T.interp (StateFreeModel .fst) ρ (T.S.app read γ))
+        (T.recFA (StateFreeModel .fst) ρ .snd read γ
+          (T.S.app read γ) refl)
+
+    StateWriteAppFiller : {V : Type ℓV}
+      (s : Store .fst)
+      (ρ : V → StateFreeModel .fst .fst)
+      (ρᴰ : (v : V) → StateFreeAlgebraᴰ .fst (ρ v))
+      (γ : Unit* → T.|FreeAlgebra| V)
+      → Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
+          ( StateFreeModel .fst .snd (write s)
+              (λ u → T.interp (StateFreeModel .fst) ρ (γ u))
+          , StateFreeAlgebraᴰ .snd (write s)
+              (λ u → T.interp (StateFreeModel .fst) ρ (γ u))
+              (λ u → T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ (γ u))
+              _ refl)
+          ( T.interp (StateFreeModel .fst) ρ (T.S.app (write s) γ)
+          , T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
+              (T.S.app (write s) γ))
+    StateWriteAppFiller s ρ ρᴰ γ =
+      T.Algebraᴰ-op-filler StateFreeAlgebraᴰ (write s)
+        (λ u → T.interp (StateFreeModel .fst) ρ (γ u))
+        (λ u → T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ (γ u))
+        (T.interp (StateFreeModel .fst) ρ (T.S.app (write s) γ))
+        (T.recFA (StateFreeModel .fst) ρ .snd (write s) γ
+          (T.S.app (write s) γ) refl)
+
+    StateFreeModelᴰ :
+      T.Modelᴰ StateFreeModel (ℓ-max ℓS ℓD)
+    StateFreeModelᴰ .fst = StateFreeAlgebraᴰ
+    StateFreeModelᴰ .snd .fst (wt-rdEq s) ρ ρᴰ =
+      R.rectifyOut {e' = StateFreeModel .snd .fst (wt-rdEq s) ρ}
+        ( sym (StateWriteAppFiller s ρ ρᴰ
+            (λ _ → T.S.app read T.S.var))
+        ∙ StateWriteNormalize s
+            (λ _ → T.interp (StateFreeModel .fst) ρ
+              (T.S.app read T.S.var))
+            (λ _ → T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
+              (T.S.app read T.S.var))
+        ∙ cong writeTotal innerPath
+        ∙ sym (StateWriteNormalize s
+            (λ _ → ρ s) (λ _ → ρᴰ s))
+        ∙ StateWriteAppFiller s ρ ρᴰ (λ _ → T.S.var s))
+      where
+      innerPath : Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
+        ( T.interp (StateFreeModel .fst) ρ (T.S.app read T.S.var)
+        , T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
+            (T.S.app read T.S.var))
+        ( StateFreeModel .fst .snd read ρ
+        , λ s' → ρᴰ s' s')
+      innerPath =
+        sym (StateReadAppFiller ρ ρᴰ T.S.var)
+        ∙ StateReadNormalize ρ ρᴰ
+
+      writeTotal : T.∫Algebra StateFreeAlgebraᴰ .fst →
+        T.∫Algebra StateFreeAlgebraᴰ .fst
+      writeTotal z =
+        (λ _ → z .fst s) , (λ _ → z .snd s)
+    StateFreeModelᴰ .snd .fst rd-wtEq ρ ρᴰ =
+      R.rectifyOut {e' = StateFreeModel .snd .fst rd-wtEq ρ}
+        (sym rhsToLhs)
+      where
+      innerPath : (s : Store .fst) →
+        Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
+          ( T.interp (StateFreeModel .fst) ρ
+              (T.S.app (write s) (λ _ → T.S.var tt*))
+          , T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
+              (T.S.app (write s) (λ _ → T.S.var tt*)))
+          ( StateFreeModel .fst .snd (write s) (λ _ → ρ tt*)
+          , λ _ → ρᴰ tt* s)
+      innerPath s =
+        sym (StateWriteAppFiller s ρ ρᴰ (λ _ → T.S.var tt*))
+        ∙ StateWriteNormalize s (λ _ → ρ tt*) (λ _ → ρᴰ tt*)
+
+      middlePath : Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
+        ( StateFreeModel .fst .snd read
+            (λ s → T.interp (StateFreeModel .fst) ρ
+              (T.S.app (write s) (λ _ → T.S.var tt*)))
+        , λ s → T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
+            (T.S.app (write s) (λ _ → T.S.var tt*)) s)
+        (ρ tt* , ρᴰ tt*)
+      middlePath i .fst s = innerPath s i .fst s
+      middlePath i .snd s = innerPath s i .snd s
+
+      rhsToLhs : Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
+        ( T.interp (StateFreeModel .fst) ρ
+            (T.S.app read
+              (λ s → T.S.app (write s) (λ _ → T.S.var tt*)))
+        , T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
+            (T.S.app read
+              (λ s → T.S.app (write s) (λ _ → T.S.var tt*))))
+        (ρ tt* , ρᴰ tt*)
+      rhsToLhs =
+        sym (StateReadAppFiller ρ ρᴰ
+          (λ s → T.S.app (write s) (λ _ → T.S.var tt*)))
+        ∙ StateReadNormalize
+            (λ s → T.interp (StateFreeModel .fst) ρ
+              (T.S.app (write s) (λ _ → T.S.var tt*)))
+            (λ s → T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
+              (T.S.app (write s) (λ _ → T.S.var tt*)))
+        ∙ middlePath
+    StateFreeModelᴰ .snd .fst (wt-wtEq s s') ρ ρᴰ =
+      R.rectifyOut {e' = StateFreeModel .snd .fst (wt-wtEq s s') ρ}
+        ( sym (StateWriteAppFiller s ρ ρᴰ
+            (λ _ → T.S.app (write s') (λ _ → T.S.var tt*)))
+        ∙ StateWriteNormalize s
+            (λ _ → T.interp (StateFreeModel .fst) ρ
+              (T.S.app (write s') (λ _ → T.S.var tt*)))
+            (λ _ → T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
+              (T.S.app (write s') (λ _ → T.S.var tt*)))
+        ∙ cong writeTotal innerPath
+        ∙ sym (StateWriteNormalize s'
+            (λ _ → ρ tt*) (λ _ → ρᴰ tt*))
+        ∙ StateWriteAppFiller s' ρ ρᴰ (λ _ → T.S.var tt*))
+      where
+      innerPath : Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
+        ( T.interp (StateFreeModel .fst) ρ
+            (T.S.app (write s') (λ _ → T.S.var tt*))
+        , T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
+            (T.S.app (write s') (λ _ → T.S.var tt*)))
+        ( StateFreeModel .fst .snd (write s') (λ _ → ρ tt*)
+        , λ _ → ρᴰ tt* s')
+      innerPath =
+        sym (StateWriteAppFiller s' ρ ρᴰ (λ _ → T.S.var tt*))
+        ∙ StateWriteNormalize s' (λ _ → ρ tt*) (λ _ → ρᴰ tt*)
+
+      writeTotal : T.∫Algebra StateFreeAlgebraᴰ .fst →
+        T.∫Algebra StateFreeAlgebraᴰ .fst
+      writeTotal z =
+        (λ _ → z .fst s) , (λ _ → z .snd s)
+    StateFreeModelᴰ .snd .snd q =
+      isSetΠ λ s → Xᴰ (q s .snd) .snd
+
+    StateFreeModelηᴰ : (x : X .fst) → Xᴰ x .fst →
+      StateFreeModelᴰ .fst .fst (StateFreeModelη x)
+    StateFreeModelηᴰ x xᴰ _ = xᴰ
+
+    module _
+      (Bᴰ : T.Modelᴰ StateFreeModel ℓD')
+      (fᴰ : (x : X .fst) → Xᴰ x .fst →
+        Bᴰ .fst .fst (StateFreeModelη x))
+      where
+      private
+        TargetModel : T.Model (ℓ-max (ℓ-max ℓS ℓX) ℓD')
+        TargetModel = T.∫Model {M = StateFreeModel} Bᴰ
+
+        module BᴰR = hSetReasoning
+          (StateFreeModel .fst .fst , StateFreeModel .snd .snd)
+          (Bᴰ .fst .fst)
+
+        generator : (x : X .fst) (xᴰ : Xᴰ x .fst) →
+          TargetModel .fst .fst
+        generator x xᴰ = StateFreeModelη x , fᴰ x xᴰ
+
+        RecᴰTotal : T.∫Algebra StateFreeAlgebraᴰ .fst →
+          TargetModel .fst .fst
+        RecᴰTotal z =
+          StateModelRead (Store .fst) TargetModel λ s →
+            StateModelWrite (Store .fst) TargetModel (z .fst s .fst)
+              (generator (z .fst s .snd) (z .snd s))
+
+      StateFreeModelRecᴰ-fun :
+        (q : StateFreeModel .fst .fst) →
+        StateFreeAlgebraᴰ .fst q → Bᴰ .fst .fst q
+      StateFreeModelRecᴰ-fun q qᴰ = RecᴰTotal (q , qᴰ) .snd
+
+      StateFreeModelRecᴰ-β : (x : X .fst) (xᴰ : Xᴰ x .fst) →
+        StateFreeModelRecᴰ-fun
+          (StateFreeModelη x) (StateFreeModelηᴰ x xᴰ) ≡ fᴰ x xᴰ
+      StateFreeModelRecᴰ-β x xᴰ = BᴰR.rectifyOut {e' = refl}
+        (sym (StateModelReadWrite (Store .fst) TargetModel
+          (generator x xᴰ)))
+
+      StateFreeModelRecᴰ :
+        T.Homoᴰ (T.idHomo {A = StateFreeModel .fst})
+          StateFreeAlgebraᴰ (Bᴰ .fst)
+      StateFreeModelRecᴰ .fst = StateFreeModelRecᴰ-fun
+      StateFreeModelRecᴰ .snd read γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩
+        op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ =
+          BᴰR.rectifyOut {e' = refl}
+            ( sym (T.Algebraᴰ-op-filler (Bᴰ .fst) read γ
+                (λ s → StateFreeModelRecᴰ-fun (γ s) (γᴰ s))
+                op⟨γ⟩ op∘γ≡op⟨γ⟩)
+            ∙ StateModelReadRead (Store .fst) TargetModel matrix
+            ∙ cong RecᴰTotal sourcePath)
+          where
+          matrix : Store .fst → Store .fst → TargetModel .fst .fst
+          matrix s s' =
+            StateModelWrite (Store .fst) TargetModel (γ s s' .fst)
+              (generator (γ s s' .snd) (γᴰ s s'))
+
+          sourcePath : Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
+            ( StateFreeModel .fst .snd read γ
+            , λ s → γᴰ s s)
+            (op⟨γ⟩ , op⟨γᴰ⟩)
+          sourcePath =
+            R.reind-filler op∘γ≡op⟨γ⟩
+            ∙ R.≡in {pth = refl} op∘γᴰ≡op⟨γᴰ⟩
+      StateFreeModelRecᴰ .snd (write s) γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩
+        op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ =
+          BᴰR.rectifyOut {e' = refl}
+            ( sym (T.Algebraᴰ-op-filler (Bᴰ .fst) (write s) γ
+                (λ u → StateFreeModelRecᴰ-fun (γ u) (γᴰ u))
+                op⟨γ⟩ op∘γ≡op⟨γ⟩)
+            ∙ StateModelWriteRead (Store .fst) TargetModel s matrix
+            ∙ StateModelWriteWrite (Store .fst) TargetModel s output
+                (generator value valueᴰ)
+            ∙ sym (StateModelReadIdempotent (Store .fst) TargetModel
+                (StateModelWrite (Store .fst) TargetModel output
+                  (generator value valueᴰ)))
+            ∙ cong RecᴰTotal sourcePath)
+          where
+          matrix : Store .fst → TargetModel .fst .fst
+          matrix s' =
+            StateModelWrite (Store .fst) TargetModel
+              (γ tt* s' .fst)
+              (generator (γ tt* s' .snd) (γᴰ tt* s'))
+
+          output : Store .fst
+          output = γ tt* s .fst
+
+          value : X .fst
+          value = γ tt* s .snd
+
+          valueᴰ : Xᴰ value .fst
+          valueᴰ = γᴰ tt* s
+
+          sourcePath : Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
+            ( StateFreeModel .fst .snd (write s) γ
+            , λ _ → γᴰ tt* s)
+            (op⟨γ⟩ , op⟨γᴰ⟩)
+          sourcePath =
+            R.reind-filler op∘γ≡op⟨γ⟩
+            ∙ R.≡in {pth = refl} op∘γᴰ≡op⟨γᴰ⟩
+
+    StateFreeModelRecᴰ-uniq :
+      (Bᴰ : T.Modelᴰ StateFreeModel ℓD')
+      (hᴰ : T.Homoᴰ (T.idHomo {A = StateFreeModel .fst})
+        StateFreeAlgebraᴰ (Bᴰ .fst))
+      → hᴰ .fst ≡
+        StateFreeModelRecᴰ Bᴰ
+          (λ x xᴰ → hᴰ .fst
+            (StateFreeModelη x) (StateFreeModelηᴰ x xᴰ)) .fst
+    StateFreeModelRecᴰ-uniq Bᴰ hᴰ =
+      funExt λ q → funExt λ qᴰ →
+        BᴰR.rectifyOut {e' = refl} (sym (totalPath q qᴰ))
+      where
+      TargetModel : T.Model _
+      TargetModel = T.∫Model {M = StateFreeModel} Bᴰ
+
+      module BᴰR = hSetReasoning
+        (StateFreeModel .fst .fst , StateFreeModel .snd .snd)
+        (Bᴰ .fst .fst)
+
+      HomoᴰTotal : T.Homo
+        (T.∫Algebra StateFreeAlgebraᴰ)
+        (TargetModel .fst)
+      HomoᴰTotal .fst z = z .fst , hᴰ .fst (z .fst) (z .snd)
+      HomoᴰTotal .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+        T.Algebraᴰ-op-filler (Bᴰ .fst) op
+          (λ v → γ v .fst)
+          (λ v → hᴰ .fst (γ v .fst) (γ v .snd))
+          (op⟨γ⟩ .fst) basePath
+        ∙ BᴰR.≡in {pth = refl}
+            (hᴰ .snd op
+              (λ v → γ v .fst) (λ v → γ v .snd)
+              (op⟨γ⟩ .fst) basePath (op⟨γ⟩ .snd) sourceᴰ≡)
+        where
+        basePath : StateFreeModel .fst .snd op (λ v → γ v .fst) ≡
+          op⟨γ⟩ .fst
+        basePath i = op∘γ≡op⟨γ⟩ i .fst
+
+        sourceᴰ≡ :
+          StateFreeAlgebraᴰ .snd op
+            (λ v → γ v .fst) (λ v → γ v .snd)
+            (op⟨γ⟩ .fst) basePath
+          ≡ op⟨γ⟩ .snd
+        sourceᴰ≡ = R.rectifyOut {e' = refl}
+          ( sym (T.Algebraᴰ-op-filler StateFreeAlgebraᴰ op
+              (λ v → γ v .fst) (λ v → γ v .snd)
+              (op⟨γ⟩ .fst) basePath)
+          ∙ op∘γ≡op⟨γ⟩)
+
+      generator : (x : X .fst) (xᴰ : Xᴰ x .fst) →
+        T.∫Algebra StateFreeAlgebraᴰ .fst
+      generator x xᴰ = StateFreeModelη x , StateFreeModelηᴰ x xᴰ
+
+      branch : (q : StateFreeModel .fst .fst)
+        (qᴰ : StateFreeAlgebraᴰ .fst q) (s : Store .fst) →
+        T.∫Algebra StateFreeAlgebraᴰ .fst
+      branch q qᴰ s =
+        T.∫Algebra StateFreeAlgebraᴰ .snd (write (q s .fst))
+          (λ _ → generator (q s .snd) (qᴰ s))
+
+      branchNormalize : (q : StateFreeModel .fst .fst)
+        (qᴰ : StateFreeAlgebraᴰ .fst q) (s : Store .fst) →
+        Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
+          (branch q qᴰ s)
+          ((λ _ → q s) , (λ _ → qᴰ s))
+      branchNormalize q qᴰ s =
+        StateWriteNormalize (q s .fst)
+          (λ _ → StateFreeModelη (q s .snd))
+          (λ _ → StateFreeModelηᴰ (q s .snd) (qᴰ s))
+
+      representationPath : (q : StateFreeModel .fst .fst)
+        (qᴰ : StateFreeAlgebraᴰ .fst q) →
+        Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
+          (T.∫Algebra StateFreeAlgebraᴰ .snd read (branch q qᴰ))
+          (q , qᴰ)
+      representationPath q qᴰ =
+        cong (T.∫Algebra StateFreeAlgebraᴰ .snd read)
+          (funExt (branchNormalize q qᴰ))
+        ∙ StateReadNormalize (λ s → λ _ → q s) (λ s → λ _ → qᴰ s)
+
+      branchHomoPath : (q : StateFreeModel .fst .fst)
+        (qᴰ : StateFreeAlgebraᴰ .fst q) (s : Store .fst) →
+        Path (TargetModel .fst .fst)
+          ( StateModelWrite (Store .fst) TargetModel (q s .fst)
+              (HomoᴰTotal .fst (generator (q s .snd) (qᴰ s))) )
+          (HomoᴰTotal .fst (branch q qᴰ s))
+      branchHomoPath q qᴰ s =
+        HomoᴰTotal .snd (write (q s .fst))
+          (λ _ → generator (q s .snd) (qᴰ s))
+          (branch q qᴰ s) refl
+
+      totalPath : (q : StateFreeModel .fst .fst)
+        (qᴰ : StateFreeAlgebraᴰ .fst q) →
+        Path (TargetModel .fst .fst)
+          ( q
+          , StateFreeModelRecᴰ Bᴰ
+              (λ x xᴰ → hᴰ .fst
+                (StateFreeModelη x) (StateFreeModelηᴰ x xᴰ))
+              .fst q qᴰ)
+          (q , hᴰ .fst q qᴰ)
+      totalPath q qᴰ =
+        cong (StateModelRead (Store .fst) TargetModel)
+          (funExt (branchHomoPath q qᴰ))
+        ∙ HomoᴰTotal .snd read (branch q qᴰ) (q , qᴰ)
+            (representationPath q qᴰ)
+
+    StateFreeModelUniversalᴰ :
+      (Bᴰ : T.Modelᴰ StateFreeModel ℓD') →
+      isEquiv
+        (λ (hᴰ : T.Homoᴰ (T.idHomo {A = StateFreeModel .fst})
+            StateFreeAlgebraᴰ (Bᴰ .fst)) x xᴰ →
+          hᴰ .fst (StateFreeModelη x) (StateFreeModelηᴰ x xᴰ))
+    StateFreeModelUniversalᴰ Bᴰ = isIsoToIsEquiv
+      ( StateFreeModelRecᴰ Bᴰ
+      , (λ fᴰ → funExt λ x → funExt λ xᴰ →
+          StateFreeModelRecᴰ-β Bᴰ fᴰ x xᴰ)
+      , (λ hᴰ → Σ≡Prop
+          (λ _ → isPropΠ6 λ _ _ _ _ _ _ →
+            isPropΠ λ _ → Bᴰ .snd .snd _ _ _)
+          (sym (StateFreeModelRecᴰ-uniq Bᴰ hᴰ)))
+      )
+
+    module _ {B : T.Model ℓB}
+      (ϕ : T.Homo (StateFreeModel .fst) (B .fst))
+      (Bᴰ : T.Modelᴰ B ℓD')
+      (fᴰ : (x : X .fst) → Xᴰ x .fst →
+        Bᴰ .fst .fst (ϕ .fst (StateFreeModelη x)))
+      where
+      StateFreeModelRecOverᴰ :
+        T.Homoᴰ ϕ StateFreeAlgebraᴰ (Bᴰ .fst)
+      StateFreeModelRecOverᴰ =
+        StateFreeModelRecᴰ
+          (T._*_ {M = StateFreeModel} {N = B} ϕ Bᴰ) fᴰ
+
+      StateFreeModelRecOverᴰ-β :
+        (x : X .fst) (xᴰ : Xᴰ x .fst) →
+        StateFreeModelRecOverᴰ .fst
+          (StateFreeModelη x) (StateFreeModelηᴰ x xᴰ) ≡ fᴰ x xᴰ
+      StateFreeModelRecOverᴰ-β =
+        StateFreeModelRecᴰ-β
+          (T._*_ {M = StateFreeModel} {N = B} ϕ Bᴰ) fᴰ
+
+    StateFreeModelRecOverᴰ-uniq : {B : T.Model ℓB}
+      (ϕ : T.Homo (StateFreeModel .fst) (B .fst))
+      (Bᴰ : T.Modelᴰ B ℓD')
+      (hᴰ : T.Homoᴰ ϕ StateFreeAlgebraᴰ (Bᴰ .fst))
+      → hᴰ .fst ≡ StateFreeModelRecOverᴰ {B = B} ϕ Bᴰ
+          (λ x xᴰ → hᴰ .fst
+            (StateFreeModelη x) (StateFreeModelηᴰ x xᴰ)) .fst
+    StateFreeModelRecOverᴰ-uniq {B = B} ϕ Bᴰ =
+      StateFreeModelRecᴰ-uniq
+        (T._*_ {M = StateFreeModel} {N = B} ϕ Bᴰ)
+
+    StateFreeModelUniversalOverᴰ : {B : T.Model ℓB}
+      (ϕ : T.Homo (StateFreeModel .fst) (B .fst))
+      (Bᴰ : T.Modelᴰ B ℓD') →
+      isEquiv
+        (λ (hᴰ : T.Homoᴰ ϕ StateFreeAlgebraᴰ (Bᴰ .fst)) x xᴰ →
+          hᴰ .fst (StateFreeModelη x) (StateFreeModelηᴰ x xᴰ))
+    StateFreeModelUniversalOverᴰ {B = B} ϕ Bᴰ =
+      StateFreeModelUniversalᴰ
+        (T._*_ {M = StateFreeModel} {N = B} ϕ Bᴰ)

--- a/Cubical/Algebra/Theory/Instances/State.agda
+++ b/Cubical/Algebra/Theory/Instances/State.agda
@@ -16,7 +16,7 @@ private
   variable
     ℓS ℓV ℓX ℓB ℓD ℓD' : Level
 
-data StateOp {s : Level} (Store : Type s) : Type s where
+data StateOp {ℓS : Level} (Store : Type ℓS) : Type ℓS where
   read : StateOp Store
   write : Store → StateOp Store
 
@@ -29,16 +29,15 @@ module StateSignature {s : Level} (Store : Type s) where
   open Signature (StateSignature Store) public
 
 module _ (Store : Type ℓS) where
-  private
-    module S = Signature (StateSignature Store)
+  open Signature (StateSignature Store)
 
   readTm : ∀ {V : Type ℓV}
-    → (Store → S.|FreeAlgebra| V) → S.|FreeAlgebra| V
-  readTm γ = S.app read γ
+    → (Store → |FreeAlgebra| V) → |FreeAlgebra| V
+  readTm γ = app read γ
 
   writeTm : ∀ {V : Type ℓV}
-    → Store → S.|FreeAlgebra| V → S.|FreeAlgebra| V
-  writeTm s t = S.app (write s) (λ _ → t)
+    → Store → |FreeAlgebra| V → |FreeAlgebra| V
+  writeTm s t = app (write s) (λ _ → t)
 
   data StateEq : Type ℓS where
     wt-rdEq : Store → StateEq
@@ -50,17 +49,17 @@ module _ (Store : Type ℓS) where
   StateEqArity rd-wtEq = Unit*
   StateEqArity (wt-wtEq _ _) = Unit*
 
-  StateLhs : (e : StateEq) → S.|FreeAlgebra| (StateEqArity e)
+  StateLhs : (e : StateEq) → |FreeAlgebra| (StateEqArity e)
   StateLhs (wt-rdEq s) =
-    writeTm s (readTm S.var)
-  StateLhs rd-wtEq = S.var tt*
+    writeTm s (readTm var)
+  StateLhs rd-wtEq = var tt*
   StateLhs (wt-wtEq s s') =
-    writeTm s (writeTm s' (S.var tt*))
+    writeTm s (writeTm s' (var tt*))
 
-  StateRhs : (e : StateEq) → S.|FreeAlgebra| (StateEqArity e)
-  StateRhs (wt-rdEq s) = writeTm s (S.var s)
-  StateRhs rd-wtEq = readTm (λ s → writeTm s (S.var tt*))
-  StateRhs (wt-wtEq _ s') = writeTm s' (S.var tt*)
+  StateRhs : (e : StateEq) → |FreeAlgebra| (StateEqArity e)
+  StateRhs (wt-rdEq s) = writeTm s (var s)
+  StateRhs rd-wtEq = readTm (λ s → writeTm s (var tt*))
+  StateRhs (wt-wtEq _ s') = writeTm s' (var tt*)
 
   StateTheory : Theory ℓS ℓS ℓS ℓS
   StateTheory .Theory.S = StateSignature Store
@@ -115,10 +114,9 @@ module _ (Store : Type ℓS) (B : Theory.Model (StateTheory Store) ℓB) where
     ∙ sym (StateModelReadWrite x)
 
 module _ (Store : hSet ℓS) (X : hSet ℓX) where
-  private
-    module T = Theory (StateTheory (Store .fst))
+  open Theory (StateTheory (Store .fst))
 
-  StateFreeModel : T.Model (ℓ-max ℓS ℓX)
+  StateFreeModel : Model (ℓ-max ℓS ℓX)
   StateFreeModel .fst .fst = Store .fst → Store .fst × X .fst
   StateFreeModel .fst .snd read γ s = γ s s
   StateFreeModel .fst .snd (write s) γ _ = γ tt* s
@@ -134,8 +132,8 @@ module _ (Store : hSet ℓS) (X : hSet ℓX) where
   StateFreeModelη : X .fst → StateFreeModel .fst .fst
   StateFreeModelη x s = s , x
 
-  module _ (B : T.Model ℓB) (f : X .fst → B .fst .fst) where
-    StateFreeModelRec : T.Homo (StateFreeModel .fst) (B .fst)
+  module _ (B : Model ℓB) (f : X .fst → B .fst .fst) where
+    StateFreeModelRec : Homo (StateFreeModel .fst) (B .fst)
     StateFreeModelRec .fst q =
       StateModelRead (Store .fst) B λ s →
         StateModelWrite (Store .fst) B (q s .fst) (f (q s .snd))
@@ -164,28 +162,19 @@ module _ (Store : hSet ℓS) (X : hSet ℓX) where
       sym (StateModelReadWrite (Store .fst) B (f x))
 
   StateFreeModelRec-uniq :
-    (B : T.Model ℓB)
-    (f : T.Homo (StateFreeModel .fst) (B .fst))
+    (B : Model ℓB)
+    (f : Homo (StateFreeModel .fst) (B .fst))
     → f .fst ≡
       StateFreeModelRec B (λ x → f .fst (StateFreeModelη x)) .fst
   StateFreeModelRec-uniq B f = funExt λ q →
     sym
       ( cong (StateModelRead (Store .fst) B)
-          (funExt λ s →
-            f .snd (write (q s .fst))
-              (λ _ → StateFreeModelη (q s .snd))
-              (branch q s) refl)
-      ∙ f .snd read (branch q) q refl)
-    where
-    branch : StateFreeModel .fst .fst →
-      Store .fst → StateFreeModel .fst .fst
-    branch q s =
-      StateFreeModel .fst .snd (write (q s .fst))
-        (λ _ → StateFreeModelη (q s .snd))
+          (funExt λ s → f .snd (write _) _ _ refl)
+      ∙ f .snd read _ _ refl)
 
-  StateFreeModelUniversal : (B : T.Model ℓB) →
+  StateFreeModelUniversal : (B : Model ℓB) →
     isEquiv
-      (λ (f : T.Homo (StateFreeModel .fst) (B .fst)) x →
+      (λ (f : Homo (StateFreeModel .fst) (B .fst)) x →
         f .fst (StateFreeModelη x))
   StateFreeModelUniversal B = isIsoToIsEquiv
     ( StateFreeModelRec B
@@ -202,7 +191,7 @@ module _ (Store : hSet ℓS) (X : hSet ℓX) where
         (λ q → (s : Store .fst) → Xᴰ (q s .snd) .fst)
 
     StateFreeAlgebraᴰ :
-      T.Algebraᴰ (StateFreeModel .fst) (ℓ-max ℓS ℓD)
+      Algebraᴰ (StateFreeModel .fst) (ℓ-max ℓS ℓD)
     StateFreeAlgebraᴰ .fst q =
       (s : Store .fst) → Xᴰ (q s .snd) .fst
     StateFreeAlgebraᴰ .snd read γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
@@ -213,7 +202,7 @@ module _ (Store : hSet ℓS) (X : hSet ℓX) where
     StateReadNormalize :
       (γ : Store .fst → StateFreeModel .fst .fst)
       (γᴰ : (s : Store .fst) → StateFreeAlgebraᴰ .fst (γ s))
-      → Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
+      → Path (∫Algebra StateFreeAlgebraᴰ .fst)
           ( StateFreeModel .fst .snd read γ
           , StateFreeAlgebraᴰ .snd read γ γᴰ _ refl)
           ( StateFreeModel .fst .snd read γ
@@ -224,7 +213,7 @@ module _ (Store : hSet ℓS) (X : hSet ℓX) where
       (s : Store .fst)
       (γ : Unit* → StateFreeModel .fst .fst)
       (γᴰ : (u : Unit*) → StateFreeAlgebraᴰ .fst (γ u))
-      → Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
+      → Path (∫Algebra StateFreeAlgebraᴰ .fst)
           ( StateFreeModel .fst .snd (write s) γ
           , StateFreeAlgebraᴰ .snd (write s) γ γᴰ _ refl)
           ( StateFreeModel .fst .snd (write s) γ
@@ -234,76 +223,76 @@ module _ (Store : hSet ℓS) (X : hSet ℓX) where
     StateReadAppFiller : {V : Type ℓV}
       (ρ : V → StateFreeModel .fst .fst)
       (ρᴰ : (v : V) → StateFreeAlgebraᴰ .fst (ρ v))
-      (γ : Store .fst → T.|FreeAlgebra| V)
-      → Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
+      (γ : Store .fst → |FreeAlgebra| V)
+      → Path (∫Algebra StateFreeAlgebraᴰ .fst)
           ( StateFreeModel .fst .snd read
-              (λ s → T.interp (StateFreeModel .fst) ρ (γ s))
+              (λ s → interp (StateFreeModel .fst) ρ (γ s))
           , StateFreeAlgebraᴰ .snd read
-              (λ s → T.interp (StateFreeModel .fst) ρ (γ s))
-              (λ s → T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ (γ s))
+              (λ s → interp (StateFreeModel .fst) ρ (γ s))
+              (λ s → interpᴰ StateFreeAlgebraᴰ ρ ρᴰ (γ s))
               _ refl)
-          ( T.interp (StateFreeModel .fst) ρ (T.S.app read γ)
-          , T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ (T.S.app read γ))
+          ( interp (StateFreeModel .fst) ρ (app read γ)
+          , interpᴰ StateFreeAlgebraᴰ ρ ρᴰ (app read γ))
     StateReadAppFiller ρ ρᴰ γ =
-      T.Algebraᴰ-op-filler StateFreeAlgebraᴰ read
-        (λ s → T.interp (StateFreeModel .fst) ρ (γ s))
-        (λ s → T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ (γ s))
-        (T.interp (StateFreeModel .fst) ρ (T.S.app read γ))
-        (T.recFA (StateFreeModel .fst) ρ .snd read γ
-          (T.S.app read γ) refl)
+      Algebraᴰ-op-filler StateFreeAlgebraᴰ read
+        (λ s → interp (StateFreeModel .fst) ρ (γ s))
+        (λ s → interpᴰ StateFreeAlgebraᴰ ρ ρᴰ (γ s))
+        (interp (StateFreeModel .fst) ρ (app read γ))
+        (recFA (StateFreeModel .fst) ρ .snd read γ
+          (app read γ) refl)
 
     StateWriteAppFiller : {V : Type ℓV}
       (s : Store .fst)
       (ρ : V → StateFreeModel .fst .fst)
       (ρᴰ : (v : V) → StateFreeAlgebraᴰ .fst (ρ v))
-      (γ : Unit* → T.|FreeAlgebra| V)
-      → Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
+      (γ : Unit* → |FreeAlgebra| V)
+      → Path (∫Algebra StateFreeAlgebraᴰ .fst)
           ( StateFreeModel .fst .snd (write s)
-              (λ u → T.interp (StateFreeModel .fst) ρ (γ u))
+              (λ u → interp (StateFreeModel .fst) ρ (γ u))
           , StateFreeAlgebraᴰ .snd (write s)
-              (λ u → T.interp (StateFreeModel .fst) ρ (γ u))
-              (λ u → T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ (γ u))
+              (λ u → interp (StateFreeModel .fst) ρ (γ u))
+              (λ u → interpᴰ StateFreeAlgebraᴰ ρ ρᴰ (γ u))
               _ refl)
-          ( T.interp (StateFreeModel .fst) ρ (T.S.app (write s) γ)
-          , T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
-              (T.S.app (write s) γ))
+          ( interp (StateFreeModel .fst) ρ (app (write s) γ)
+          , interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
+              (app (write s) γ))
     StateWriteAppFiller s ρ ρᴰ γ =
-      T.Algebraᴰ-op-filler StateFreeAlgebraᴰ (write s)
-        (λ u → T.interp (StateFreeModel .fst) ρ (γ u))
-        (λ u → T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ (γ u))
-        (T.interp (StateFreeModel .fst) ρ (T.S.app (write s) γ))
-        (T.recFA (StateFreeModel .fst) ρ .snd (write s) γ
-          (T.S.app (write s) γ) refl)
+      Algebraᴰ-op-filler StateFreeAlgebraᴰ (write s)
+        (λ u → interp (StateFreeModel .fst) ρ (γ u))
+        (λ u → interpᴰ StateFreeAlgebraᴰ ρ ρᴰ (γ u))
+        (interp (StateFreeModel .fst) ρ (app (write s) γ))
+        (recFA (StateFreeModel .fst) ρ .snd (write s) γ
+          (app (write s) γ) refl)
 
     StateFreeModelᴰ :
-      T.Modelᴰ StateFreeModel (ℓ-max ℓS ℓD)
+      Modelᴰ StateFreeModel (ℓ-max ℓS ℓD)
     StateFreeModelᴰ .fst = StateFreeAlgebraᴰ
     StateFreeModelᴰ .snd .fst (wt-rdEq s) ρ ρᴰ =
       R.rectifyOut {e' = StateFreeModel .snd .fst (wt-rdEq s) ρ}
         ( sym (StateWriteAppFiller s ρ ρᴰ
-            (λ _ → T.S.app read T.S.var))
+            (λ _ → app read var))
         ∙ StateWriteNormalize s
-            (λ _ → T.interp (StateFreeModel .fst) ρ
-              (T.S.app read T.S.var))
-            (λ _ → T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
-              (T.S.app read T.S.var))
+            (λ _ → interp (StateFreeModel .fst) ρ
+              (app read var))
+            (λ _ → interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
+              (app read var))
         ∙ cong writeTotal innerPath
         ∙ sym (StateWriteNormalize s
             (λ _ → ρ s) (λ _ → ρᴰ s))
-        ∙ StateWriteAppFiller s ρ ρᴰ (λ _ → T.S.var s))
+        ∙ StateWriteAppFiller s ρ ρᴰ (λ _ → var s))
       where
-      innerPath : Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
-        ( T.interp (StateFreeModel .fst) ρ (T.S.app read T.S.var)
-        , T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
-            (T.S.app read T.S.var))
+      innerPath : Path (∫Algebra StateFreeAlgebraᴰ .fst)
+        ( interp (StateFreeModel .fst) ρ (app read var)
+        , interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
+            (app read var))
         ( StateFreeModel .fst .snd read ρ
         , λ s' → ρᴰ s' s')
       innerPath =
-        sym (StateReadAppFiller ρ ρᴰ T.S.var)
+        sym (StateReadAppFiller ρ ρᴰ var)
         ∙ StateReadNormalize ρ ρᴰ
 
-      writeTotal : T.∫Algebra StateFreeAlgebraᴰ .fst →
-        T.∫Algebra StateFreeAlgebraᴰ .fst
+      writeTotal : ∫Algebra StateFreeAlgebraᴰ .fst →
+        ∫Algebra StateFreeAlgebraᴰ .fst
       writeTotal z =
         (λ _ → z .fst s) , (λ _ → z .snd s)
     StateFreeModelᴰ .snd .fst rd-wtEq ρ ρᴰ =
@@ -311,71 +300,71 @@ module _ (Store : hSet ℓS) (X : hSet ℓX) where
         (sym rhsToLhs)
       where
       innerPath : (s : Store .fst) →
-        Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
-          ( T.interp (StateFreeModel .fst) ρ
-              (T.S.app (write s) (λ _ → T.S.var tt*))
-          , T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
-              (T.S.app (write s) (λ _ → T.S.var tt*)))
+        Path (∫Algebra StateFreeAlgebraᴰ .fst)
+          ( interp (StateFreeModel .fst) ρ
+              (app (write s) (λ _ → var tt*))
+          , interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
+              (app (write s) (λ _ → var tt*)))
           ( StateFreeModel .fst .snd (write s) (λ _ → ρ tt*)
           , λ _ → ρᴰ tt* s)
       innerPath s =
-        sym (StateWriteAppFiller s ρ ρᴰ (λ _ → T.S.var tt*))
+        sym (StateWriteAppFiller s ρ ρᴰ (λ _ → var tt*))
         ∙ StateWriteNormalize s (λ _ → ρ tt*) (λ _ → ρᴰ tt*)
 
-      middlePath : Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
+      middlePath : Path (∫Algebra StateFreeAlgebraᴰ .fst)
         ( StateFreeModel .fst .snd read
-            (λ s → T.interp (StateFreeModel .fst) ρ
-              (T.S.app (write s) (λ _ → T.S.var tt*)))
-        , λ s → T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
-            (T.S.app (write s) (λ _ → T.S.var tt*)) s)
+            (λ s → interp (StateFreeModel .fst) ρ
+              (app (write s) (λ _ → var tt*)))
+        , λ s → interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
+            (app (write s) (λ _ → var tt*)) s)
         (ρ tt* , ρᴰ tt*)
       middlePath i .fst s = innerPath s i .fst s
       middlePath i .snd s = innerPath s i .snd s
 
-      rhsToLhs : Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
-        ( T.interp (StateFreeModel .fst) ρ
-            (T.S.app read
-              (λ s → T.S.app (write s) (λ _ → T.S.var tt*)))
-        , T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
-            (T.S.app read
-              (λ s → T.S.app (write s) (λ _ → T.S.var tt*))))
+      rhsToLhs : Path (∫Algebra StateFreeAlgebraᴰ .fst)
+        ( interp (StateFreeModel .fst) ρ
+            (app read
+              (λ s → app (write s) (λ _ → var tt*)))
+        , interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
+            (app read
+              (λ s → app (write s) (λ _ → var tt*))))
         (ρ tt* , ρᴰ tt*)
       rhsToLhs =
         sym (StateReadAppFiller ρ ρᴰ
-          (λ s → T.S.app (write s) (λ _ → T.S.var tt*)))
+          (λ s → app (write s) (λ _ → var tt*)))
         ∙ StateReadNormalize
-            (λ s → T.interp (StateFreeModel .fst) ρ
-              (T.S.app (write s) (λ _ → T.S.var tt*)))
-            (λ s → T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
-              (T.S.app (write s) (λ _ → T.S.var tt*)))
+            (λ s → interp (StateFreeModel .fst) ρ
+              (app (write s) (λ _ → var tt*)))
+            (λ s → interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
+              (app (write s) (λ _ → var tt*)))
         ∙ middlePath
     StateFreeModelᴰ .snd .fst (wt-wtEq s s') ρ ρᴰ =
       R.rectifyOut {e' = StateFreeModel .snd .fst (wt-wtEq s s') ρ}
         ( sym (StateWriteAppFiller s ρ ρᴰ
-            (λ _ → T.S.app (write s') (λ _ → T.S.var tt*)))
+            (λ _ → app (write s') (λ _ → var tt*)))
         ∙ StateWriteNormalize s
-            (λ _ → T.interp (StateFreeModel .fst) ρ
-              (T.S.app (write s') (λ _ → T.S.var tt*)))
-            (λ _ → T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
-              (T.S.app (write s') (λ _ → T.S.var tt*)))
+            (λ _ → interp (StateFreeModel .fst) ρ
+              (app (write s') (λ _ → var tt*)))
+            (λ _ → interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
+              (app (write s') (λ _ → var tt*)))
         ∙ cong writeTotal innerPath
         ∙ sym (StateWriteNormalize s'
             (λ _ → ρ tt*) (λ _ → ρᴰ tt*))
-        ∙ StateWriteAppFiller s' ρ ρᴰ (λ _ → T.S.var tt*))
+        ∙ StateWriteAppFiller s' ρ ρᴰ (λ _ → var tt*))
       where
-      innerPath : Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
-        ( T.interp (StateFreeModel .fst) ρ
-            (T.S.app (write s') (λ _ → T.S.var tt*))
-        , T.interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
-            (T.S.app (write s') (λ _ → T.S.var tt*)))
+      innerPath : Path (∫Algebra StateFreeAlgebraᴰ .fst)
+        ( interp (StateFreeModel .fst) ρ
+            (app (write s') (λ _ → var tt*))
+        , interpᴰ StateFreeAlgebraᴰ ρ ρᴰ
+            (app (write s') (λ _ → var tt*)))
         ( StateFreeModel .fst .snd (write s') (λ _ → ρ tt*)
         , λ _ → ρᴰ tt* s')
       innerPath =
-        sym (StateWriteAppFiller s' ρ ρᴰ (λ _ → T.S.var tt*))
+        sym (StateWriteAppFiller s' ρ ρᴰ (λ _ → var tt*))
         ∙ StateWriteNormalize s' (λ _ → ρ tt*) (λ _ → ρᴰ tt*)
 
-      writeTotal : T.∫Algebra StateFreeAlgebraᴰ .fst →
-        T.∫Algebra StateFreeAlgebraᴰ .fst
+      writeTotal : ∫Algebra StateFreeAlgebraᴰ .fst →
+        ∫Algebra StateFreeAlgebraᴰ .fst
       writeTotal z =
         (λ _ → z .fst s) , (λ _ → z .snd s)
     StateFreeModelᴰ .snd .snd q =
@@ -386,13 +375,13 @@ module _ (Store : hSet ℓS) (X : hSet ℓX) where
     StateFreeModelηᴰ x xᴰ _ = xᴰ
 
     module _
-      (Bᴰ : T.Modelᴰ StateFreeModel ℓD')
+      (Bᴰ : Modelᴰ StateFreeModel ℓD')
       (fᴰ : (x : X .fst) → Xᴰ x .fst →
         Bᴰ .fst .fst (StateFreeModelη x))
       where
       private
-        TargetModel : T.Model (ℓ-max (ℓ-max ℓS ℓX) ℓD')
-        TargetModel = T.∫Model {M = StateFreeModel} Bᴰ
+        TargetModel : Model (ℓ-max (ℓ-max ℓS ℓX) ℓD')
+        TargetModel = ∫Model {M = StateFreeModel} Bᴰ
 
         module BᴰR = hSetReasoning
           (StateFreeModel .fst .fst , StateFreeModel .snd .snd)
@@ -402,7 +391,7 @@ module _ (Store : hSet ℓS) (X : hSet ℓX) where
           TargetModel .fst .fst
         generator x xᴰ = StateFreeModelη x , fᴰ x xᴰ
 
-        RecᴰTotal : T.∫Algebra StateFreeAlgebraᴰ .fst →
+        RecᴰTotal : ∫Algebra StateFreeAlgebraᴰ .fst →
           TargetModel .fst .fst
         RecᴰTotal z =
           StateModelRead (Store .fst) TargetModel λ s →
@@ -422,13 +411,13 @@ module _ (Store : hSet ℓS) (X : hSet ℓX) where
           (generator x xᴰ)))
 
       StateFreeModelRecᴰ :
-        T.Homoᴰ (T.idHomo {A = StateFreeModel .fst})
+        Homoᴰ (idHomo {A = StateFreeModel .fst})
           StateFreeAlgebraᴰ (Bᴰ .fst)
       StateFreeModelRecᴰ .fst = StateFreeModelRecᴰ-fun
       StateFreeModelRecᴰ .snd read γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩
         op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ =
           BᴰR.rectifyOut {e' = refl}
-            ( sym (T.Algebraᴰ-op-filler (Bᴰ .fst) read γ
+            ( sym (Algebraᴰ-op-filler (Bᴰ .fst) read γ
                 (λ s → StateFreeModelRecᴰ-fun (γ s) (γᴰ s))
                 op⟨γ⟩ op∘γ≡op⟨γ⟩)
             ∙ StateModelReadRead (Store .fst) TargetModel matrix
@@ -439,7 +428,7 @@ module _ (Store : hSet ℓS) (X : hSet ℓX) where
             StateModelWrite (Store .fst) TargetModel (γ s s' .fst)
               (generator (γ s s' .snd) (γᴰ s s'))
 
-          sourcePath : Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
+          sourcePath : Path (∫Algebra StateFreeAlgebraᴰ .fst)
             ( StateFreeModel .fst .snd read γ
             , λ s → γᴰ s s)
             (op⟨γ⟩ , op⟨γᴰ⟩)
@@ -449,7 +438,7 @@ module _ (Store : hSet ℓS) (X : hSet ℓX) where
       StateFreeModelRecᴰ .snd (write s) γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩
         op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ =
           BᴰR.rectifyOut {e' = refl}
-            ( sym (T.Algebraᴰ-op-filler (Bᴰ .fst) (write s) γ
+            ( sym (Algebraᴰ-op-filler (Bᴰ .fst) (write s) γ
                 (λ u → StateFreeModelRecᴰ-fun (γ u) (γᴰ u))
                 op⟨γ⟩ op∘γ≡op⟨γ⟩)
             ∙ StateModelWriteRead (Store .fst) TargetModel s matrix
@@ -475,7 +464,7 @@ module _ (Store : hSet ℓS) (X : hSet ℓX) where
           valueᴰ : Xᴰ value .fst
           valueᴰ = γᴰ tt* s
 
-          sourcePath : Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
+          sourcePath : Path (∫Algebra StateFreeAlgebraᴰ .fst)
             ( StateFreeModel .fst .snd (write s) γ
             , λ _ → γᴰ tt* s)
             (op⟨γ⟩ , op⟨γᴰ⟩)
@@ -484,8 +473,8 @@ module _ (Store : hSet ℓS) (X : hSet ℓX) where
             ∙ R.≡in {pth = refl} op∘γᴰ≡op⟨γᴰ⟩
 
     StateFreeModelRecᴰ-uniq :
-      (Bᴰ : T.Modelᴰ StateFreeModel ℓD')
-      (hᴰ : T.Homoᴰ (T.idHomo {A = StateFreeModel .fst})
+      (Bᴰ : Modelᴰ StateFreeModel ℓD')
+      (hᴰ : Homoᴰ (idHomo {A = StateFreeModel .fst})
         StateFreeAlgebraᴰ (Bᴰ .fst))
       → hᴰ .fst ≡
         StateFreeModelRecᴰ Bᴰ
@@ -495,19 +484,19 @@ module _ (Store : hSet ℓS) (X : hSet ℓX) where
       funExt λ q → funExt λ qᴰ →
         BᴰR.rectifyOut {e' = refl} (sym (totalPath q qᴰ))
       where
-      TargetModel : T.Model _
-      TargetModel = T.∫Model {M = StateFreeModel} Bᴰ
+      TargetModel : Model _
+      TargetModel = ∫Model {M = StateFreeModel} Bᴰ
 
       module BᴰR = hSetReasoning
         (StateFreeModel .fst .fst , StateFreeModel .snd .snd)
         (Bᴰ .fst .fst)
 
-      HomoᴰTotal : T.Homo
-        (T.∫Algebra StateFreeAlgebraᴰ)
+      HomoᴰTotal : Homo
+        (∫Algebra StateFreeAlgebraᴰ)
         (TargetModel .fst)
       HomoᴰTotal .fst z = z .fst , hᴰ .fst (z .fst) (z .snd)
       HomoᴰTotal .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
-        T.Algebraᴰ-op-filler (Bᴰ .fst) op
+        Algebraᴰ-op-filler (Bᴰ .fst) op
           (λ v → γ v .fst)
           (λ v → hᴰ .fst (γ v .fst) (γ v .snd))
           (op⟨γ⟩ .fst) basePath
@@ -526,25 +515,25 @@ module _ (Store : hSet ℓS) (X : hSet ℓX) where
             (op⟨γ⟩ .fst) basePath
           ≡ op⟨γ⟩ .snd
         sourceᴰ≡ = R.rectifyOut {e' = refl}
-          ( sym (T.Algebraᴰ-op-filler StateFreeAlgebraᴰ op
+          ( sym (Algebraᴰ-op-filler StateFreeAlgebraᴰ op
               (λ v → γ v .fst) (λ v → γ v .snd)
               (op⟨γ⟩ .fst) basePath)
           ∙ op∘γ≡op⟨γ⟩)
 
       generator : (x : X .fst) (xᴰ : Xᴰ x .fst) →
-        T.∫Algebra StateFreeAlgebraᴰ .fst
+        ∫Algebra StateFreeAlgebraᴰ .fst
       generator x xᴰ = StateFreeModelη x , StateFreeModelηᴰ x xᴰ
 
       branch : (q : StateFreeModel .fst .fst)
         (qᴰ : StateFreeAlgebraᴰ .fst q) (s : Store .fst) →
-        T.∫Algebra StateFreeAlgebraᴰ .fst
+        ∫Algebra StateFreeAlgebraᴰ .fst
       branch q qᴰ s =
-        T.∫Algebra StateFreeAlgebraᴰ .snd (write (q s .fst))
+        ∫Algebra StateFreeAlgebraᴰ .snd (write (q s .fst))
           (λ _ → generator (q s .snd) (qᴰ s))
 
       branchNormalize : (q : StateFreeModel .fst .fst)
         (qᴰ : StateFreeAlgebraᴰ .fst q) (s : Store .fst) →
-        Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
+        Path (∫Algebra StateFreeAlgebraᴰ .fst)
           (branch q qᴰ s)
           ((λ _ → q s) , (λ _ → qᴰ s))
       branchNormalize q qᴰ s =
@@ -554,11 +543,11 @@ module _ (Store : hSet ℓS) (X : hSet ℓX) where
 
       representationPath : (q : StateFreeModel .fst .fst)
         (qᴰ : StateFreeAlgebraᴰ .fst q) →
-        Path (T.∫Algebra StateFreeAlgebraᴰ .fst)
-          (T.∫Algebra StateFreeAlgebraᴰ .snd read (branch q qᴰ))
+        Path (∫Algebra StateFreeAlgebraᴰ .fst)
+          (∫Algebra StateFreeAlgebraᴰ .snd read (branch q qᴰ))
           (q , qᴰ)
       representationPath q qᴰ =
-        cong (T.∫Algebra StateFreeAlgebraᴰ .snd read)
+        cong (∫Algebra StateFreeAlgebraᴰ .snd read)
           (funExt (branchNormalize q qᴰ))
         ∙ StateReadNormalize (λ s → λ _ → q s) (λ s → λ _ → qᴰ s)
 
@@ -589,9 +578,9 @@ module _ (Store : hSet ℓS) (X : hSet ℓX) where
             (representationPath q qᴰ)
 
     StateFreeModelUniversalᴰ :
-      (Bᴰ : T.Modelᴰ StateFreeModel ℓD') →
+      (Bᴰ : Modelᴰ StateFreeModel ℓD') →
       isEquiv
-        (λ (hᴰ : T.Homoᴰ (T.idHomo {A = StateFreeModel .fst})
+        (λ (hᴰ : Homoᴰ (idHomo {A = StateFreeModel .fst})
             StateFreeAlgebraᴰ (Bᴰ .fst)) x xᴰ →
           hᴰ .fst (StateFreeModelη x) (StateFreeModelηᴰ x xᴰ))
     StateFreeModelUniversalᴰ Bᴰ = isIsoToIsEquiv
@@ -604,17 +593,17 @@ module _ (Store : hSet ℓS) (X : hSet ℓX) where
           (sym (StateFreeModelRecᴰ-uniq Bᴰ hᴰ)))
       )
 
-    module _ {B : T.Model ℓB}
-      (ϕ : T.Homo (StateFreeModel .fst) (B .fst))
-      (Bᴰ : T.Modelᴰ B ℓD')
+    module _ {B : Model ℓB}
+      (ϕ : Homo (StateFreeModel .fst) (B .fst))
+      (Bᴰ : Modelᴰ B ℓD')
       (fᴰ : (x : X .fst) → Xᴰ x .fst →
         Bᴰ .fst .fst (ϕ .fst (StateFreeModelη x)))
       where
       StateFreeModelRecOverᴰ :
-        T.Homoᴰ ϕ StateFreeAlgebraᴰ (Bᴰ .fst)
+        Homoᴰ ϕ StateFreeAlgebraᴰ (Bᴰ .fst)
       StateFreeModelRecOverᴰ =
         StateFreeModelRecᴰ
-          (T._*_ {M = StateFreeModel} {N = B} ϕ Bᴰ) fᴰ
+          (_*_ {M = StateFreeModel} {N = B} ϕ Bᴰ) fᴰ
 
       StateFreeModelRecOverᴰ-β :
         (x : X .fst) (xᴰ : Xᴰ x .fst) →
@@ -622,25 +611,25 @@ module _ (Store : hSet ℓS) (X : hSet ℓX) where
           (StateFreeModelη x) (StateFreeModelηᴰ x xᴰ) ≡ fᴰ x xᴰ
       StateFreeModelRecOverᴰ-β =
         StateFreeModelRecᴰ-β
-          (T._*_ {M = StateFreeModel} {N = B} ϕ Bᴰ) fᴰ
+          (_*_ {M = StateFreeModel} {N = B} ϕ Bᴰ) fᴰ
 
-    StateFreeModelRecOverᴰ-uniq : {B : T.Model ℓB}
-      (ϕ : T.Homo (StateFreeModel .fst) (B .fst))
-      (Bᴰ : T.Modelᴰ B ℓD')
-      (hᴰ : T.Homoᴰ ϕ StateFreeAlgebraᴰ (Bᴰ .fst))
+    StateFreeModelRecOverᴰ-uniq : {B : Model ℓB}
+      (ϕ : Homo (StateFreeModel .fst) (B .fst))
+      (Bᴰ : Modelᴰ B ℓD')
+      (hᴰ : Homoᴰ ϕ StateFreeAlgebraᴰ (Bᴰ .fst))
       → hᴰ .fst ≡ StateFreeModelRecOverᴰ {B = B} ϕ Bᴰ
           (λ x xᴰ → hᴰ .fst
             (StateFreeModelη x) (StateFreeModelηᴰ x xᴰ)) .fst
     StateFreeModelRecOverᴰ-uniq {B = B} ϕ Bᴰ =
       StateFreeModelRecᴰ-uniq
-        (T._*_ {M = StateFreeModel} {N = B} ϕ Bᴰ)
+        (_*_ {M = StateFreeModel} {N = B} ϕ Bᴰ)
 
-    StateFreeModelUniversalOverᴰ : {B : T.Model ℓB}
-      (ϕ : T.Homo (StateFreeModel .fst) (B .fst))
-      (Bᴰ : T.Modelᴰ B ℓD') →
+    StateFreeModelUniversalOverᴰ : {B : Model ℓB}
+      (ϕ : Homo (StateFreeModel .fst) (B .fst))
+      (Bᴰ : Modelᴰ B ℓD') →
       isEquiv
-        (λ (hᴰ : T.Homoᴰ ϕ StateFreeAlgebraᴰ (Bᴰ .fst)) x xᴰ →
+        (λ (hᴰ : Homoᴰ ϕ StateFreeAlgebraᴰ (Bᴰ .fst)) x xᴰ →
           hᴰ .fst (StateFreeModelη x) (StateFreeModelηᴰ x xᴰ))
     StateFreeModelUniversalOverᴰ {B = B} ϕ Bᴰ =
       StateFreeModelUniversalᴰ
-        (T._*_ {M = StateFreeModel} {N = B} ϕ Bᴰ)
+        (_*_ {M = StateFreeModel} {N = B} ϕ Bᴰ)

--- a/Cubical/Algebra/Theory/Instances/Writer.agda
+++ b/Cubical/Algebra/Theory/Instances/Writer.agda
@@ -1,0 +1,448 @@
+-- The algebraic theory of a monoidal write-only output.
+module Cubical.Algebra.Theory.Instances.Writer where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.More
+
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit
+
+open import Cubical.Algebra.Monoid.Base
+open import Cubical.Algebra.Theory.Base
+
+private
+  variable
+    ℓW ℓV ℓX ℓB ℓD ℓD' : Level
+
+data WriterOp {w : Level} (Output : Type w) : Type w where
+  tell : Output → WriterOp Output
+
+WriterSignature : (Output : Type ℓW) → Signature ℓW ℓ-zero
+WriterSignature Output .Signature.Op = WriterOp Output
+WriterSignature Output .Signature.Arity (tell _) = Unit
+
+module WriterSignature {w : Level} (Output : Type w) where
+  open Signature (WriterSignature Output) public
+
+module _ (Output : Type ℓW) where
+  private
+    module S = Signature (WriterSignature Output)
+
+  tellTm : ∀ {V : Type ℓV}
+    → Output → S.|FreeAlgebra| V → S.|FreeAlgebra| V
+  tellTm w t = S.app (tell w) (λ _ → t)
+
+  data WriterEq : Type ℓW where
+    tell-idEq : WriterEq
+    tell-tellEq : Output → Output → WriterEq
+
+  WriterEqArity : WriterEq → Type ℓ-zero
+  WriterEqArity tell-idEq = Unit
+  WriterEqArity (tell-tellEq _ _) = Unit
+
+module _ (W : Monoid ℓW) where
+  private
+    module W = MonoidStr (W .snd)
+    module S = Signature (WriterSignature (W .fst))
+
+  WriterLhs : (e : WriterEq (W .fst))
+    → S.|FreeAlgebra| (WriterEqArity (W .fst) e)
+  WriterLhs tell-idEq = tellTm (W .fst) W.ε (S.var tt)
+  WriterLhs (tell-tellEq w w') =
+    tellTm (W .fst) w (tellTm (W .fst) w' (S.var tt))
+
+  WriterRhs : (e : WriterEq (W .fst))
+    → S.|FreeAlgebra| (WriterEqArity (W .fst) e)
+  WriterRhs tell-idEq = S.var tt
+  WriterRhs (tell-tellEq w w') =
+    tellTm (W .fst) (W._·_ w w') (S.var tt)
+
+  WriterTheory : Theory ℓW ℓ-zero ℓW ℓ-zero
+  WriterTheory .Theory.S = WriterSignature (W .fst)
+  WriterTheory .Theory.Eq = WriterEq (W .fst)
+  WriterTheory .Theory.EqArity = WriterEqArity (W .fst)
+  WriterTheory .Theory.lhs = WriterLhs
+  WriterTheory .Theory.rhs = WriterRhs
+
+module WriterTheory {w : Level} (W : Monoid w) where
+  open Theory (WriterTheory W) public
+
+module _ (W : Monoid ℓW) (X : hSet ℓX) where
+  private
+    module W = MonoidStr (W .snd)
+    module T = Theory (WriterTheory W)
+
+  WriterFreeModel : T.Model (ℓ-max ℓW ℓX)
+  WriterFreeModel .fst .fst = W .fst × X .fst
+  WriterFreeModel .fst .snd (tell w) γ =
+    W._·_ w (γ tt .fst) , γ tt .snd
+  WriterFreeModel .snd .fst tell-idEq ρ =
+    ΣPathP (W.·IdL (ρ tt .fst) , refl)
+  WriterFreeModel .snd .fst (tell-tellEq w w') ρ =
+    ΣPathP (W.·Assoc w w' (ρ tt .fst) , refl)
+  WriterFreeModel .snd .snd = isSet× W.is-set (X .snd)
+
+  WriterFreeModelη : X .fst → WriterFreeModel .fst .fst
+  WriterFreeModelη x = W.ε , x
+
+  module _ (B : T.Model ℓB) (f : X .fst → B .fst .fst) where
+    WriterFreeModelRec : T.Homo (WriterFreeModel .fst) (B .fst)
+    WriterFreeModelRec .fst (w , x) =
+      B .fst .snd (tell w) (λ _ → f x)
+    WriterFreeModelRec .snd (tell w) γ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+      B .snd .fst (tell-tellEq w (γ tt .fst))
+        (λ _ → f (γ tt .snd))
+      ∙ cong (WriterFreeModelRec .fst) op∘γ≡op⟨γ⟩
+
+    WriterFreeModelRec-β : (x : X .fst) →
+      WriterFreeModelRec .fst (WriterFreeModelη x) ≡ f x
+    WriterFreeModelRec-β x =
+      B .snd .fst tell-idEq (λ _ → f x)
+
+  WriterFreeModelRec-uniq :
+    (B : T.Model ℓB)
+    (f : T.Homo (WriterFreeModel .fst) (B .fst))
+    → f .fst ≡
+      WriterFreeModelRec B (λ x → f .fst (WriterFreeModelη x)) .fst
+  WriterFreeModelRec-uniq B f = funExt λ { (w , x) →
+    sym
+      (f .snd (tell w) (λ _ → WriterFreeModelη x) (w , x)
+        (ΣPathP (W.·IdR w , refl))) }
+
+  WriterFreeModelUniversal : (B : T.Model ℓB) →
+    isEquiv
+      (λ (f : T.Homo (WriterFreeModel .fst) (B .fst)) x →
+        f .fst (WriterFreeModelη x))
+  WriterFreeModelUniversal B = isIsoToIsEquiv
+    ( WriterFreeModelRec B
+    , (λ f → funExt (WriterFreeModelRec-β B f))
+    , (λ f → Σ≡Prop
+        (λ _ → isPropΠ4 λ _ _ _ _ → B .snd .snd _ _)
+        (sym (WriterFreeModelRec-uniq B f)))
+    )
+
+  module _ (Xᴰ : X .fst → hSet ℓD) where
+    private
+      module R = hSetReasoning
+        (WriterFreeModel .fst .fst , WriterFreeModel .snd .snd)
+        (λ wx → Xᴰ (wx .snd) .fst)
+
+    WriterFreeAlgebraᴰ :
+      T.Algebraᴰ (WriterFreeModel .fst) ℓD
+    WriterFreeAlgebraᴰ .fst wx = Xᴰ (wx .snd) .fst
+    WriterFreeAlgebraᴰ .snd (tell w) γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+      R.reind op∘γ≡op⟨γ⟩ (γᴰ tt)
+
+    WriterOpNormalize :
+      (w : W .fst)
+      (γ : Unit → WriterFreeModel .fst .fst)
+      (γᴰ : (u : Unit) → WriterFreeAlgebraᴰ .fst (γ u))
+      → Path (T.∫Algebra WriterFreeAlgebraᴰ .fst)
+          ( WriterFreeModel .fst .snd (tell w) γ
+          , WriterFreeAlgebraᴰ .snd (tell w) γ γᴰ _ refl)
+          ( WriterFreeModel .fst .snd (tell w) γ
+          , γᴰ tt)
+    WriterOpNormalize w γ γᴰ = R.reind-filler⁻ refl
+
+    WriterAppFiller : {V : Type ℓV}
+      (w : W .fst)
+      (ρ : V → WriterFreeModel .fst .fst)
+      (ρᴰ : (v : V) → WriterFreeAlgebraᴰ .fst (ρ v))
+      (γ : Unit → T.|FreeAlgebra| V)
+      → Path (T.∫Algebra WriterFreeAlgebraᴰ .fst)
+          ( WriterFreeModel .fst .snd (tell w)
+              (λ u → T.interp (WriterFreeModel .fst) ρ (γ u))
+          , WriterFreeAlgebraᴰ .snd (tell w)
+              (λ u → T.interp (WriterFreeModel .fst) ρ (γ u))
+              (λ u → T.interpᴰ WriterFreeAlgebraᴰ ρ ρᴰ (γ u))
+              _ refl)
+          ( T.interp (WriterFreeModel .fst) ρ (T.S.app (tell w) γ)
+          , T.interpᴰ WriterFreeAlgebraᴰ ρ ρᴰ
+              (T.S.app (tell w) γ))
+    WriterAppFiller w ρ ρᴰ γ =
+      T.Algebraᴰ-op-filler WriterFreeAlgebraᴰ (tell w)
+        (λ u → T.interp (WriterFreeModel .fst) ρ (γ u))
+        (λ u → T.interpᴰ WriterFreeAlgebraᴰ ρ ρᴰ (γ u))
+        (T.interp (WriterFreeModel .fst) ρ (T.S.app (tell w) γ))
+        (T.recFA (WriterFreeModel .fst) ρ .snd (tell w) γ
+          (T.S.app (tell w) γ) refl)
+
+    WriterFreeModelᴰ : T.Modelᴰ WriterFreeModel ℓD
+    WriterFreeModelᴰ .fst = WriterFreeAlgebraᴰ
+    WriterFreeModelᴰ .snd .fst tell-idEq ρ ρᴰ =
+      R.rectifyOut
+        {e' = WriterFreeModel .snd .fst tell-idEq ρ}
+        ( sym (WriterAppFiller W.ε ρ ρᴰ (λ _ → T.S.var tt))
+        ∙ WriterOpNormalize W.ε (λ _ → ρ tt) (λ _ → ρᴰ tt)
+        ∙ unitPath)
+      where
+      unitPath : Path (T.∫Algebra WriterFreeAlgebraᴰ .fst)
+        ( (W._·_ W.ε (ρ tt .fst) , ρ tt .snd) , ρᴰ tt)
+        (ρ tt , ρᴰ tt)
+      unitPath i .fst .fst = W.·IdL (ρ tt .fst) i
+      unitPath i .fst .snd = ρ tt .snd
+      unitPath i .snd = ρᴰ tt
+    WriterFreeModelᴰ .snd .fst (tell-tellEq w w') ρ ρᴰ =
+      R.rectifyOut
+        {e' = WriterFreeModel .snd .fst (tell-tellEq w w') ρ}
+        ( sym (WriterAppFiller w ρ ρᴰ
+            (λ _ → T.S.app (tell w') (λ _ → T.S.var tt)))
+        ∙ WriterOpNormalize w
+            (λ _ → T.interp (WriterFreeModel .fst) ρ
+              (T.S.app (tell w') (λ _ → T.S.var tt)))
+            (λ _ → T.interpᴰ WriterFreeAlgebraᴰ ρ ρᴰ
+              (T.S.app (tell w') (λ _ → T.S.var tt)))
+        ∙ cong leftMultiplyTotal innerPath
+        ∙ assocPath
+        ∙ sym (WriterOpNormalize (W._·_ w w')
+            (λ _ → ρ tt) (λ _ → ρᴰ tt))
+        ∙ WriterAppFiller (W._·_ w w') ρ ρᴰ
+            (λ _ → T.S.var tt))
+      where
+      innerPath : Path (T.∫Algebra WriterFreeAlgebraᴰ .fst)
+        ( T.interp (WriterFreeModel .fst) ρ
+            (T.S.app (tell w') (λ _ → T.S.var tt))
+        , T.interpᴰ WriterFreeAlgebraᴰ ρ ρᴰ
+            (T.S.app (tell w') (λ _ → T.S.var tt)))
+        ( (W._·_ w' (ρ tt .fst) , ρ tt .snd) , ρᴰ tt)
+      innerPath =
+        sym (WriterAppFiller w' ρ ρᴰ (λ _ → T.S.var tt))
+        ∙ WriterOpNormalize w' (λ _ → ρ tt) (λ _ → ρᴰ tt)
+
+      leftMultiplyTotal : T.∫Algebra WriterFreeAlgebraᴰ .fst →
+        T.∫Algebra WriterFreeAlgebraᴰ .fst
+      leftMultiplyTotal z =
+        (W._·_ w (z .fst .fst) , z .fst .snd) , z .snd
+
+      assocPath : Path (T.∫Algebra WriterFreeAlgebraᴰ .fst)
+        ( (W._·_ w (W._·_ w' (ρ tt .fst)) , ρ tt .snd) , ρᴰ tt)
+        ( (W._·_ (W._·_ w w') (ρ tt .fst) , ρ tt .snd) , ρᴰ tt)
+      assocPath i .fst .fst = W.·Assoc w w' (ρ tt .fst) i
+      assocPath i .fst .snd = ρ tt .snd
+      assocPath i .snd = ρᴰ tt
+    WriterFreeModelᴰ .snd .snd wx = Xᴰ (wx .snd) .snd
+
+    WriterFreeModelηᴰ : (x : X .fst) → Xᴰ x .fst →
+      WriterFreeModelᴰ .fst .fst (WriterFreeModelη x)
+    WriterFreeModelηᴰ x xᴰ = xᴰ
+
+    module _
+      (Bᴰ : T.Modelᴰ WriterFreeModel ℓD')
+      (fᴰ : (x : X .fst) → Xᴰ x .fst →
+        Bᴰ .fst .fst (WriterFreeModelη x))
+      where
+      private
+        module BᴰR = hSetReasoning
+          (WriterFreeModel .fst .fst , WriterFreeModel .snd .snd)
+          (Bᴰ .fst .fst)
+
+      WriterFreeModelRecᴰ-fun :
+        (wx : WriterFreeModel .fst .fst) →
+        WriterFreeAlgebraᴰ .fst wx → Bᴰ .fst .fst wx
+      WriterFreeModelRecᴰ-fun (w , x) xᴰ =
+        Bᴰ .fst .snd (tell w)
+          (λ _ → WriterFreeModelη x)
+          (λ _ → fᴰ x xᴰ)
+          (w , x) (ΣPathP (W.·IdR w , refl))
+
+      TargetAppFiller : {V : Type ℓV}
+        (w : W .fst)
+        (ρ : V → WriterFreeModel .fst .fst)
+        (ρᴰ : (v : V) → Bᴰ .fst .fst (ρ v))
+        (γ : Unit → T.|FreeAlgebra| V)
+        → Path (T.∫Algebra (Bᴰ .fst) .fst)
+            ( WriterFreeModel .fst .snd (tell w)
+                (λ u → T.interp (WriterFreeModel .fst) ρ (γ u))
+            , Bᴰ .fst .snd (tell w)
+                (λ u → T.interp (WriterFreeModel .fst) ρ (γ u))
+                (λ u → T.interpᴰ (Bᴰ .fst) ρ ρᴰ (γ u))
+                _ refl)
+            ( T.interp (WriterFreeModel .fst) ρ
+                (T.S.app (tell w) γ)
+            , T.interpᴰ (Bᴰ .fst) ρ ρᴰ (T.S.app (tell w) γ))
+      TargetAppFiller w ρ ρᴰ γ =
+        T.Algebraᴰ-op-filler (Bᴰ .fst) (tell w)
+          (λ u → T.interp (WriterFreeModel .fst) ρ (γ u))
+          (λ u → T.interpᴰ (Bᴰ .fst) ρ ρᴰ (γ u))
+          (T.interp (WriterFreeModel .fst) ρ (T.S.app (tell w) γ))
+          (T.recFA (WriterFreeModel .fst) ρ .snd (tell w) γ
+            (T.S.app (tell w) γ) refl)
+
+      WriterFreeModelRecᴰ-β : (x : X .fst) (xᴰ : Xᴰ x .fst) →
+        WriterFreeModelRecᴰ-fun
+          (WriterFreeModelη x) (WriterFreeModelηᴰ x xᴰ) ≡ fᴰ x xᴰ
+      WriterFreeModelRecᴰ-β x xᴰ = BᴰR.rectifyOut {e' = refl}
+        ( sym (T.Algebraᴰ-op-filler (Bᴰ .fst) (tell W.ε)
+            (λ _ → WriterFreeModelη x) (λ _ → fᴰ x xᴰ)
+            (WriterFreeModelη x) (ΣPathP (W.·IdR W.ε , refl)))
+        ∙ TargetAppFiller W.ε
+            (λ (_ : Unit) → WriterFreeModelη x)
+            (λ (_ : Unit) → fᴰ x xᴰ)
+            (λ _ → T.S.var tt)
+        ∙ ΣPathP
+            ( WriterFreeModel .snd .fst tell-idEq
+                (λ _ → WriterFreeModelη x)
+            , Bᴰ .snd .fst tell-idEq
+                (λ _ → WriterFreeModelη x) (λ _ → fᴰ x xᴰ)))
+
+      private
+        RecᴰTotal : T.∫Algebra WriterFreeAlgebraᴰ .fst →
+          T.∫Algebra (Bᴰ .fst) .fst
+        RecᴰTotal z =
+          z .fst , WriterFreeModelRecᴰ-fun (z .fst) (z .snd)
+
+      WriterFreeModelRecᴰ :
+        T.Homoᴰ (T.idHomo {A = WriterFreeModel .fst})
+          WriterFreeAlgebraᴰ (Bᴰ .fst)
+      WriterFreeModelRecᴰ .fst = WriterFreeModelRecᴰ-fun
+      WriterFreeModelRecᴰ .snd (tell w) γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩
+        op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ =
+          BᴰR.rectifyOut {e' = refl}
+            ( sym (T.Algebraᴰ-op-filler (Bᴰ .fst) (tell w) γ
+                (λ u → WriterFreeModelRecᴰ-fun (γ u) (γᴰ u))
+                op⟨γ⟩ op∘γ≡op⟨γ⟩)
+            ∙ cong (T.∫Algebra (Bᴰ .fst) .snd (tell w))
+                (funExt λ { tt → branchPath })
+            ∙ TargetAppFiller w valuation valuationᴰ
+                (λ _ → T.S.app (tell w') (λ _ → T.S.var tt))
+            ∙ ΣPathP
+                ( WriterFreeModel .snd .fst (tell-tellEq w w') valuation
+                , Bᴰ .snd .fst (tell-tellEq w w') valuation valuationᴰ)
+            ∙ sym (TargetAppFiller (W._·_ w w') valuation valuationᴰ
+                (λ _ → T.S.var tt))
+            ∙ T.Algebraᴰ-op-filler (Bᴰ .fst) (tell (W._·_ w w'))
+                (λ _ → WriterFreeModelη x) (λ _ → fᴰ x xᴰ)
+                (W._·_ w w' , x)
+                (ΣPathP (W.·IdR (W._·_ w w') , refl))
+            ∙ cong RecᴰTotal sourcePath)
+          where
+          w' : W .fst
+          w' = γ tt .fst
+
+          x : X .fst
+          x = γ tt .snd
+
+          xᴰ : Xᴰ x .fst
+          xᴰ = γᴰ tt
+
+          valuation : Unit → WriterFreeModel .fst .fst
+          valuation _ = WriterFreeModelη x
+
+          valuationᴰ : (u : Unit) → Bᴰ .fst .fst (valuation u)
+          valuationᴰ _ = fᴰ x xᴰ
+
+          branchPath : Path (T.∫Algebra (Bᴰ .fst) .fst)
+            (γ tt , WriterFreeModelRecᴰ-fun (γ tt) (γᴰ tt))
+            ( T.interp (WriterFreeModel .fst) valuation
+                (T.S.app (tell w') (λ _ → T.S.var tt))
+            , T.interpᴰ (Bᴰ .fst) valuation valuationᴰ
+                (T.S.app (tell w') (λ _ → T.S.var tt)))
+          branchPath =
+            sym (T.Algebraᴰ-op-filler (Bᴰ .fst) (tell w')
+              (λ _ → WriterFreeModelη x) (λ _ → fᴰ x xᴰ)
+              (w' , x) (ΣPathP (W.·IdR w' , refl)))
+            ∙ TargetAppFiller w' valuation valuationᴰ
+                (λ _ → T.S.var tt)
+
+          sourcePath : Path (T.∫Algebra WriterFreeAlgebraᴰ .fst)
+            ((W._·_ w w' , x) , xᴰ)
+            (op⟨γ⟩ , op⟨γᴰ⟩)
+          sourcePath =
+            R.reind-filler op∘γ≡op⟨γ⟩
+            ∙ R.≡in {pth = refl} op∘γᴰ≡op⟨γᴰ⟩
+
+    WriterFreeModelRecᴰ-uniq :
+      (Bᴰ : T.Modelᴰ WriterFreeModel ℓD')
+      (hᴰ : T.Homoᴰ (T.idHomo {A = WriterFreeModel .fst})
+        WriterFreeAlgebraᴰ (Bᴰ .fst))
+      → hᴰ .fst ≡
+        WriterFreeModelRecᴰ Bᴰ
+          (λ x xᴰ → hᴰ .fst
+            (WriterFreeModelη x) (WriterFreeModelηᴰ x xᴰ)) .fst
+    WriterFreeModelRecᴰ-uniq Bᴰ hᴰ =
+      funExt λ { (w , x) → funExt λ xᴰ →
+        sym
+          (hᴰ .snd (tell w)
+            (λ _ → WriterFreeModelη x)
+            (λ _ → WriterFreeModelηᴰ x xᴰ)
+            (w , x) basePath xᴰ (sourceᴰ≡ w x xᴰ)) }
+      where
+      basePath : {w : W .fst} {x : X .fst} →
+        WriterFreeModel .fst .snd (tell w)
+          (λ _ → WriterFreeModelη x) ≡ (w , x)
+      basePath {w = w} = ΣPathP (W.·IdR w , refl)
+
+      sourceᴰ≡ : (w : W .fst) (x : X .fst) (xᴰ : Xᴰ x .fst) →
+        WriterFreeAlgebraᴰ .snd (tell w)
+          (λ _ → WriterFreeModelη x)
+          (λ _ → WriterFreeModelηᴰ x xᴰ)
+          (w , x) basePath
+        ≡ xᴰ
+      sourceᴰ≡ w x xᴰ = R.rectifyOut {e' = refl}
+        (R.reind-filler⁻ basePath ∙ constantPath)
+        where
+        constantPath : Path (T.∫Algebra WriterFreeAlgebraᴰ .fst)
+          ((W._·_ w W.ε , x) , xᴰ) ((w , x) , xᴰ)
+        constantPath i .fst .fst = W.·IdR w i
+        constantPath i .fst .snd = x
+        constantPath i .snd = xᴰ
+
+    WriterFreeModelUniversalᴰ :
+      (Bᴰ : T.Modelᴰ WriterFreeModel ℓD') →
+      isEquiv
+        (λ (hᴰ : T.Homoᴰ (T.idHomo {A = WriterFreeModel .fst})
+            WriterFreeAlgebraᴰ (Bᴰ .fst)) x xᴰ →
+          hᴰ .fst (WriterFreeModelη x) (WriterFreeModelηᴰ x xᴰ))
+    WriterFreeModelUniversalᴰ Bᴰ = isIsoToIsEquiv
+      ( WriterFreeModelRecᴰ Bᴰ
+      , (λ fᴰ → funExt λ x → funExt λ xᴰ →
+          WriterFreeModelRecᴰ-β Bᴰ fᴰ x xᴰ)
+      , (λ hᴰ → Σ≡Prop
+          (λ _ → isPropΠ6 λ _ _ _ _ _ _ →
+            isPropΠ λ _ → Bᴰ .snd .snd _ _ _)
+          (sym (WriterFreeModelRecᴰ-uniq Bᴰ hᴰ)))
+      )
+
+    module _ {B : T.Model ℓB}
+      (ϕ : T.Homo (WriterFreeModel .fst) (B .fst))
+      (Bᴰ : T.Modelᴰ B ℓD')
+      (fᴰ : (x : X .fst) → Xᴰ x .fst →
+        Bᴰ .fst .fst (ϕ .fst (WriterFreeModelη x)))
+      where
+      WriterFreeModelRecOverᴰ :
+        T.Homoᴰ ϕ WriterFreeAlgebraᴰ (Bᴰ .fst)
+      WriterFreeModelRecOverᴰ =
+        WriterFreeModelRecᴰ
+          (T._*_ {M = WriterFreeModel} {N = B} ϕ Bᴰ) fᴰ
+
+      WriterFreeModelRecOverᴰ-β :
+        (x : X .fst) (xᴰ : Xᴰ x .fst) →
+        WriterFreeModelRecOverᴰ .fst
+          (WriterFreeModelη x) (WriterFreeModelηᴰ x xᴰ) ≡ fᴰ x xᴰ
+      WriterFreeModelRecOverᴰ-β =
+        WriterFreeModelRecᴰ-β
+          (T._*_ {M = WriterFreeModel} {N = B} ϕ Bᴰ) fᴰ
+
+    WriterFreeModelRecOverᴰ-uniq : {B : T.Model ℓB}
+      (ϕ : T.Homo (WriterFreeModel .fst) (B .fst))
+      (Bᴰ : T.Modelᴰ B ℓD')
+      (hᴰ : T.Homoᴰ ϕ WriterFreeAlgebraᴰ (Bᴰ .fst))
+      → hᴰ .fst ≡ WriterFreeModelRecOverᴰ {B = B} ϕ Bᴰ
+          (λ x xᴰ → hᴰ .fst
+            (WriterFreeModelη x) (WriterFreeModelηᴰ x xᴰ)) .fst
+    WriterFreeModelRecOverᴰ-uniq {B = B} ϕ Bᴰ =
+      WriterFreeModelRecᴰ-uniq
+        (T._*_ {M = WriterFreeModel} {N = B} ϕ Bᴰ)
+
+    WriterFreeModelUniversalOverᴰ : {B : T.Model ℓB}
+      (ϕ : T.Homo (WriterFreeModel .fst) (B .fst))
+      (Bᴰ : T.Modelᴰ B ℓD') →
+      isEquiv
+        (λ (hᴰ : T.Homoᴰ ϕ WriterFreeAlgebraᴰ (Bᴰ .fst)) x xᴰ →
+          hᴰ .fst (WriterFreeModelη x) (WriterFreeModelηᴰ x xᴰ))
+    WriterFreeModelUniversalOverᴰ {B = B} ϕ Bᴰ =
+      WriterFreeModelUniversalᴰ
+        (T._*_ {M = WriterFreeModel} {N = B} ϕ Bᴰ)

--- a/Cubical/Categories/Displayed/CBPV/Unary/Additive.agda
+++ b/Cubical/Categories/Displayed/CBPV/Unary/Additive.agda
@@ -11,7 +11,6 @@ open import Cubical.Categories.Instances.TotalCategory
 open import Cubical.Categories.Instances.Sets
 open import Cubical.Categories.Instances.WalkingArrow
   renaming (WalkingArrow to KIND; Vertex to Kind; l to 𝒱; r to 𝒞)
-open import Cubical.Categories.Presheaf.Morphism.Alt
 open import Cubical.Categories.Displayed.Base
 open import Cubical.Categories.Displayed.Functor
 open import Cubical.Categories.Displayed.Instances.Opposite
@@ -296,50 +295,20 @@ module _
     Dᴰ = Dⱽ .fst .fst
     G = ∫F F
 
-    -- The direct opposite avoids the toOpOp transports introduced by _^opF.
-    G-op : Functor ((∫C C) ^op) ((∫C D) ^op)
-    G-op .F-ob = G .F-ob
-    G-op .F-hom = G .F-hom
-    G-op .F-id = G .F-id
-    G-op .F-seq f g = G .F-seq g f
 
-  -- These cases are just eta expansions to get around the
-  -- no-eta-equality for Categoryᴰ, specifically more ∫ and ^op stuff.
   reindexValueInitialⱽ : ValueInitialsⱽ (reindex Dᴰ G)
   reindexValueInitialⱽ A =
-    init' .fst ,
-    pshiso
-      (pshhom
-        (λ x → init' .snd .PshIso.trans .PshHom.N-ob x)
-        (λ _ _ _ _ → refl))
-      (init' .snd .PshIso.nIso)
-    where
-    init' = reindexTerminalⱽ G-op (𝒱 , A)
-      (Dⱽ .snd .snd .snd .snd .fst (F.F-obᴰ A))
+    reindexInitialⱽ G (𝒱 , A) (Dⱽ .snd .snd .snd .snd .fst (F.F-obᴰ A))
 
   reindexValueBinCoProductⱽ : ValueBinCoProductsⱽ (reindex Dᴰ G)
   reindexValueBinCoProductⱽ A₁ᴰ A₂ᴰ =
-    bcp' .fst ,
-    pshiso
-      (pshhom
-        (λ x → bcp' .snd .PshIso.trans .PshHom.N-ob x)
-        (λ x y f p → bcp' .snd .PshIso.trans .PshHom.N-hom x y f p))
-      (bcp' .snd .PshIso.nIso)
-    where
-    bcp' = reindexBinProductⱽ G-op A₁ᴰ A₂ᴰ
+    reindexBinCoProductⱽ G A₁ᴰ A₂ᴰ
       (Dⱽ .snd .snd .snd .snd .snd .fst A₁ᴰ A₂ᴰ)
 
   reindexValueOpcartesianLifts :
     hasVerticalOpcartesianLiftsAt (reindex Dᴰ G) 𝒱
   reindexValueOpcartesianLifts f Aᴰ =
-    lift' .fst ,
-    pshiso
-      (pshhom
-        (λ x → lift' .snd .PshIso.trans .PshHom.N-ob x)
-        (λ x y g p → lift' .snd .PshIso.trans .PshHom.N-hom x y g p))
-      (lift' .snd .PshIso.nIso)
-    where
-    lift' = reindexCartesianLift (Dᴰ ^opᴰ) G-op (_ , f) Aᴰ
+    reindexOpcartesianLift G (_ , f) Aᴰ
       (Dⱽ .snd .snd .snd .snd .snd .snd .fst (F.F-homᴰ f) Aᴰ)
 
   AddCBPVCatⱽReindex : AddCBPVCatⱽ C ℓᴰᴰ ℓᴰᴰ'

--- a/Cubical/Categories/Displayed/CBPV/Unary/Additive.agda
+++ b/Cubical/Categories/Displayed/CBPV/Unary/Additive.agda
@@ -247,55 +247,24 @@ AddCBPVCatⱽ→ᴰ {C = C} Cⱽ .snd .snd .fst A₁ A₂ A₁ᴰ A₂ᴰ =
   π₂*A₂ᴰ = Cⱽ .snd .snd .snd .fst bp.π₂ A₂ᴰ
 AddCBPVCatⱽ→ᴰ {C = C} Cⱽ .snd .snd .snd .fst =
   Terminalⱽ→ⱽᴰ (D ^opᴰᴰ) value-initial
-    value-initialⱽ
+    (Terminalⱽ^opᴰ→^opᴰᴰ D
+      (Cⱽ .snd .snd .snd .snd .fst (value-initial .fst)))
   where
   D = Cⱽ .fst .fst
   value-initial = C .snd .snd .snd .fst
-  value-initial' = Cⱽ .snd .snd .snd .snd .fst (value-initial .fst)
-  value-initialⱽ : Terminalⱽ (D ^opᴰᴰ) (𝒱 , value-initial .fst)
-  value-initialⱽ .fst = value-initial' .fst
-  value-initialⱽ .snd =
-    pshiso
-      (pshhom
-        (λ x → value-initial' .snd .PshIso.trans .PshHom.N-ob x)
-        (λ _ _ _ _ → refl))
-      (value-initial' .snd .PshIso.nIso)
 AddCBPVCatⱽ→ᴰ {C = C} Cⱽ .snd .snd .snd .snd .fst
   A₁ A₂ A₁ᴰ A₂ᴰ =
   BinProductⱽ+π*→ⱽᴰ (D ^opᴰᴰ) bcp A₁ᴰ A₂ᴰ σ₁!A₁ᴰ σ₂!A₂ᴰ
-    bcpⱽ
+    (BinProductⱽ^opᴰ→^opᴰᴰ D
+      (Cⱽ .snd .snd .snd .snd .snd .fst (σ₁!A₁ᴰ .fst) (σ₂!A₂ᴰ .fst)))
   where
   D = Cⱽ .fst .fst
   bcp = C .snd .snd .snd .snd .fst A₁ A₂
   module bcp = BinProductⱽNotation ((C .fst .fst) ^opᴰ) bcp
-  σ₁!A₁ᴰ' = Cⱽ .snd .snd .snd .snd .snd .snd .fst bcp.π₁ A₁ᴰ
-  σ₂!A₂ᴰ' = Cⱽ .snd .snd .snd .snd .snd .snd .fst bcp.π₂ A₂ᴰ
-  σ₁!A₁ᴰ : CartesianLift (D ^opᴰᴰ) (_ , bcp.π₁) A₁ᴰ
-  σ₁!A₁ᴰ .fst = σ₁!A₁ᴰ' .fst
-  σ₁!A₁ᴰ .snd =
-    pshiso
-      (pshhom
-        (λ x → σ₁!A₁ᴰ' .snd .PshIso.trans .PshHom.N-ob x)
-        (λ x y f p → σ₁!A₁ᴰ' .snd .PshIso.trans .PshHom.N-hom x y f p))
-      (σ₁!A₁ᴰ' .snd .PshIso.nIso)
-  σ₂!A₂ᴰ : CartesianLift (D ^opᴰᴰ) (_ , bcp.π₂) A₂ᴰ
-  σ₂!A₂ᴰ .fst = σ₂!A₂ᴰ' .fst
-  σ₂!A₂ᴰ .snd =
-    pshiso
-      (pshhom
-        (λ x → σ₂!A₂ᴰ' .snd .PshIso.trans .PshHom.N-ob x)
-        (λ x y f p → σ₂!A₂ᴰ' .snd .PshIso.trans .PshHom.N-hom x y f p))
-      (σ₂!A₂ᴰ' .snd .PshIso.nIso)
-  bcpⱽ' = Cⱽ .snd .snd .snd .snd .snd .fst
-    (σ₁!A₁ᴰ .fst) (σ₂!A₂ᴰ .fst)
-  bcpⱽ : BinProductⱽ (D ^opᴰᴰ) (σ₁!A₁ᴰ .fst) (σ₂!A₂ᴰ .fst)
-  bcpⱽ .fst = bcpⱽ' .fst
-  bcpⱽ .snd =
-    pshiso
-      (pshhom
-        (λ x → bcpⱽ' .snd .PshIso.trans .PshHom.N-ob x)
-        (λ x y f p → bcpⱽ' .snd .PshIso.trans .PshHom.N-hom x y f p))
-      (bcpⱽ' .snd .PshIso.nIso)
+  σ₁!A₁ᴰ = CartesianLift^opᴰ→^opᴰᴰ D
+    (Cⱽ .snd .snd .snd .snd .snd .snd .fst bcp.π₁ A₁ᴰ)
+  σ₂!A₂ᴰ = CartesianLift^opᴰ→^opᴰᴰ D
+    (Cⱽ .snd .snd .snd .snd .snd .snd .fst bcp.π₂ A₂ᴰ)
 AddCBPVCatⱽ→ᴰ {C = C} Cⱽ .snd .snd .snd .snd .snd .fst =
   Terminalⱽ→ⱽᴰ D computation-terminal
     (Cⱽ .snd .snd .snd .snd .snd .snd .snd .fst

--- a/Cubical/Categories/Displayed/CBPV/Unary/Additive.agda
+++ b/Cubical/Categories/Displayed/CBPV/Unary/Additive.agda
@@ -89,7 +89,7 @@ module AddCBPVCatᴰNotation
 
   open TerminalⱽᴰNotation Dᴰ (C .snd .fst) (Cᴰ .snd .fst) public renaming
     (vertexᴰ to value-terminal-obᴰ ; !ⱽᴰ to value-terminal-introᴰ ;
-     !ηⱽᴰ to value-terminal-ηᴰ)
+     !ηⱽᴰ to value-terminal-ηᴰ ; !ηⱽᴰ-on to value-terminal-ηᴰ-on)
 
   module _ {A₁ A₂}
     (A₁ᴰ : Categoryᴰ.ob[_] Dᴰ (𝒱 , A₁))
@@ -105,7 +105,7 @@ module AddCBPVCatᴰNotation
   open InitialⱽᴰNotation Dᴰ (C .snd .snd .snd .fst)
     (Cᴰ .snd .snd .snd .fst) public renaming
     (vertexᴰ to value-initial-obᴰ ; ¡ⱽᴰ to value-initial-elimᴰ ;
-     ¡ηⱽᴰ to value-initial-ηᴰ)
+     ¡ηⱽᴰ to value-initial-ηᴰ ; ¡ηⱽᴰ-on to value-initial-ηᴰ-on)
 
   module _ {A₁ A₂}
     (A₁ᴰ : Categoryᴰ.ob[_] Dᴰ (𝒱 , A₁))
@@ -121,7 +121,8 @@ module AddCBPVCatᴰNotation
   open TerminalⱽᴰNotation Dᴰ (C .snd .snd .snd .snd .snd .fst)
     (Cᴰ .snd .snd .snd .snd .snd .fst) public renaming
     (vertexᴰ to computation-terminal-obᴰ ; !ⱽᴰ to computation-terminal-introᴰ ;
-     !ηⱽᴰ to computation-terminal-ηᴰ)
+     !ηⱽᴰ to computation-terminal-ηᴰ ;
+     !ηⱽᴰ-on to computation-terminal-ηᴰ-on)
 
   module _ {B₁ B₂}
     (B₁ᴰ : Categoryᴰ.ob[_] Dᴰ (𝒞 , B₁))

--- a/Cubical/Categories/Displayed/CBPV/Unary/Base.agda
+++ b/Cubical/Categories/Displayed/CBPV/Unary/Base.agda
@@ -12,7 +12,7 @@ module Cubical.Categories.Displayed.CBPV.Unary.Base where
 
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.More
-open import Cubical.Foundations.Equiv.Dependent
+open import Cubical.Foundations.Function
 
 open import Cubical.Prop
 
@@ -141,12 +141,16 @@ module _ {C : CBPVCat ℓ ℓ'}(Cᴰ : CBPVCatᴰ C ℓᴰ ℓᴰ') where
   hasFᴰ : hasF C → Type _
   hasFᴰ = Liftsᴰ⁺ⱽ.Quadrableᴰ _ _ (Cᴰ ^opᴰᴰ) {k1 = 𝓒}{k2 = 𝓥} _
 
-  -- Notation for getting rid of the reinds etc that arise from the
-  -- bad universal properties. These give a clean interface to the
-  -- eliminators for free CBPV models.
+  -- Notation for the displayed U/F types. The displayed β/η laws are
+  -- instances of the generic cartesian-lift laws in
+  -- Liftsᴰ⁺ⱽ.CartesianLiftᴰNotation, rectified along caller-supplied
+  -- paths for the base force/ret and β/η. These give a clean interface
+  -- to the eliminators for free CBPV models.
   module _ (hasUC : hasU C) (hasUᴰC : hasUᴰ hasUC) where
     private
       module ∫Ccat = Category (∫C C)
+      module Uᴰ {B} {Bᴰ : Cᴰ.ob[ 𝓒 , B ]} =
+        Liftsᴰ⁺ⱽ.QuadrableᴰNotation KIND C Cᴰ _ hasUC hasUᴰC {Bᴰ = Bᴰ}
 
       U-ob : C.ob[ 𝓒 ] → C.ob[ 𝓥 ]
       U-ob B = hasUC B .fst
@@ -160,39 +164,14 @@ module _ {C : CBPVCat ℓ ℓ'}(Cᴰ : CBPVCatᴰ C ℓᴰ ℓᴰ') where
 
     forceᴰ : ∀ {B : C.ob[ 𝓒 ]}{Bᴰ : Cᴰ.ob[ 𝓒 , B ]}
       → Cᴰ.Hom[ _ , QuadrableNotation.πⱽ C hasUC ][ hasUᴰC Bᴰ .fst , Bᴰ ]
-    forceᴰ {Bᴰ = Bᴰ} =
-      hasUᴰC Bᴰ .snd .fst .PshHom.N-ob _ Cᴰ.idᴰ
+    forceᴰ = Uᴰ.πⱽ
 
     thunkᴰ : ∀ {A : C.ob[ 𝓥 ]}{B : C.ob[ 𝓒 ]}
       {Aᴰ : Cᴰ.ob[ 𝓥 , A ]}{Bᴰ : Cᴰ.ob[ 𝓒 , B ]}
       (M : C [ ı tt ][ A , B ])
       → Cᴰ.Hom[ ı tt , M ][ Aᴰ , Bᴰ ]
       → Cᴰ.Hom[ ı tt , QuadrableNotation.introᴰ C hasUC M ][ Aᴰ , hasUᴰC Bᴰ .fst ]
-    thunkᴰ {Bᴰ = Bᴰ} M Mᴰ =
-      hasUᴰC Bᴰ .snd .snd _ _ .isIsoOver.inv _ Mᴰ
-
-    cong-thunkᴰ : ∀ {A : C.ob[ 𝓥 ]}{B : C.ob[ 𝓒 ]}
-      {Aᴰ : Cᴰ.ob[ 𝓥 , A ]}{Bᴰ : Cᴰ.ob[ 𝓒 , B ]}
-      {M N : C [ ı tt ][ A , B ]}
-      {Mᴰ : Cᴰ.Hom[ ı tt , M ][ Aᴰ , Bᴰ ]}
-      {Nᴰ : Cᴰ.Hom[ ı tt , N ][ Aᴰ , Bᴰ ]}
-      → Path Cᴰ.Hom[ _ , _ ] (_ , Mᴰ) (_ , Nᴰ)
-      → Path Cᴰ.Hom[ _ , _ ] (_ , thunkᴰ M Mᴰ) (_ , thunkᴰ N Nᴰ)
-    cong-thunkᴰ {Bᴰ = Bᴰ} =
-      cong (invPshIso (∫PshIsoᴰ (hasUᴰC Bᴰ .snd)) .PshIso.trans .PshHom.N-ob _)
-
-    force-naturalᴰ : ∀ {A : C.ob[ 𝓥 ]}{B : C.ob[ 𝓒 ]}
-      {Aᴰ : Cᴰ.ob[ 𝓥 , A ]}{Bᴰ : Cᴰ.ob[ 𝓒 , B ]}
-      {V : C [ _ ][ A , hasUC B .fst ]}
-      (Vᴰ : Cᴰ.Hom[ _ , V ][ Aᴰ , hasUᴰC Bᴰ .fst ])
-      → Path Cᴰ.Hom[ _ , _ ]
-          (_ , Vᴰ Cᴰ.⋆ᴰ forceᴰ)
-          (_ , hasUᴰC Bᴰ .snd .fst .PshHom.N-ob _ Vᴰ)
-    force-naturalᴰ {Bᴰ = Bᴰ} Vᴰ =
-      Cᴰ.reind-filler {p = Vᴰ Cᴰ.⋆ᴰ forceᴰ} _
-      ∙ sym (∫PshHomᴰ (hasUᴰC Bᴰ .snd .fst) .PshHom.N-hom _ _ _ _)
-      ∙ cong (∫PshHomᴰ (hasUᴰC Bᴰ .snd .fst) .PshHom.N-ob _)
-          (sym (Cᴰ.reind-filler _) ∙ Cᴰ.⋆IdR _)
+    thunkᴰ M Mᴰ = Uᴰ.introᴰ Mᴰ
 
     Uβᴰ : ∀ {A : C.ob[ 𝓥 ]}{B : C.ob[ 𝓒 ]}
       {Aᴰ : Cᴰ.ob[ 𝓥 , A ]}{Bᴰ : Cᴰ.ob[ 𝓒 , B ]}
@@ -205,12 +184,8 @@ module _ {C : CBPVCat ℓ ℓ'}(Cᴰ : CBPVCatᴰ C ℓᴰ ℓᴰ') where
       → PathP (λ i → (Cᴰ .Categoryᴰ.Hom[_][_,_]) (Uβ i) Aᴰ Bᴰ)
           (thunkᴰ M Mᴰ Cᴰ.⋆ᴰ Cᴰ.reind U-force≡force forceᴰ)
           Mᴰ
-    Uβᴰ {Bᴰ = Bᴰ} U-force≡force M Uβ Mᴰ =
-      Cᴰ.rectify {e' = Uβ} (Cᴰ.≡out
-        (Cᴰ.⟨⟩⋆⟨ Cᴰ.reind-filler⁻ U-force≡force ⟩
-        ∙ force-naturalᴰ (thunkᴰ M Mᴰ)
-        ∙ Cᴰ.≡in
-            (hasUᴰC Bᴰ .snd .snd _ _ .isIsoOver.rightInv _ Mᴰ)))
+    Uβᴰ U-force≡force M Uβ Mᴰ = Cᴰ.rectify {e' = Uβ} $ Cᴰ.≡out $
+      Cᴰ.⟨⟩⋆⟨ Cᴰ.reind-filler⁻ U-force≡force ⟩ ∙ Uᴰ.βᴰ' Mᴰ
 
     Uηᴰ : ∀ {A : C.ob[ 𝓥 ]}{B : C.ob[ 𝓒 ]}
       {Aᴰ : Cᴰ.ob[ 𝓥 , A ]}{Bᴰ : Cᴰ.ob[ 𝓒 , B ]}
@@ -226,18 +201,17 @@ module _ {C : CBPVCat ℓ ℓ'}(Cᴰ : CBPVCatᴰ C ℓᴰ ℓᴰ') where
           Vᴰ
           (thunkᴰ (V C.⋆ᴰ force)
             (Vᴰ Cᴰ.⋆ᴰ Cᴰ.reind U-force≡force forceᴰ))
-    Uηᴰ {Bᴰ = Bᴰ} U-force≡force V Uη Vᴰ =
-      Cᴰ.rectify {e' = Uη} (Cᴰ.≡out
-        (sym (Cᴰ.≡in
-          (hasUᴰC Bᴰ .snd .snd _ _ .isIsoOver.leftInv _ Vᴰ))
-        ∙ cong-thunkᴰ
-            (sym (force-naturalᴰ Vᴰ)
-            ∙ Cᴰ.⟨⟩⋆⟨ Cᴰ.reind-filler U-force≡force ⟩)))
+    Uηᴰ U-force≡force V Uη Vᴰ = Cᴰ.rectify {e' = Uη} $ Cᴰ.≡out $
+      Uᴰ.ηᴰ Vᴰ
+      ∙ Uᴰ.cong-introᴰ
+          (Uᴰ.⋆πⱽ≡⋆ᴰπⱽ Vᴰ ∙ Cᴰ.⟨⟩⋆⟨ Cᴰ.reind-filler U-force≡force ⟩)
 
   module _ (hasFC : hasF C) (hasFᴰC : hasFᴰ hasFC) where
     private
-      module Cᴰ^op = Fibers (Cᴰ ^opᴰᴰ)
       module ∫Ccat = Category (∫C C)
+      module Fᴰ {A} {Aᴰ : Cᴰ.ob[ 𝓥 , A ]} =
+        Liftsᴰ⁺ⱽ.QuadrableᴰNotation (KIND ^op) (C ^opᴰ) (Cᴰ ^opᴰᴰ) _
+          hasFC hasFᴰC {Bᴰ = Aᴰ}
 
       F-ob : C.ob[ 𝓥 ] → C.ob[ 𝓒 ]
       F-ob A = hasFC A .fst
@@ -251,8 +225,7 @@ module _ {C : CBPVCat ℓ ℓ'}(Cᴰ : CBPVCatᴰ C ℓᴰ ℓᴰ') where
 
     F-retᴰ : ∀ {A : C.ob[ 𝓥 ]}{Aᴰ : Cᴰ.ob[ 𝓥 , A ]}
       → Cᴰ.Hom[ ı tt , F-ret ][ Aᴰ , hasFᴰC Aᴰ .fst ]
-    F-retᴰ {Aᴰ = Aᴰ} =
-      hasFᴰC Aᴰ .snd .fst .PshHom.N-ob _ Cᴰ^op.idᴰ
+    F-retᴰ = Fᴰ.πⱽ
 
     F-bindᴰ : ∀ {A : C.ob[ 𝓥 ]}{B : C.ob[ 𝓒 ]}
       {Aᴰ : Cᴰ.ob[ 𝓥 , A ]}{Bᴰ : Cᴰ.ob[ 𝓒 , B ]}
@@ -261,31 +234,7 @@ module _ {C : CBPVCat ℓ ℓ'}(Cᴰ : CBPVCatᴰ C ℓᴰ ℓᴰ') where
       → (Cᴰ .Categoryᴰ.Hom[_][_,_])
           (Category.id KIND , F-bind M)
           (hasFᴰC Aᴰ .fst) Bᴰ
-    F-bindᴰ {Aᴰ = Aᴰ} M Mᴰ =
-      hasFᴰC Aᴰ .snd .snd _ _ .isIsoOver.inv _ Mᴰ
-
-    cong-F-bindᴰ : ∀ {A : C.ob[ 𝓥 ]}{B : C.ob[ 𝓒 ]}
-      {Aᴰ : Cᴰ.ob[ 𝓥 , A ]}{Bᴰ : Cᴰ.ob[ 𝓒 , B ]}
-      {M N : C [ ı tt ][ A , B ]}
-      {Mᴰ : Cᴰ.Hom[ ı tt , M ][ Aᴰ , Bᴰ ]}
-      {Nᴰ : Cᴰ.Hom[ ı tt , N ][ Aᴰ , Bᴰ ]}
-      → Path Cᴰ.Hom[ _ , _ ] (_ , Mᴰ) (_ , Nᴰ)
-      → Path Cᴰ.Hom[ _ , _ ] (_ , F-bindᴰ M Mᴰ) (_ , F-bindᴰ N Nᴰ)
-    cong-F-bindᴰ {Aᴰ = Aᴰ} =
-      cong (invPshIso (∫PshIsoᴰ (hasFᴰC Aᴰ .snd)) .PshIso.trans .PshHom.N-ob _)
-
-    F-ret-naturalᴰ : ∀ {A : C.ob[ 𝓥 ]}{B : C.ob[ 𝓒 ]}
-      {Aᴰ : Cᴰ.ob[ 𝓥 , A ]}{Bᴰ : Cᴰ.ob[ 𝓒 , B ]}
-      {K : C [ Category.id KIND ][ hasFC A .fst , B ]}
-      (Kᴰ : Cᴰ.Hom[ Category.id KIND , K ][ hasFᴰC Aᴰ .fst , Bᴰ ])
-      → Path Cᴰ.Hom[ _ , _ ]
-          (_ , F-retᴰ Cᴰ.⋆ᴰ Kᴰ)
-          (_ , hasFᴰC Aᴰ .snd .fst .PshHom.N-ob _ Kᴰ)
-    F-ret-naturalᴰ {Aᴰ = Aᴰ} Kᴰ =
-      Cᴰ^op.reind-filler {p = Kᴰ Cᴰ^op.⋆ᴰ F-retᴰ} _
-      ∙ sym (∫PshHomᴰ (hasFᴰC Aᴰ .snd .fst) .PshHom.N-hom _ _ _ _)
-      ∙ cong (∫PshHomᴰ (hasFᴰC Aᴰ .snd .fst) .PshHom.N-ob _)
-          (sym (Cᴰ^op.reind-filler _) ∙ Cᴰ^op.⋆IdR _)
+    F-bindᴰ M Mᴰ = Fᴰ.introᴰ Mᴰ
 
     Fβᴰ : ∀ {A : C.ob[ 𝓥 ]}{B : C.ob[ 𝓒 ]}
       {Aᴰ : Cᴰ.ob[ 𝓥 , A ]}{Bᴰ : Cᴰ.ob[ 𝓒 , B ]}
@@ -298,12 +247,8 @@ module _ {C : CBPVCat ℓ ℓ'}(Cᴰ : CBPVCatᴰ C ℓᴰ ℓᴰ') where
       → PathP (λ i → (Cᴰ .Categoryᴰ.Hom[_][_,_]) (Fβ i) Aᴰ Bᴰ)
           (Cᴰ.reind F-ret≡ret F-retᴰ Cᴰ.⋆ᴰ F-bindᴰ M Mᴰ)
           Mᴰ
-    Fβᴰ {Aᴰ = Aᴰ} F-ret≡ret M Fβ Mᴰ =
-      Cᴰ.rectify {e' = Fβ} (Cᴰ.≡out
-        (Cᴰ.⟨ Cᴰ.reind-filler⁻ F-ret≡ret ⟩⋆⟨⟩
-        ∙ F-ret-naturalᴰ (F-bindᴰ M Mᴰ)
-        ∙ Cᴰ^op.≡in
-            (hasFᴰC Aᴰ .snd .snd _ _ .isIsoOver.rightInv _ Mᴰ)))
+    Fβᴰ F-ret≡ret M Fβ Mᴰ = Cᴰ.rectify {e' = Fβ} $ Cᴰ.≡out $
+      Cᴰ.⟨ Cᴰ.reind-filler⁻ F-ret≡ret ⟩⋆⟨⟩ ∙ Fᴰ.βᴰ' Mᴰ
 
     Fηᴰ : ∀ {A : C.ob[ 𝓥 ]}{B : C.ob[ 𝓒 ]}
       {Aᴰ : Cᴰ.ob[ 𝓥 , A ]}{Bᴰ : Cᴰ.ob[ 𝓒 , B ]}
@@ -319,13 +264,10 @@ module _ {C : CBPVCat ℓ ℓ'}(Cᴰ : CBPVCatᴰ C ℓᴰ ℓᴰ') where
           Kᴰ
           (F-bindᴰ (ret C.⋆ᴰ K)
             (Cᴰ.reind F-ret≡ret F-retᴰ Cᴰ.⋆ᴰ Kᴰ))
-    Fηᴰ {Aᴰ = Aᴰ} F-ret≡ret K Fη Kᴰ =
-      Cᴰ.rectify {e' = Fη} (Cᴰ.≡out
-        (sym (Cᴰ^op.≡in
-          (hasFᴰC Aᴰ .snd .snd _ _ .isIsoOver.leftInv _ Kᴰ))
-        ∙ cong-F-bindᴰ
-            (sym (F-ret-naturalᴰ Kᴰ)
-            ∙ Cᴰ^op.⟨⟩⋆⟨ Cᴰ.reind-filler F-ret≡ret ⟩)))
+    Fηᴰ F-ret≡ret K Fη Kᴰ = Cᴰ.rectify {e' = Fη} $ Cᴰ.≡out $
+      Fᴰ.ηᴰ Kᴰ
+      ∙ Fᴰ.cong-introᴰ
+          (Fᴰ.⋆πⱽ≡⋆ᴰπⱽ Kᴰ ∙ Cᴰ.⟨ Cᴰ.reind-filler F-ret≡ret ⟩⋆⟨⟩)
 
   module _ (hasUC : hasU C) where
     hasUⱽ→ᴰ : hasUⱽ → hasUᴰ hasUC

--- a/Cubical/Categories/Displayed/CBPV/Unary/Enrichment/Algebra.agda
+++ b/Cubical/Categories/Displayed/CBPV/Unary/Enrichment/Algebra.agda
@@ -1,0 +1,287 @@
+{-# OPTIONS --lossy-unification --prop #-}
+module Cubical.Categories.Displayed.CBPV.Unary.Enrichment.Algebra where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv.Dependent
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.More
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Instances.Fiber
+open import Cubical.Categories.Instances.TotalCategory
+open import Cubical.Categories.Instances.WalkingArrow
+  renaming (WalkingArrow to KIND; Vertex to Kind; l to 𝒱; r to 𝒞; ≤Vertex to ≤Kind)
+
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Displayed.Instances.Reindex
+open import Cubical.Categories.Displayed.CBPV.Unary.Base
+open import Cubical.Algebra.Signature.Base
+
+private
+  variable
+    ℓ ℓ' ℓᴰ ℓᴰ' ℓD ℓD' ℓCᴰ ℓCᴰ' ℓO ℓA : Level
+
+open Category hiding (_∘_)
+open Categoryᴰ
+open Functor
+
+module _ (C : CBPVCat ℓ ℓ') (Sig : Signature ℓO ℓA) where
+  open Signature Sig
+  private module C = Fibers C
+
+  AlgebraEnrichment : Type _
+  AlgebraEnrichment =
+    Σ[ AlgebraEff ∈ (∀ (A : C.ob[ 𝒱 ]) (B : C.ob[ 𝒞 ])
+      → AlgebraWithCarrier (C.Hom[ _ ][ A , B ])) ]
+    (∀ {A A'} (V : C.Hom[ _ ][ A , A' ]) B
+      → isHomoSimpl (_ , AlgebraEff A' B) (_ , AlgebraEff A B)
+          (λ M → V C.⋆ᴰ M))
+    ×
+    (∀ {B B'} (S : C.Hom[ _ ][ B , B' ]) A
+      → isHomoSimpl (_ , AlgebraEff A B) (_ , AlgebraEff A B')
+          (λ M → M C.⋆ᴰ S))
+
+module _ {C : CBPVCat ℓ ℓ'} (Sig : Signature ℓO ℓA)
+  (CAlg : AlgebraEnrichment C Sig)
+  (Cᴰ : CBPVCatᴰ C ℓᴰ ℓᴰ') where
+  open Signature Sig
+  private module C = Fibers C
+  private module Cᴰ = Fibers Cᴰ
+
+  AlgebraEnrichmentᴰ : Type _
+  AlgebraEnrichmentᴰ =
+    Σ[ AlgebraEffᴰ ∈ (∀ {A B}
+      (Aᴰ : Cᴰ.ob[ _ , A ]) (Bᴰ : Cᴰ.ob[ _ , B ])
+      → AlgebraᴰWithCarrier (_ , CAlg .fst A B)
+          (λ M → Cᴰ.Hom[ _ , M ][ Aᴰ , Bᴰ ])) ]
+    (∀ {A A' B}
+      {Aᴰ : Cᴰ.ob[ _ , A ]} {Aᴰ' : Cᴰ.ob[ _ , A' ]}
+      {Bᴰ : Cᴰ.ob[ _ , B ]} {V : _}
+      (Vᴰ : Cᴰ.Hom[ _ , V ][ Aᴰ , Aᴰ' ])
+      → isHomoᴰSimpl
+          ((λ M → V C.⋆ᴰ M) , CAlg .snd .fst V B)
+          (_ , AlgebraEffᴰ Aᴰ' Bᴰ) (_ , AlgebraEffᴰ Aᴰ Bᴰ)
+          (λ _ Mᴰ → Vᴰ Cᴰ.⋆ᴰ Mᴰ))
+    ×
+    (∀ {A B B'}
+      {Aᴰ : Cᴰ.ob[ _ , A ]} {Bᴰ : Cᴰ.ob[ _ , B ]}
+      {Bᴰ' : Cᴰ.ob[ _ , B' ]} {S : _}
+      (Sᴰ : Cᴰ.Hom[ _ , S ][ Bᴰ , Bᴰ' ])
+      → isHomoᴰSimpl
+          ((λ M → M C.⋆ᴰ S) , CAlg .snd .snd S A)
+          (_ , AlgebraEffᴰ Aᴰ Bᴰ) (_ , AlgebraEffᴰ Aᴰ Bᴰ')
+          (λ _ Mᴰ → Mᴰ Cᴰ.⋆ᴰ Sᴰ))
+
+module _ {C : CBPVCat ℓ ℓ'} {D : CBPVCat ℓD ℓD'}
+  (Sig : Signature ℓO ℓA)
+  (F : Functorⱽ C D)
+  (CAlg : AlgebraEnrichment C Sig) (DAlg : AlgebraEnrichment D Sig)
+  where
+  open Signature Sig
+
+  PreservesAlgebraEnrichment : Type _
+  PreservesAlgebraEnrichment = ∀ A B →
+    isHomoSimpl (_ , CAlg .fst A B)
+      (_ , DAlg .fst (F .Functorᴰ.F-obᴰ A) (F .Functorᴰ.F-obᴰ B))
+      (F .Functorᴰ.F-homᴰ)
+
+module _ {ℓO ℓA} (Sig : Signature ℓO ℓA) where
+  open Signature Sig
+
+  reindexAlgebraᴰ-op-filler :
+    {A : Algebra ℓ} {B : Algebra ℓ'}
+    (ϕ : Homo A B) (Bᴰ : Algebraᴰ B ℓᴰ)
+    (op : Op) (γ : Arity op → A .fst)
+    (γᴰ : ∀ v → Bᴰ .fst (ϕ .fst (γ v)))
+    (op⟨γ⟩ : A .fst) (op∘γ≡op⟨γ⟩ : A .snd op γ ≡ op⟨γ⟩)
+    → Path (∫Algebra Bᴰ .fst)
+        (ϕ .fst op⟨γ⟩ ,
+          (ϕ * Bᴰ) .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩)
+        (B .snd op (ϕ .fst ∘ γ) ,
+          Bᴰ .snd op (ϕ .fst ∘ γ) γᴰ
+            (B .snd op (ϕ .fst ∘ γ)) refl)
+  reindexAlgebraᴰ-op-filler ϕ Bᴰ op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ i .fst =
+    ϕ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ (~ i)
+  reindexAlgebraᴰ-op-filler {B = B} ϕ Bᴰ op γ γᴰ
+    op⟨γ⟩ op∘γ≡op⟨γ⟩ i .snd =
+    Bᴰ .snd op (ϕ .fst ∘ γ) γᴰ
+      (ϕ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ (~ i))
+      (λ j → ϕ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ (j ∧ ~ i))
+
+  totalHomoᴰ :
+    {A : Algebra ℓ} {B : Algebra ℓ'}
+    {Aᴰ : Algebraᴰ A ℓᴰ} {Bᴰ : Algebraᴰ B ℓᴰ'}
+    {ϕ : Homo A B}
+    → Homoᴰ ϕ Aᴰ Bᴰ → Homo (∫Algebra Aᴰ) (∫Algebra Bᴰ)
+  totalHomoᴰ {A = A} {B = B} {Aᴰ = Aᴰ} {Bᴰ = Bᴰ} {ϕ = ϕ} ϕᴰ =
+    ∫intro (_⋆H_ {C = B} (Signature.Fst Sig) ϕ) section
+    where
+    section : Section (_⋆H_ {C = B} (Signature.Fst Sig) ϕ * Bᴰ)
+    section .fst z = ϕᴰ .fst (z .fst) (z .snd)
+    section .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+      ϕᴰ .snd op (fst ∘ γ) (snd ∘ γ)
+        (op⟨γ⟩ .fst) (cong fst op∘γ≡op⟨γ⟩)
+        (op⟨γ⟩ .snd)
+        (Signature.Snd Sig {Aᴰ = Aᴰ} .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩)
+
+module _
+  {C : CBPVCat ℓ ℓ'} {D : CBPVCat ℓD ℓD'}
+  (Sig : Signature ℓO ℓA)
+  (F : Functorⱽ C D)
+  (CAlg : AlgebraEnrichment C Sig) (DAlg : AlgebraEnrichment D Sig)
+  (FAlg : PreservesAlgebraEnrichment Sig F CAlg DAlg)
+  (Dᴰ : CBPVCatᴰ D ℓCᴰ ℓCᴰ')
+  (DᴰAlg : AlgebraEnrichmentᴰ Sig DAlg Dᴰ)
+  where
+  open Signature Sig
+  private
+    module C = Fibers C
+    module D = Fibers D
+    module Dᴰ = Fibers Dᴰ
+    module F = Functorᴰ F
+
+    FAlgHomo : ∀ A B → Homo (_ , CAlg .fst A B)
+      (_ , DAlg .fst (F.F-obᴰ A) (F.F-obᴰ B))
+    FAlgHomo A B = F.F-homᴰ , FAlg A B
+
+    F*Cᴰ = reindex Dᴰ (∫F F)
+    module F*Cᴰ = Fibers F*Cᴰ
+
+    AlgebraEffᴰReindex : ∀ {A : C.ob[ 𝒱 ]} {B : C.ob[ 𝒞 ]}
+      (Aᴰ : Dᴰ.ob[ _ , F.F-obᴰ A ]) (Bᴰ : Dᴰ.ob[ _ , F.F-obᴰ B ])
+      → Algebraᴰ (_ , CAlg .fst A B) ℓCᴰ'
+    AlgebraEffᴰReindex {A} {B} Aᴰ Bᴰ .fst M =
+      Dᴰ.Hom[ _ , F.F-homᴰ M ][ Aᴰ , Bᴰ ]
+    AlgebraEffᴰReindex {A} {B} Aᴰ Bᴰ .snd
+      op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+        DᴰAlg .fst Aᴰ Bᴰ op (F.F-homᴰ ∘ γ) γᴰ
+          (F.F-homᴰ op⟨γ⟩)
+          (FAlg A B op γ op⟨γ⟩ op∘γ≡op⟨γ⟩)
+
+    algebra-subst-filler : ∀
+      {A A' : C.ob[ 𝒱 ]} {B : C.ob[ 𝒞 ]}
+      {Aᴰ : Dᴰ.ob[ _ , F.F-obᴰ A ]} {Aᴰ' : Dᴰ.ob[ _ , F.F-obᴰ A' ]}
+      {Bᴰ : Dᴰ.ob[ _ , F.F-obᴰ B ]}
+      {V : C.Hom[ _ ][ A , A' ]} {M : C.Hom[ _ ][ A' , B ]}
+      (Vᴰ : Dᴰ.Hom[ _ , F.F-homᴰ V ][ Aᴰ , Aᴰ' ])
+      (Mᴰ : Dᴰ.Hom[ _ , F.F-homᴰ M ][ Aᴰ' , Bᴰ ])
+      → Path
+          (Σ[ N ∈ D.Hom[ _ ][ F.F-obᴰ A , F.F-obᴰ B ] ]
+            Dᴰ.Hom[ _ , N ][ Aᴰ , Bᴰ ])
+          (F.F-homᴰ (V C.⋆ᴰ M) , Vᴰ F*Cᴰ.⋆ᴰ Mᴰ)
+          (F.F-homᴰ V D.⋆ᴰ F.F-homᴰ M , Vᴰ Dᴰ.⋆ᴰ Mᴰ)
+    algebra-subst-filler {V = V} {M = M} Vᴰ Mᴰ i .fst =
+      sym (Dᴰ.reind-revealed-filler {p = Vᴰ Dᴰ.⋆ᴰ Mᴰ}
+        (sym (Functor.F-seq (∫F F) (_ , V) (_ , M)))) i .fst .snd
+    algebra-subst-filler {V = V} {M = M} Vᴰ Mᴰ i .snd =
+      sym (Dᴰ.reind-revealed-filler {p = Vᴰ Dᴰ.⋆ᴰ Mᴰ}
+        (sym (Functor.F-seq (∫F F) (_ , V) (_ , M)))) i .snd
+
+    algebra-plug-filler : ∀
+      {A : C.ob[ 𝒱 ]} {B B' : C.ob[ 𝒞 ]}
+      {Aᴰ : Dᴰ.ob[ _ , F.F-obᴰ A ]} {Bᴰ : Dᴰ.ob[ _ , F.F-obᴰ B ]}
+      {Bᴰ' : Dᴰ.ob[ _ , F.F-obᴰ B' ]}
+      {M : C.Hom[ _ ][ A , B ]} {S : C.Hom[ _ ][ B , B' ]}
+      (Mᴰ : Dᴰ.Hom[ _ , F.F-homᴰ M ][ Aᴰ , Bᴰ ])
+      (Sᴰ : Dᴰ.Hom[ _ , F.F-homᴰ S ][ Bᴰ , Bᴰ' ])
+      → Path
+          (Σ[ N ∈ D.Hom[ _ ][ F.F-obᴰ A , F.F-obᴰ B' ] ]
+            Dᴰ.Hom[ _ , N ][ Aᴰ , Bᴰ' ])
+          (F.F-homᴰ (M C.⋆ᴰ S) , Mᴰ F*Cᴰ.⋆ᴰ Sᴰ)
+          (F.F-homᴰ M D.⋆ᴰ F.F-homᴰ S , Mᴰ Dᴰ.⋆ᴰ Sᴰ)
+    algebra-plug-filler {M = M} {S = S} Mᴰ Sᴰ i .fst =
+      sym (Dᴰ.reind-revealed-filler {p = Mᴰ Dᴰ.⋆ᴰ Sᴰ}
+        (sym (Functor.F-seq (∫F F) (_ , M) (_ , S)))) i .fst .snd
+    algebra-plug-filler {M = M} {S = S} Mᴰ Sᴰ i .snd =
+      sym (Dᴰ.reind-revealed-filler {p = Mᴰ Dᴰ.⋆ᴰ Sᴰ}
+        (sym (Functor.F-seq (∫F F) (_ , M) (_ , S)))) i .snd
+
+    module _
+      {A₀ A₁ : C.ob[ 𝒱 ]} {B₀ B₁ : C.ob[ 𝒞 ]}
+      {A₀ᴰ : Dᴰ.ob[ _ , F.F-obᴰ A₀ ]} {B₀ᴰ : Dᴰ.ob[ _ , F.F-obᴰ B₀ ]}
+      {A₁ᴰ : Dᴰ.ob[ _ , F.F-obᴰ A₁ ]} {B₁ᴰ : Dᴰ.ob[ _ , F.F-obᴰ B₁ ]}
+      {ψ : Homo (_ , CAlg .fst A₀ B₀) (_ , CAlg .fst A₁ B₁)}
+      {ψ' : Homo
+        (_ , DAlg .fst (F.F-obᴰ A₀) (F.F-obᴰ B₀))
+        (_ , DAlg .fst (F.F-obᴰ A₁) (F.F-obᴰ B₁))}
+      (ψᴰ' : Homoᴰ ψ'
+        (_ , DᴰAlg .fst A₀ᴰ B₀ᴰ) (_ , DᴰAlg .fst A₁ᴰ B₁ᴰ))
+      {gᴰ : mapOver (ψ .fst)
+        (λ M → Dᴰ.Hom[ _ , F.F-homᴰ M ][ A₀ᴰ , B₀ᴰ ])
+        (λ M → Dᴰ.Hom[ _ , F.F-homᴰ M ][ A₁ᴰ , B₁ᴰ ])}
+      (gᴰ-filler : ∀ M Mᴰ → Path
+        (Σ[ N ∈ D.Hom[ _ ][ F.F-obᴰ A₁ , F.F-obᴰ B₁ ] ]
+          Dᴰ.Hom[ _ , N ][ A₁ᴰ , B₁ᴰ ])
+        (F.F-homᴰ (ψ .fst M) , gᴰ M Mᴰ)
+        (ψ' .fst (F.F-homᴰ M) , ψᴰ' .fst (F.F-homᴰ M) Mᴰ))
+      where
+      private
+        C₀ᴰ = AlgebraEffᴰReindex A₀ᴰ B₀ᴰ
+        C₁ᴰ = AlgebraEffᴰReindex A₁ᴰ B₁ᴰ
+
+        D₀ᴰ : Algebraᴰ
+          (_ , DAlg .fst (F.F-obᴰ A₀) (F.F-obᴰ B₀)) ℓCᴰ'
+        D₀ᴰ .fst M = Dᴰ.Hom[ _ , M ][ A₀ᴰ , B₀ᴰ ]
+        D₀ᴰ .snd = DᴰAlg .fst A₀ᴰ B₀ᴰ
+
+        D₁ᴰ : Algebraᴰ
+          (_ , DAlg .fst (F.F-obᴰ A₁) (F.F-obᴰ B₁)) ℓCᴰ'
+        D₁ᴰ .fst M = Dᴰ.Hom[ _ , M ][ A₁ᴰ , B₁ᴰ ]
+        D₁ᴰ .snd = DᴰAlg .fst A₁ᴰ B₁ᴰ
+
+        module D₁ᴰReasoning where
+          open hSetReasoning
+            (_ , Categoryᴰ.isSetHomᴰ D)
+            (λ M → Dᴰ.Hom[ _ , M ][ A₁ᴰ , B₁ᴰ ])
+            using (rectifyOut) public
+
+        total-gᴰ' :
+          (Σ[ M ∈ D.Hom[ _ ][ F.F-obᴰ A₀ , F.F-obᴰ B₀ ] ]
+            Dᴰ.Hom[ _ , M ][ A₀ᴰ , B₀ᴰ ])
+          → (Σ[ M ∈ D.Hom[ _ ][ F.F-obᴰ A₁ , F.F-obᴰ B₁ ] ]
+            Dᴰ.Hom[ _ , M ][ A₁ᴰ , B₁ᴰ ])
+        total-gᴰ' (M , Mᴰ) = ψ' .fst M , ψᴰ' .fst M Mᴰ
+
+      reindexHomoᴰ : Homoᴰ ψ C₀ᴰ C₁ᴰ
+      reindexHomoᴰ .fst = gᴰ
+      reindexHomoᴰ .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩
+        op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ = D₁ᴰReasoning.rectifyOut $ sym $
+          gᴰ-filler op⟨γ⟩ op⟨γᴰ⟩
+          ∙ cong total-gᴰ'
+              (ΣPathP (refl , sym op∘γᴰ≡op⟨γᴰ⟩))
+          ∙ cong total-gᴰ'
+              (reindexAlgebraᴰ-op-filler Sig (FAlgHomo A₀ B₀) D₀ᴰ
+                op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩)
+          ∙ sym (totalHomoᴰ Sig ψᴰ' .snd op
+              (λ v → F.F-homᴰ (γ v) , γᴰ v) _ refl)
+          ∙ cong (∫Algebra D₁ᴰ .snd op)
+              (funExt λ v → sym (gᴰ-filler (γ v) (γᴰ v)))
+          ∙ sym (reindexAlgebraᴰ-op-filler Sig (FAlgHomo A₁ B₁) D₁ᴰ op
+              (ψ .fst ∘ γ) (λ v → gᴰ (γ v) (γᴰ v))
+              (ψ .fst op⟨γ⟩)
+              (ψ .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩))
+
+  AlgebraEnrichmentᴰReindex : AlgebraEnrichmentᴰ Sig CAlg F*Cᴰ
+  AlgebraEnrichmentᴰReindex .fst Aᴰ Bᴰ =
+    AlgebraEffᴰReindex Aᴰ Bᴰ .snd
+  AlgebraEnrichmentᴰReindex .snd .fst
+    {A} {A'} {B} {V = V} Vᴰ =
+      reindexHomoᴰ
+        {ψ = (λ M → V C.⋆ᴰ M) , CAlg .snd .fst V B}
+        {ψ' = (λ M → F.F-homᴰ V D.⋆ᴰ M) ,
+          DAlg .snd .fst (F.F-homᴰ V) (F.F-obᴰ B)}
+        ((λ _ Mᴰ → Vᴰ Dᴰ.⋆ᴰ Mᴰ) , DᴰAlg .snd .fst Vᴰ)
+        (λ _ Mᴰ → algebra-subst-filler Vᴰ Mᴰ) .snd
+  AlgebraEnrichmentᴰReindex .snd .snd
+    {A} {B} {B'} {S = S} Sᴰ =
+      reindexHomoᴰ
+        {ψ = (λ M → M C.⋆ᴰ S) , CAlg .snd .snd S A}
+        {ψ' = (λ M → M D.⋆ᴰ F.F-homᴰ S) ,
+          DAlg .snd .snd (F.F-homᴰ S) (F.F-obᴰ A)}
+        ((λ _ Mᴰ → Mᴰ Dᴰ.⋆ᴰ Sᴰ) , DᴰAlg .snd .snd Sᴰ)
+        (λ _ Mᴰ → algebra-plug-filler Mᴰ Sᴰ) .snd

--- a/Cubical/Categories/Displayed/CBPV/Unary/Enrichment/Model.agda
+++ b/Cubical/Categories/Displayed/CBPV/Unary/Enrichment/Model.agda
@@ -1,0 +1,166 @@
+{-# OPTIONS --lossy-unification --prop #-}
+module Cubical.Categories.Displayed.CBPV.Unary.Enrichment.Model where
+
+open import Cubical.Foundations.Prelude
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Instances.Fiber
+open import Cubical.Categories.Instances.TotalCategory
+open import Cubical.Categories.Instances.WalkingArrow
+  renaming (WalkingArrow to KIND; Vertex to Kind; l to 𝒱; r to 𝒞; ≤Vertex to ≤Kind)
+
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Displayed.CBPV.Unary.Base
+open import Cubical.Categories.Displayed.CBPV.Unary.Enrichment.Algebra
+open import Cubical.Categories.Displayed.Instances.Algebra.Model
+open import Cubical.Categories.Displayed.Instances.Reindex
+
+open import Cubical.Algebra.Theory.Base
+  hiding (ℓ; ℓᴰ; ℓᴰᴰ; ℓ'; ℓᴰ'; ℓᴰᴰ'; ℓ''; ℓᴰ''; ℓO; ℓA; ℓE)
+
+private
+  variable
+    ℓ ℓ' ℓᴰ ℓᴰ' ℓD ℓD' ℓCᴰ ℓCᴰ' ℓO ℓA ℓE ℓEA : Level
+
+open Categoryᴰ
+
+module _ (C : CBPVCat ℓ ℓ') (T : Theory ℓO ℓA ℓE ℓEA) where
+  open Theory T
+  private module C = Fibers C
+
+  ModelEnrichment : Type _
+  ModelEnrichment =
+    Σ[ ModelEff ∈ (∀ (A : C.ob[ 𝒱 ]) (B : C.ob[ 𝒞 ])
+      → Categoryᴰ.ob[_] (MODELOver T ℓ')
+          (C.Hom[ _ ][ A , B ] , Categoryᴰ.isSetHomᴰ C)) ]
+    (∀ {A A'} (V : C.Hom[ _ ][ A , A' ]) B
+      → isHomoSimpl (_ , ModelEff A' B .fst) (_ , ModelEff A B .fst)
+          (λ M → V C.⋆ᴰ M))
+    ×
+    (∀ {B B'} (S : C.Hom[ _ ][ B , B' ]) A
+      → isHomoSimpl (_ , ModelEff A B .fst) (_ , ModelEff A B' .fst)
+          (λ M → M C.⋆ᴰ S))
+
+  ModelEnrichmentModel : ModelEnrichment →
+    ∀ (A : C.ob[ 𝒱 ]) (B : C.ob[ 𝒞 ]) → Model ℓ'
+  ModelEnrichmentModel CModel A B .fst =
+    C.Hom[ _ ][ A , B ] , CModel .fst A B .fst
+  ModelEnrichmentModel CModel A B .snd .fst = CModel .fst A B .snd
+  ModelEnrichmentModel CModel A B .snd .snd = Categoryᴰ.isSetHomᴰ C
+
+module _ {C : CBPVCat ℓ ℓ'} (T : Theory ℓO ℓA ℓE ℓEA)
+  (CModel : ModelEnrichment C T)
+  (Cᴰ : CBPVCatᴰ C ℓᴰ ℓᴰ') where
+  open Theory T
+  private module C = Fibers C
+  private module Cᴰ = Fibers Cᴰ
+
+  ModelEnrichmentᴰ : Type _
+  ModelEnrichmentᴰ =
+    Σ[ ModelEffᴰ ∈ (∀ {A B}
+      (Aᴰ : Cᴰ.ob[ _ , A ]) (Bᴰ : Cᴰ.ob[ _ , B ])
+      → ModelᴰWithCarrier (ModelEnrichmentModel C T CModel A B)
+          (λ M → Cᴰ.Hom[ _ , M ][ Aᴰ , Bᴰ ])) ]
+    (∀ {A A' B}
+      {Aᴰ : Cᴰ.ob[ _ , A ]} {Aᴰ' : Cᴰ.ob[ _ , A' ]}
+      {Bᴰ : Cᴰ.ob[ _ , B ]} {V : _}
+      (Vᴰ : Cᴰ.Hom[ _ , V ][ Aᴰ , Aᴰ' ])
+      → isHomoᴰSimpl
+          ((λ M → V C.⋆ᴰ M) , CModel .snd .fst V B)
+          (_ , ModelEffᴰ Aᴰ' Bᴰ .fst) (_ , ModelEffᴰ Aᴰ Bᴰ .fst)
+          (λ _ Mᴰ → Vᴰ Cᴰ.⋆ᴰ Mᴰ))
+    ×
+    (∀ {A B B'}
+      {Aᴰ : Cᴰ.ob[ _ , A ]} {Bᴰ : Cᴰ.ob[ _ , B ]}
+      {Bᴰ' : Cᴰ.ob[ _ , B' ]} {S : _}
+      (Sᴰ : Cᴰ.Hom[ _ , S ][ Bᴰ , Bᴰ' ])
+      → isHomoᴰSimpl
+          ((λ M → M C.⋆ᴰ S) , CModel .snd .snd S A)
+          (_ , ModelEffᴰ Aᴰ Bᴰ .fst) (_ , ModelEffᴰ Aᴰ Bᴰ' .fst)
+          (λ _ Mᴰ → Mᴰ Cᴰ.⋆ᴰ Sᴰ))
+
+module _ {C : CBPVCat ℓ ℓ'} {D : CBPVCat ℓD ℓD'}
+  (T : Theory ℓO ℓA ℓE ℓEA)
+  (F : Functorⱽ C D)
+  (CModel : ModelEnrichment C T) (DModel : ModelEnrichment D T)
+  where
+  open Theory T
+
+  PreservesModelEnrichment : Type _
+  PreservesModelEnrichment = ∀ A B →
+    isHomoSimpl (_ , CModel .fst A B .fst)
+      (_ , DModel .fst
+        (F .Functorᴰ.F-obᴰ A) (F .Functorᴰ.F-obᴰ B) .fst)
+      (F .Functorᴰ.F-homᴰ)
+
+module _
+  {C : CBPVCat ℓ ℓ'} {D : CBPVCat ℓD ℓD'}
+  (T : Theory ℓO ℓA ℓE ℓEA)
+  (F : Functorⱽ C D)
+  (CModel : ModelEnrichment C T) (DModel : ModelEnrichment D T)
+  (FModel : PreservesModelEnrichment T F CModel DModel)
+  (Dᴰ : CBPVCatᴰ D ℓCᴰ ℓCᴰ')
+  (DᴰModel : ModelEnrichmentᴰ T DModel Dᴰ)
+  where
+  open Theory T
+  private
+    module C = Fibers C
+    module D = Fibers D
+    module Dᴰ = Fibers Dᴰ
+    module F = Functorᴰ F
+
+    CAlg : AlgebraEnrichment C S
+    CAlg .fst A B = CModel .fst A B .fst
+    CAlg .snd = CModel .snd
+
+    DAlg : AlgebraEnrichment D S
+    DAlg .fst A B = DModel .fst A B .fst
+    DAlg .snd = DModel .snd
+
+    FAlg : PreservesAlgebraEnrichment S F CAlg DAlg
+    FAlg = FModel
+
+    DᴰAlg : AlgebraEnrichmentᴰ S DAlg Dᴰ
+    DᴰAlg .fst Aᴰ Bᴰ = DᴰModel .fst Aᴰ Bᴰ .fst
+    DᴰAlg .snd = DᴰModel .snd
+
+    F*Cᴰ = reindex Dᴰ (∫F F)
+    module F*Cᴰ = Fibers F*Cᴰ
+
+    FModelHomo : ∀ A B → Homo
+      (ModelEnrichmentModel C T CModel A B .fst)
+      (ModelEnrichmentModel D T DModel (F.F-obᴰ A) (F.F-obᴰ B) .fst)
+    FModelHomo A B .fst = F.F-homᴰ
+    FModelHomo A B .snd = FModel A B
+
+    DᴰModelAt : ∀ {A : D.ob[ 𝒱 ]} {B : D.ob[ 𝒞 ]}
+      (Aᴰ : Dᴰ.ob[ _ , A ]) (Bᴰ : Dᴰ.ob[ _ , B ])
+      → Modelᴰ (ModelEnrichmentModel D T DModel A B) ℓCᴰ'
+    DᴰModelAt Aᴰ Bᴰ .fst .fst M = Dᴰ.Hom[ _ , M ][ Aᴰ , Bᴰ ]
+    DᴰModelAt Aᴰ Bᴰ .fst .snd = DᴰModel .fst Aᴰ Bᴰ .fst
+    DᴰModelAt Aᴰ Bᴰ .snd .fst = DᴰModel .fst Aᴰ Bᴰ .snd
+    DᴰModelAt Aᴰ Bᴰ .snd .snd _ = Categoryᴰ.isSetHomᴰ Dᴰ
+
+    PulledModel : ∀ {A : C.ob[ 𝒱 ]} {B : C.ob[ 𝒞 ]}
+      (Aᴰ : Dᴰ.ob[ _ , F.F-obᴰ A ]) (Bᴰ : Dᴰ.ob[ _ , F.F-obᴰ B ])
+      → Modelᴰ (ModelEnrichmentModel C T CModel A B) ℓCᴰ'
+    PulledModel {A} {B} Aᴰ Bᴰ =
+      Theory._*_ T (FModelHomo A B) (DᴰModelAt Aᴰ Bᴰ)
+
+    ModelEffᴰReindex : ∀ {A : C.ob[ 𝒱 ]} {B : C.ob[ 𝒞 ]}
+      (Aᴰ : Dᴰ.ob[ _ , F.F-obᴰ A ]) (Bᴰ : Dᴰ.ob[ _ , F.F-obᴰ B ])
+      → ModelᴰWithCarrier (ModelEnrichmentModel C T CModel A B)
+          (λ M → F*Cᴰ.Hom[ _ , M ][ Aᴰ , Bᴰ ])
+    ModelEffᴰReindex Aᴰ Bᴰ .fst = PulledModel Aᴰ Bᴰ .fst .snd
+    ModelEffᴰReindex Aᴰ Bᴰ .snd = PulledModel Aᴰ Bᴰ .snd .fst
+
+    AlgebraEnrichmentᴰReindexed : AlgebraEnrichmentᴰ S CAlg F*Cᴰ
+    AlgebraEnrichmentᴰReindexed =
+      AlgebraEnrichmentᴰReindex S F CAlg DAlg FAlg Dᴰ DᴰAlg
+
+  ModelEnrichmentᴰReindex : ModelEnrichmentᴰ T CModel F*Cᴰ
+  ModelEnrichmentᴰReindex .fst = ModelEffᴰReindex
+  ModelEnrichmentᴰReindex .snd = AlgebraEnrichmentᴰReindexed .snd

--- a/Cubical/Categories/Displayed/CBPV/Unary/Instances/Algebra/Additive.agda
+++ b/Cubical/Categories/Displayed/CBPV/Unary/Instances/Algebra/Additive.agda
@@ -1,0 +1,507 @@
+-- Additive structure for the Set/Algebra unary CBPV model.
+{-# OPTIONS --prop --lossy-unification #-}
+module Cubical.Categories.Displayed.CBPV.Unary.Instances.Algebra.Additive where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.HLevels
+open import Cubical.Functions.FunExtEquiv
+
+open import Cubical.Data.Empty as Empty
+open import Cubical.Data.Sigma
+open import Cubical.Data.Sum as Sum
+open import Cubical.Data.Unit
+import Cubical.Data.Equality as Eq
+
+open import Cubical.Algebra.Signature.Base
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Instances.Fiber
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.TotalCategory
+open import Cubical.Categories.Instances.WalkingArrow
+  renaming (WalkingArrow to KIND; l to 𝒱; r to 𝒞)
+open import Cubical.Categories.Presheaf.Constructions
+open import Cubical.Categories.Presheaf.Morphism.Alt
+open import Cubical.Categories.Presheaf.Representable.More
+
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Instances.Algebra.Algebra
+open import Cubical.Categories.Displayed.Instances.Algebra.DisplayedAlgebra
+open import Cubical.Categories.Displayed.Instances.Opposite
+open import Cubical.Categories.Displayed.Instances.Sets.Base
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Fibration
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Eq.Conversion.CartesianV
+import Cubical.Categories.Displayed.Presheaf.Uncurried.Eq.Base as EqPsh
+open import Cubical.Categories.Displayed.CBPV.Unary.Additive
+open import Cubical.Categories.Displayed.CBPV.Unary.Instances.Algebra.Base
+open import Cubical.Categories.Displayed.CBPV.Unary.Instances.Algebra.Multiplicative
+
+private
+  variable
+    ℓO ℓA : Level
+
+open Category
+
+module _ (Sig : Signature ℓO ℓA) (isSetOp : isSet (Signature.Op Sig)) where
+  open Signature Sig
+
+  private
+    L = AlgebraLevel Sig
+    C = AlgebraCBPVEq Sig isSetOp .fst
+    Cop = C ^opᴰ
+
+    KIND-idR : EqPsh.EqIdR KIND
+    KIND-idR _ = Eq.refl
+
+    KIND^op-idR : EqPsh.EqIdR (KIND ^op)
+    KIND^op-idR _ = Eq.refl
+
+  AlgebraValueTerminalEqⱽ : EqTerminalⱽ C 𝒱
+  AlgebraValueTerminalEqⱽ = EqPsh.UEⱽ→Reprⱽ _ KIND-idR ue
+    where
+    ue : EqPsh.UEⱽ
+      (EqPsh.UnitⱽPsh {Cᴰ = C} {P = KIND [-, 𝒱 ]}) KIND-idR
+    ue .EqPsh.UEⱽ.v = Unit* , isSetUnit*
+    ue .EqPsh.UEⱽ.e = tt
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .fst _ _ = tt*
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .snd .snd h =
+      funExt λ _ → refl
+
+  AlgebraValueProductEqⱽ : ∀ A₁ A₂ → EqBinProductⱽ C {k = 𝒱} A₁ A₂
+  AlgebraValueProductEqⱽ A₁ A₂ = EqPsh.UEⱽ→Reprⱽ _ KIND-idR ue
+    where
+    ue : EqPsh.UEⱽ
+      ((EqPsh._[-][-,_] C A₁) EqPsh.×ⱽPsh (EqPsh._[-][-,_] C A₂))
+      KIND-idR
+    ue .EqPsh.UEⱽ.v .fst = A₁ .fst × A₂ .fst
+    ue .EqPsh.UEⱽ.v .snd = isSet× (A₁ .snd) (A₂ .snd)
+    ue .EqPsh.UEⱽ.e = fst , snd
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .fst
+      (p , q) x = p x , q x
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .snd .snd _ = refl
+
+  AlgebraValueInitialEqⱽ : EqInitialⱽ C 𝒱
+  AlgebraValueInitialEqⱽ = EqPsh.UEⱽ→Reprⱽ _ KIND^op-idR ue
+    where
+    ue : EqPsh.UEⱽ
+      (EqPsh.UnitⱽPsh {Cᴰ = Cop} {P = (KIND ^op) [-, 𝒱 ]})
+      KIND^op-idR
+    ue .EqPsh.UEⱽ.v = ⊥* , isProp→isSet isProp⊥*
+    ue .EqPsh.UEⱽ.e = tt
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .fst _ = λ ()
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .fst _ = λ ()
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .snd .snd h =
+      funExt λ ()
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .snd .snd h =
+      funExt λ ()
+
+  AlgebraValueCoProductEqⱽ : ∀ A₁ A₂ →
+    EqBinCoProductⱽ C {k = 𝒱} A₁ A₂
+  AlgebraValueCoProductEqⱽ A₁ A₂ =
+    EqPsh.UEⱽ→Reprⱽ _ KIND^op-idR ue
+    where
+    case-η : ∀ {X : Type L} (h : A₁ .fst ⊎ A₂ .fst → X) →
+      Sum.rec (λ x → h (inl x)) (λ x → h (inr x)) ≡ h
+    case-η h = funExt λ { (inl _) → refl ; (inr _) → refl }
+
+    ue : EqPsh.UEⱽ
+      ((EqPsh._[-][-,_] Cop A₁) EqPsh.×ⱽPsh
+       (EqPsh._[-][-,_] Cop A₂))
+      KIND^op-idR
+    ue .EqPsh.UEⱽ.v .fst = A₁ .fst ⊎ A₂ .fst
+    ue .EqPsh.UEⱽ.v .snd = isSet⊎ (A₁ .snd) (A₂ .snd)
+    ue .EqPsh.UEⱽ.e = inl , inr
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .fst
+      (p , q) = Sum.rec p q
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .fst
+      (p , q) = Sum.rec p q
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .snd .snd h =
+      case-η h
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .snd .snd h =
+      case-η h
+
+  AlgebraComputationTerminalEqⱽ : EqTerminalⱽ C 𝒞
+  AlgebraComputationTerminalEqⱽ = EqPsh.UEⱽ→Reprⱽ _ KIND-idR ue
+    where
+    ue : EqPsh.UEⱽ
+      (EqPsh.UnitⱽPsh {Cᴰ = C} {P = KIND [-, 𝒞 ]}) KIND-idR
+    ue .EqPsh.UEⱽ.v = (Unit* , isSetUnit*) , ⊤*Algebra
+    ue .EqPsh.UEⱽ.e = tt
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .fst _ _ = tt*
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .fst _ .fst _ = tt*
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .fst _ .snd
+      _ _ _ _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .snd .snd h =
+      funExt λ _ → refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .snd .snd h =
+      Σ≡Prop (λ _ → isPropΠ4 λ _ _ _ _ → isSetUnit* _ _)
+        (funExt λ _ → refl)
+
+  AlgebraComputationProductEqⱽ : ∀ B₁ B₂ →
+    EqBinProductⱽ C {k = 𝒞} B₁ B₂
+  AlgebraComputationProductEqⱽ B₁ B₂ =
+    EqPsh.UEⱽ→Reprⱽ _ KIND-idR ue
+    where
+    product : Algebra L
+    product = (_ , B₁ .snd) ×Alg (_ , B₂ .snd)
+
+    ue : EqPsh.UEⱽ
+      ((EqPsh._[-][-,_] C B₁) EqPsh.×ⱽPsh
+       (EqPsh._[-][-,_] C B₂))
+      KIND-idR
+    ue .EqPsh.UEⱽ.v =
+      (_ , isSet× (B₁ .fst .snd) (B₂ .fst .snd)) , product .snd
+    ue .EqPsh.UEⱽ.e .fst .fst = fst
+    ue .EqPsh.UEⱽ.e .fst .snd _ _ _ p = cong fst p
+    ue .EqPsh.UEⱽ.e .snd .fst = snd
+    ue .EqPsh.UEⱽ.e .snd .snd _ _ _ p = cong snd p
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .fst
+      (p , q) x = p x , q x
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .fst
+      (p , q) = ×intro p q
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .snd .snd _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .snd .snd h =
+      Σ≡Prop
+        (λ _ → isPropΠ4 λ _ _ _ _ →
+          isSet× (B₁ .fst .snd) (B₂ .fst .snd) _ _)
+        refl
+
+  AlgebraAddCBPVEq : AddCBPVCatEq (ℓ-suc L) L
+  AlgebraAddCBPVEq .fst = AlgebraCBPVEq Sig isSetOp
+  AlgebraAddCBPVEq .snd .fst = AlgebraValueTerminalEqⱽ
+  AlgebraAddCBPVEq .snd .snd .fst = AlgebraValueProductEqⱽ
+  AlgebraAddCBPVEq .snd .snd .snd .fst = AlgebraValueInitialEqⱽ
+  AlgebraAddCBPVEq .snd .snd .snd .snd .fst = AlgebraValueCoProductEqⱽ
+  AlgebraAddCBPVEq .snd .snd .snd .snd .snd .fst =
+    AlgebraComputationTerminalEqⱽ
+  AlgebraAddCBPVEq .snd .snd .snd .snd .snd .snd =
+    AlgebraComputationProductEqⱽ
+
+  AlgebraAddCBPV : AddCBPVCat (ℓ-suc L) L
+  AlgebraAddCBPV = forgetAddEq AlgebraAddCBPVEq
+
+  private
+    Cᴰ = AlgebraCBPVᴰ Sig isSetOp
+
+    CBPVIdR : EqPsh.EqIdR (∫C C)
+    CBPVIdR {x = 𝒱 , A} {y = 𝒱 , B} f = Eq.refl
+    CBPVIdR {x = 𝒱 , A} {y = 𝒞 , B} f = Eq.refl
+    CBPVIdR {x = 𝒞 , A} {y = 𝒱 , B} ()
+    CBPVIdR {x = 𝒞 , A} {y = 𝒞 , B} f = Eq.refl
+
+    CBPVAssoc : EqPsh.ReprEqAssoc (∫C C)
+    CBPVAssoc (𝒱 , A)
+      {c = 𝒱 , W} {c' = 𝒱 , X} {c'' = 𝒱 , Y}
+      _ _ _ _ Eq.refl = Eq.refl
+    CBPVAssoc (𝒞 , B)
+      {c = 𝒱 , W} {c' = 𝒱 , X} {c'' = 𝒱 , Y}
+      _ _ _ _ Eq.refl = Eq.refl
+    CBPVAssoc (𝒞 , B)
+      {c = 𝒱 , W} {c' = 𝒞 , X} {c'' = 𝒞 , Y}
+      _ _ _ _ Eq.refl = Eq.refl
+    CBPVAssoc (𝒞 , B)
+      {c = 𝒞 , W} {c' = 𝒞 , X} {c'' = 𝒞 , Y}
+      _ _ _ _ Eq.refl = Eq.refl
+    CBPVAssoc x f g p f⋆g e = Eq.pathToEq
+      (sym (D.⋆Assoc f g p) ∙ cong (λ fg → fg D.⋆ p) (Eq.eqToPath e))
+      where module D = Category (∫C C)
+
+    CBPVAssoc^op : EqPsh.ReprEqAssoc ((∫C C) ^op)
+    CBPVAssoc^op (𝒱 , A)
+      {c = 𝒱 , W} {c' = 𝒱 , X} {c'' = 𝒱 , Y}
+      _ _ _ _ Eq.refl = Eq.refl
+    CBPVAssoc^op (𝒱 , A)
+      {c = 𝒞 , W} {c' = 𝒱 , X} {c'' = 𝒱 , Y}
+      _ _ _ _ Eq.refl = Eq.refl
+    CBPVAssoc^op x f g p f⋆g e = Eq.pathToEq
+      (sym (D.⋆Assoc f g p) ∙ cong (λ fg → fg D.⋆ p) (Eq.eqToPath e))
+      where module D = Category ((∫C C) ^op)
+
+    CBPVIdR^op : EqPsh.EqIdR ((∫C C) ^op)
+    CBPVIdR^op {x = 𝒱 , X} {y = 𝒱 , Y} f = Eq.refl
+    CBPVIdR^op {x = 𝒞 , X} {y = 𝒱 , Y} f = Eq.refl
+    CBPVIdR^op {x = 𝒱 , X} {y = 𝒞 , Y} ()
+    CBPVIdR^op {x = 𝒞 , X} {y = 𝒞 , Y} f = Eq.refl
+
+  AlgebraCBPVValueTerminalsⱽ : ValueTerminalsⱽ Cᴰ
+  AlgebraCBPVValueTerminalsⱽ A =
+    EqTerminalⱽ→Terminalⱽ CBPVAssoc Cᴰ
+      (EqPsh.UEⱽ→Reprⱽ _ CBPVIdR ue)
+    where
+    ue : EqPsh.UEⱽ
+      (EqPsh.UnitⱽPsh {Cᴰ = Cᴰ} {P = (∫C C) [-, (𝒱 , A) ]})
+      CBPVIdR
+    ue .EqPsh.UEⱽ.v _ = Unit* , isSetUnit*
+    ue .EqPsh.UEⱽ.e = tt
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .fst _ _ _ = tt*
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , ()) .fst
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , ()) .snd .fst
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .snd .snd _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , ()) .snd .snd
+
+  AlgebraCBPVValueBinProductsⱽ : ValueBinProductsⱽ Cᴰ
+  AlgebraCBPVValueBinProductsⱽ {A} A₁ᴰ A₂ᴰ =
+    EqBinProductⱽ→BinProductⱽ CBPVAssoc Cᴰ
+      (EqPsh.UEⱽ→Reprⱽ _ CBPVIdR ue)
+    where
+    ue : EqPsh.UEⱽ
+      ((Cᴰ EqPsh.[-][-, A₁ᴰ ]) EqPsh.×ⱽPsh
+       (Cᴰ EqPsh.[-][-, A₂ᴰ ]))
+      CBPVIdR
+    ue .EqPsh.UEⱽ.v x =
+      (A₁ᴰ x .fst × A₂ᴰ x .fst) , isSet× (A₁ᴰ x .snd) (A₂ᴰ x .snd)
+    ue .EqPsh.UEⱽ.e = (λ _ → fst) , (λ _ → snd)
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .fst (p , q) x xᴰ = p x xᴰ , q x xᴰ
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , ()) .fst
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , ()) .snd .fst
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .snd .snd _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , ()) .snd .snd
+
+  AlgebraCBPVValueInitialsⱽ : ValueInitialsⱽ Cᴰ
+  AlgebraCBPVValueInitialsⱽ A =
+    EqTerminalⱽ→Terminalⱽ CBPVAssoc^op (Cᴰ ^opᴰ)
+      (EqPsh.UEⱽ→Reprⱽ _ CBPVIdR^op ue)
+    where
+    ue : EqPsh.UEⱽ
+      (EqPsh.UnitⱽPsh {Cᴰ = Cᴰ ^opᴰ}
+        {P = ((∫C C) ^op) [-, (𝒱 , A) ]})
+      CBPVIdR^op
+    ue .EqPsh.UEⱽ.v _ = ⊥* , isProp→isSet isProp⊥*
+    ue .EqPsh.UEⱽ.e = tt
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .fst _ _ ()
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .fst _ _ ()
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .snd .snd h = funExt₂ λ _ ()
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .snd .snd h = funExt₂ λ _ ()
+
+  AlgebraCBPVValueBinCoProductsⱽ : ValueBinCoProductsⱽ Cᴰ
+  AlgebraCBPVValueBinCoProductsⱽ {A} A₁ᴰ A₂ᴰ =
+    EqBinProductⱽ→BinProductⱽ CBPVAssoc^op (Cᴰ ^opᴰ)
+      (EqPsh.UEⱽ→Reprⱽ _ CBPVIdR^op ue)
+    where
+    case-η : ∀ {X : A .fst → Type L}
+      (h : ∀ a → A₁ᴰ a .fst ⊎ A₂ᴰ a .fst → X a) →
+      (λ a → Sum.rec (λ x → h a (inl x)) (λ x → h a (inr x))) ≡ h
+    case-η h = funExt₂ λ _ → λ { (inl _) → refl ; (inr _) → refl }
+
+    ue : EqPsh.UEⱽ
+      (((Cᴰ ^opᴰ) EqPsh.[-][-, A₁ᴰ ]) EqPsh.×ⱽPsh
+       ((Cᴰ ^opᴰ) EqPsh.[-][-, A₂ᴰ ]))
+      CBPVIdR^op
+    ue .EqPsh.UEⱽ.v a =
+      (A₁ᴰ a .fst ⊎ A₂ᴰ a .fst) , isSet⊎ (A₁ᴰ a .snd) (A₂ᴰ a .snd)
+    ue .EqPsh.UEⱽ.e = (λ _ → inl) , (λ _ → inr)
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .fst (p , q) a = Sum.rec (p a) (q a)
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .fst (p , q) a = Sum.rec (p a) (q a)
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .snd .snd h = case-η h
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .snd .snd h = case-η h
+
+  AlgebraCBPVValueCartesianLifts : hasVerticalCartesianLiftsAt Cᴰ 𝒱
+  AlgebraCBPVValueCartesianLifts {A} {B} f Bᴰ =
+    EqCartesianLift→CartesianLift CBPVAssoc Cᴰ Bᴰ (𝒱 , A) (_ , f)
+      (EqPsh.UEⱽ→Reprⱽ _ CBPVIdR ue)
+    where
+    ue : EqPsh.CartesianLiftUE Cᴰ CBPVAssoc CBPVIdR (_ , f) Bᴰ
+    ue .EqPsh.UEⱽ.v x = Bᴰ (f x)
+    ue .EqPsh.UEⱽ.e _ xᴰ = xᴰ
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , g) .fst h = h
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , g) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , g) .snd .snd _ = refl
+
+  AlgebraCBPVValueOpcartesianLifts :
+    hasVerticalOpcartesianLiftsAt Cᴰ 𝒱
+  AlgebraCBPVValueOpcartesianLifts {A} {B} f Aᴰ =
+    EqCartesianLift→CartesianLift CBPVAssoc^op (Cᴰ ^opᴰ)
+      Aᴰ (𝒱 , B) (_ , f) (EqPsh.UEⱽ→Reprⱽ _ CBPVIdR^op ue)
+    where
+    ue : EqPsh.CartesianLiftUE (Cᴰ ^opᴰ)
+      CBPVAssoc^op CBPVIdR^op (_ , f) Aᴰ
+    ue .EqPsh.UEⱽ.v b .fst =
+      Σ[ a ∈ A .fst ] (f a ≡ b) × Aᴰ a .fst
+    ue .EqPsh.UEⱽ.v b .snd =
+      isSetΣ (A .snd) λ a →
+        isSet× (isProp→isSet (B .snd _ _)) (Aᴰ a .snd)
+    ue .EqPsh.UEⱽ.e a aᴰ = a , refl , aᴰ
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , g) .fst h b (a , p , aᴰ) =
+        subst (λ b' → Xᴰ (g .snd b') .fst) p (h a aᴰ)
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , g) .fst h b (a , p , aᴰ) =
+        subst (λ b' → Xᴰ .fst (g .snd b') .fst) p (h a aᴰ)
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , g) .snd .fst h =
+        funExt₂ λ _ _ → transportRefl _
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , g) .snd .fst h =
+        funExt₂ λ _ _ → transportRefl _
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , g) .snd .snd h =
+        funExt λ b → funExt λ { (a , p , aᴰ) →
+          J (λ b' p' →
+            subst (λ b'' → Xᴰ (g .snd b'') .fst) p'
+              (h (f a) (a , refl , aᴰ)) ≡ h b' (a , p' , aᴰ))
+            (transportRefl _) p }
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , g) .snd .snd h =
+        funExt λ b → funExt λ { (a , p , aᴰ) →
+          J (λ b' p' →
+            subst (λ b'' → Xᴰ .fst (g .snd b'') .fst) p'
+              (h (f a) (a , refl , aᴰ)) ≡ h b' (a , p' , aᴰ))
+            (transportRefl _) p }
+
+  AlgebraCBPVComputationTerminalsⱽ : ComputationTerminalsⱽ Cᴰ
+  AlgebraCBPVComputationTerminalsⱽ B =
+    EqTerminalⱽ→Terminalⱽ CBPVAssoc Cᴰ
+      (EqPsh.UEⱽ→Reprⱽ _ CBPVIdR ue)
+    where
+    ue : EqPsh.UEⱽ
+      (EqPsh.UnitⱽPsh {Cᴰ = Cᴰ} {P = (∫C C) [-, (𝒞 , B) ]})
+      CBPVIdR
+    ue .EqPsh.UEⱽ.v .fst _ = Unit* , isSetUnit*
+    ue .EqPsh.UEⱽ.v .snd = ⊤*ⱽ .snd
+    ue .EqPsh.UEⱽ.e = tt
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .fst _ _ _ = tt*
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .fst _ .fst _ _ = tt*
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .fst _ .snd _ _ _ _ _ _ _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .snd .snd h = funExt₂ λ _ _ → refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .snd .snd h =
+        ALGᴰHomo≡ Sig _ h (funExt₂ λ _ _ → refl)
+
+  AlgebraCBPVComputationBinProductsⱽ : ComputationBinProductsⱽ Cᴰ
+  AlgebraCBPVComputationBinProductsⱽ {B} B₁ᴰ B₂ᴰ =
+    EqBinProductⱽ→BinProductⱽ CBPVAssoc Cᴰ
+      (EqPsh.UEⱽ→Reprⱽ _ CBPVIdR ue)
+    where
+    ue : EqPsh.UEⱽ
+      ((Cᴰ EqPsh.[-][-, B₁ᴰ ]) EqPsh.×ⱽPsh
+       (Cᴰ EqPsh.[-][-, B₂ᴰ ]))
+      CBPVIdR
+    ue .EqPsh.UEⱽ.v .fst x =
+      (B₁ᴰ .fst x .fst × B₂ᴰ .fst x .fst) ,
+      isSet× (B₁ᴰ .fst x .snd) (B₂ᴰ .fst x .snd)
+    ue .EqPsh.UEⱽ.v .snd = ((_ , B₁ᴰ .snd) ×ⱽ (_ , B₂ᴰ .snd)) .snd
+    ue .EqPsh.UEⱽ.e .fst .fst _ = fst
+    ue .EqPsh.UEⱽ.e .fst .snd _ _ _ _ _ _ p = cong fst p
+    ue .EqPsh.UEⱽ.e .snd .fst _ = snd
+    ue .EqPsh.UEⱽ.e .snd .snd _ _ _ _ _ _ p = cong snd p
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .fst (p , q) x xᴰ = p x xᴰ , q x xᴰ
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .fst (p , q) .fst x xᴰ =
+        p .fst x xᴰ , q .fst x xᴰ
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .fst (p , q) .snd
+      op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ i =
+        p .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩
+          op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ i ,
+        q .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩
+          op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ i
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .snd .snd h = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .snd .snd h = ALGᴰHomo≡ Sig _ h refl
+
+  AlgebraCBPVComputationCartesianLifts :
+    hasVerticalCartesianLiftsAt Cᴰ 𝒞
+  AlgebraCBPVComputationCartesianLifts {A} {B} f Bᴰ =
+    EqCartesianLift→CartesianLift CBPVAssoc Cᴰ Bᴰ (𝒞 , A) (_ , f)
+      (EqPsh.UEⱽ→Reprⱽ _ CBPVIdR ue)
+    where
+    pullᴰ : Fibers.ob[_] Cᴰ (𝒞 , A)
+    pullᴰ .fst a = Bᴰ .fst (f .fst a)
+    pullᴰ .snd = (f * (_ , Bᴰ .snd)) .snd
+
+    ue : EqPsh.CartesianLiftUE Cᴰ CBPVAssoc CBPVIdR (_ , f) Bᴰ
+    ue .EqPsh.UEⱽ.v = pullᴰ
+    ue .EqPsh.UEⱽ.e .fst _ aᴰ = aᴰ
+    ue .EqPsh.UEⱽ.e .snd
+      op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ =
+        op∘γᴰ≡op⟨γᴰ⟩
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , g) .fst h = h
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , g) .fst h = h
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , g) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , g) .snd .fst h = ALGᴰHomo≡ Sig _ h refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , g) .snd .snd _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , g) .snd .snd h = ALGᴰHomo≡ Sig _ h refl
+
+  AlgebraAddCBPVⱽ :
+    AddCBPVCatⱽ (AlgebraAddCBPV .fst .fst) (ℓ-suc L) L
+  AlgebraAddCBPVⱽ .fst = AlgebraCBPVⱽ Sig isSetOp
+  AlgebraAddCBPVⱽ .snd .fst = AlgebraCBPVValueTerminalsⱽ
+  AlgebraAddCBPVⱽ .snd .snd .fst = AlgebraCBPVValueBinProductsⱽ
+  AlgebraAddCBPVⱽ .snd .snd .snd .fst =
+    AlgebraCBPVValueCartesianLifts
+  AlgebraAddCBPVⱽ .snd .snd .snd .snd .fst =
+    AlgebraCBPVValueInitialsⱽ
+  AlgebraAddCBPVⱽ .snd .snd .snd .snd .snd .fst =
+    AlgebraCBPVValueBinCoProductsⱽ
+  AlgebraAddCBPVⱽ .snd .snd .snd .snd .snd .snd .fst =
+    AlgebraCBPVValueOpcartesianLifts
+  AlgebraAddCBPVⱽ .snd .snd .snd .snd .snd .snd .snd .fst =
+    AlgebraCBPVComputationTerminalsⱽ
+  AlgebraAddCBPVⱽ .snd .snd .snd .snd .snd .snd .snd .snd .fst =
+    AlgebraCBPVComputationBinProductsⱽ
+  AlgebraAddCBPVⱽ .snd .snd .snd .snd .snd .snd .snd .snd .snd =
+    AlgebraCBPVComputationCartesianLifts

--- a/Cubical/Categories/Displayed/CBPV/Unary/Instances/Algebra/Base.agda
+++ b/Cubical/Categories/Displayed/CBPV/Unary/Instances/Algebra/Base.agda
@@ -1,0 +1,110 @@
+{-# OPTIONS --prop --lossy-unification #-}
+module Cubical.Categories.Displayed.CBPV.Unary.Instances.Algebra.Base where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Structure
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Algebra.Signature.Base
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Instances.Fiber
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.WalkingArrow
+  renaming (l to 𝒱; r to 𝒞)
+
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Displayed.Instances.Algebra.Algebra
+open import Cubical.Categories.Displayed.Instances.Algebra.DisplayedAlgebra
+open import Cubical.Categories.Displayed.Instances.Sets.Base
+open import Cubical.Categories.Displayed.CBPV.Unary.Base
+open import Cubical.Categories.Displayed.CBPV.Unary.Enrichment.Algebra
+open import Cubical.Categories.Displayed.CBPV.Unary.Instances.Displayed.FromU
+open import Cubical.Categories.Displayed.CBPV.Unary.Instances.FromU
+
+private
+  variable
+    ℓ ℓᴰ ℓO ℓA : Level
+
+open Category
+open Functorᴰ
+
+module _ (Sig : Signature ℓO ℓA) (isSetOp : isSet (Signature.Op Sig)) where
+  open Signature Sig
+
+  private
+    L = AlgebraLevel Sig
+
+  AlgebraCBPVEq : MultCBPVCatEq (ℓ-suc L) L
+  AlgebraCBPVEq = U→MultCBPVEq (ALGForget Sig) (ALGFree Sig isSetOp)
+
+  AlgebraCBPV : MultCBPVCat (ℓ-suc L) L
+  AlgebraCBPV = forgetEq AlgebraCBPVEq
+
+  ALGForgetᴰ : Functorᴰ (ALGForget Sig) (ALGᴰ Sig L L) (SETᴰ L L)
+  ALGForgetᴰ .F-obᴰ Bᴰ = Bᴰ .fst
+  ALGForgetᴰ .F-homᴰ fᴰ = fᴰ .fst
+  ALGForgetᴰ .F-idᴰ = refl
+  ALGForgetᴰ .F-seqᴰ _ _ = refl
+
+  AlgebraCBPVᴰ : CBPVCatᴰ (AlgebraCBPV .fst) (ℓ-suc L) L
+  AlgebraCBPVᴰ = U→CBPVᴰ (ALGForget Sig) ALGForgetᴰ
+
+  AlgebraCBPVAlg : AlgebraEnrichment (AlgebraCBPV .fst) Sig
+  AlgebraCBPVAlg .fst A B op γ x = B .snd op (λ v → γ v x)
+  AlgebraCBPVAlg .snd .fst V B op γ op⟨γ⟩ p =
+    λ i x → p i (V x)
+  AlgebraCBPVAlg .snd .snd S A op γ op⟨γ⟩ p =
+    funExt λ x → S .snd op (λ v → γ v x) (op⟨γ⟩ x)
+      (λ i → p i x)
+
+  module _
+    (C : CBPVCat ℓ L) (CAlg : AlgebraEnrichment C Sig)
+    (P : Fibers.ob[_] C 𝒱)
+    where
+    private module C = Fibers C
+
+    points : Functorⱽ C (AlgebraCBPV .fst)
+    points .F-obᴰ {x = 𝒱} A = C.Hom[ _ ][ P , A ] , C.isSetHomᴰ
+    points .F-obᴰ {x = 𝒞} B =
+      ((C.Hom[ _ ][ P , B ] , C.isSetHomᴰ) , CAlg .fst P B)
+    points .F-homᴰ {x = 𝒱} {y = 𝒱} f M = M C.⋆ᴰ f
+    points .F-homᴰ {x = 𝒱} {y = 𝒞} f M = M C.⋆ᴰ f
+    points .F-homᴰ {x = 𝒞} {y = 𝒞} f =
+      (λ M → M C.⋆ᴰ f) , CAlg .snd .snd f P
+    points .F-idᴰ {x = 𝒱} = funExt C.⋆IdRᴰ
+    points .F-idᴰ {x = 𝒞} =
+      Σ≡Prop (λ _ → isPropΠ4 λ _ _ _ _ → C.isSetHomᴰ _ _)
+        (funExt C.⋆IdRᴰ)
+    points .F-seqᴰ {x = 𝒱} {y = 𝒱} {z = 𝒱} f g =
+      funExt λ M → sym (C.⋆Assocᴰ M f g)
+    points .F-seqᴰ {x = 𝒱} {y = 𝒱} {z = 𝒞} f g =
+      funExt λ M → sym (C.⋆Assocᴰ M f g)
+    points .F-seqᴰ {x = 𝒱} {y = 𝒞} {z = 𝒞} f g =
+      funExt λ M → sym (C.⋆Assocᴰ M f g)
+    points .F-seqᴰ {x = 𝒞} {y = 𝒞} {z = 𝒞} f g =
+      Σ≡Prop (λ _ → isPropΠ4 λ _ _ _ _ → C.isSetHomᴰ _ _)
+        (funExt λ M → sym (C.⋆Assocᴰ M f g))
+
+    pointsPreservesAlgebra :
+      PreservesAlgebraEnrichment Sig points CAlg AlgebraCBPVAlg
+    pointsPreservesAlgebra A B op γ op⟨γ⟩ p =
+      funExt λ V → CAlg .snd .fst V B op γ op⟨γ⟩ p
+
+  AlgebraCBPVAlgᴰ : AlgebraEnrichmentᴰ Sig AlgebraCBPVAlg AlgebraCBPVᴰ
+  AlgebraCBPVAlgᴰ .fst Aᴰ Bᴰ op γ γᴰ op⟨γ⟩ p x xᴰ =
+    Bᴰ .snd op (λ v → γ v x) (λ v → γᴰ v x xᴰ)
+      (op⟨γ⟩ x) (λ i → p i x)
+  AlgebraCBPVAlgᴰ .snd .fst {V = V} Vᴰ
+    op γ γᴰ op⟨γ⟩ p op⟨γᴰ⟩ pᴰ i x xᴰ =
+      pᴰ i (V x) (Vᴰ x xᴰ)
+  AlgebraCBPVAlgᴰ .snd .snd {S = S} Sᴰ
+    op γ γᴰ op⟨γ⟩ p op⟨γᴰ⟩ pᴰ i x xᴰ =
+      Sᴰ .snd op (λ v → γ v x) (λ v → γᴰ v x xᴰ)
+        (op⟨γ⟩ x) (λ j → p j x)
+        (op⟨γᴰ⟩ x xᴰ) (λ j → pᴰ j x xᴰ) i

--- a/Cubical/Categories/Displayed/CBPV/Unary/Instances/Algebra/Multiplicative.agda
+++ b/Cubical/Categories/Displayed/CBPV/Unary/Instances/Algebra/Multiplicative.agda
@@ -1,0 +1,401 @@
+{-# OPTIONS --prop --lossy-unification #-}
+module Cubical.Categories.Displayed.CBPV.Unary.Instances.Algebra.Multiplicative where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.More
+open import Cubical.Foundations.Structure
+
+open import Cubical.Data.Sigma
+import Cubical.Data.Equality as Eq
+
+open import Cubical.Algebra.Signature.Base
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Instances.Fiber
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.TotalCategory hiding (elim)
+open import Cubical.Categories.Instances.WalkingArrow
+  renaming (l to 𝒱; r to 𝒞)
+open import Cubical.Categories.Presheaf.Morphism.Alt
+
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Instances.Algebra.Algebra
+open import Cubical.Categories.Displayed.Instances.Algebra.DisplayedAlgebra
+open import Cubical.Categories.Displayed.Instances.Opposite
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Fibration
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Representable
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Eq.Conversion.CartesianV
+import Cubical.Categories.Displayed.Presheaf.Uncurried.Eq.Base as EqPsh
+open import Cubical.Categories.Displayed.CBPV.Unary.Base
+open import Cubical.Categories.Displayed.CBPV.Unary.Instances.Algebra.Base
+
+private
+  variable
+    ℓO ℓA : Level
+
+module _ (Sig : Signature ℓO ℓA) (isSetOp : isSet (Signature.Op Sig)) where
+  open Signature Sig
+
+  private
+    L = AlgebraLevel Sig
+    C = AlgebraCBPV Sig isSetOp .fst
+    Cᴰ = AlgebraCBPVᴰ Sig isSetOp
+
+    CBPVIdR : EqPsh.EqIdR (∫C C)
+    CBPVIdR {x = 𝒱 , A} {y = 𝒱 , B} f = Eq.refl
+    CBPVIdR {x = 𝒱 , A} {y = 𝒞 , B} f =
+      Eq.pathToEq (Category.⋆IdR (∫C C) f)
+    CBPVIdR {x = 𝒞 , A} {y = 𝒱 , B} ()
+    CBPVIdR {x = 𝒞 , A} {y = 𝒞 , B} f = Eq.refl
+
+    CBPVAssoc : EqPsh.ReprEqAssoc (∫C C)
+    CBPVAssoc (𝒱 , A)
+      {c = 𝒱 , W} {c' = 𝒱 , X} {c'' = 𝒱 , Y}
+      _ _ _ _ Eq.refl = Eq.refl
+    CBPVAssoc (𝒞 , B)
+      {c = 𝒱 , W} {c' = 𝒱 , X} {c'' = 𝒱 , Y}
+      _ _ _ _ Eq.refl = Eq.refl
+    CBPVAssoc x f g p f⋆g e = Eq.pathToEq
+      (sym (D.⋆Assoc f g p) ∙ cong (λ fg → fg D.⋆ p) (Eq.eqToPath e))
+      where module D = Category (∫C C)
+
+  AlgebraCBPV-Uⱽ : hasUⱽ Cᴰ
+  AlgebraCBPV-Uⱽ {A = A} {B = B} f Bᴰ =
+    EqCartesianLift→CartesianLift CBPVAssoc Cᴰ Bᴰ (𝒱 , A) (_ , f)
+      (EqPsh.UEⱽ→Reprⱽ _ CBPVIdR ue)
+    where
+    ue : EqPsh.CartesianLiftUE Cᴰ CBPVAssoc CBPVIdR (_ , f) Bᴰ
+    ue .EqPsh.UEⱽ.v x = Bᴰ .fst (f x)
+    ue .EqPsh.UEⱽ.e _ xᴰ = xᴰ
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , Z) , Zᴰ , g) .fst h = h
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , Z) , Zᴰ , ()) .fst
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , Z) , Zᴰ , g) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , Z) , Zᴰ , ()) .snd .fst
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , Z) , Zᴰ , g) .snd .snd _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , Z) , Zᴰ , ()) .snd .snd
+
+  private
+    FreeALGᴰ : (A : hSet L) (Aᴰ : ⟨ A ⟩ → hSet L)
+      → Categoryᴰ.ob[_] (ALGᴰ Sig L L) (FreeALG Sig isSetOp A)
+    FreeALGᴰ A Aᴰ .fst t =
+      |FreeAlgebraᴰ| (λ x → ⟨ Aᴰ x ⟩) t ,
+      isSetFreeAlgebraᴰ (λ x → ⟨ Aᴰ x ⟩)
+        isSetOp (A .snd) (λ x → Aᴰ x .snd) t
+    FreeALGᴰ A Aᴰ .snd = FreeAlgebraᴰ (λ x → ⟨ Aᴰ x ⟩) .snd
+
+    η-base : (A : hSet L) → (∫C C) [ (𝒱 , A) , (𝒞 , FreeALG Sig isSetOp A) ]
+    η-base A = _ , var
+
+    η-lift : (A : hSet L) (Aᴰ : ⟨ A ⟩ → hSet L)
+      → CartesianLift (Cᴰ ^opᴰᴰ) (η-base A) Aᴰ
+    η-lift A Aᴰ = UniversalElementⱽ'.REPRⱽ ue
+      where
+      module Cᴰᶠ = Fibers (Cᴰ ^opᴰᴰ)
+      module Dᴰ = Fibers (ALGᴰ Sig L L)
+
+      ue : UniversalElementⱽ' (Cᴰ ^opᴰᴰ)
+        (𝒞 , FreeALG Sig isSetOp A)
+        (CartesianLiftPshSpec
+          ((∫C (C ^opᴰ)) [-, (𝒱 , A) ])
+          (Cᴰ ^opᴰᴰ)
+          ((Cᴰ ^opᴰᴰ) [-][-, Aᴰ ])
+          (η-base A))
+      ue .UniversalElementⱽ'.vertexⱽ = FreeALGᴰ A Aᴰ
+      ue .UniversalElementⱽ'.elementⱽ x xᴰ = |FreeAlgebraᴰ|.var xᴰ
+      ue .UniversalElementⱽ'.universalⱽ
+        ((𝒱 , Z) , Zᴰ , ()) .fst
+      ue .UniversalElementⱽ'.universalⱽ
+        ((𝒞 , Z) , Zᴰ , ϕ) .fst ıᴰ =
+          recFAᴰ (λ x → ⟨ Aᴰ x ⟩) (ϕ .snd) (_ , Zᴰ .snd) ıᴰ
+      ue .UniversalElementⱽ'.universalⱽ
+        ((𝒱 , Z) , Zᴰ , ()) .snd .fst
+      ue .UniversalElementⱽ'.universalⱽ
+        ((𝒞 , Z) , Zᴰ , ϕ) .snd .fst ıᴰ =
+          Cᴰᶠ.rectifyOut {e' = refl} $
+            Cᴰᶠ.reind-filler⁻ _
+            ∙ Cᴰᶠ.≡in {pth = refl} (funExt λ x → funExt λ xᴰ →
+              hSetReasoning.rectifyOut (Z .fst)
+                (λ z → ⟨ Zᴰ .fst z ⟩) refl)
+      ue .UniversalElementⱽ'.universalⱽ
+        ((𝒱 , Z) , Zᴰ , ()) .snd .snd
+      ue .UniversalElementⱽ'.universalⱽ
+        ((𝒞 , Z) , Zᴰ , ϕ) .snd .snd ϕᴰ =
+          cong (ue .UniversalElementⱽ'.universalⱽ
+            ((𝒞 , Z) , Zᴰ , ϕ) .fst)
+            (Cᴰᶠ.rectifyOut {e' = refl} (Cᴰᶠ.reind-filler⁻ _))
+          ∙ (Dᴰ.rectify $ Dᴰ.≡out $
+              Dᴰ.≡in {pth = refl}
+                (ALGᴰHomo≡ Sig _ _
+                  (sym (recFAᴰ-η (λ x → ⟨ Aᴰ x ⟩)
+                    (ϕ .snd) (_ , Zᴰ .snd) (_ , ϕᴰ .snd)))))
+
+    module _ {B B' : Category.ob (ALG Sig L)}
+      (ϕ : Homo (_ , B .snd) (_ , B' .snd))
+      (Bᴰ : Categoryᴰ.ob[_] (ALGᴰ Sig L L) B) where
+
+      PushALGᴰ : Categoryᴰ.ob[_] (ALGᴰ Sig L L) B'
+      PushALGᴰ .fst b' .fst =
+        Σ[ b ∈ ⟨ B .fst ⟩ ] (ϕ .fst b ≡ b') × ⟨ Bᴰ .fst b ⟩
+      PushALGᴰ .fst b' .snd =
+        isSetΣ (B .fst .snd) λ b →
+          isSet× (isProp→isSet (B' .fst .snd _ _)) (Bᴰ .fst b .snd)
+      PushALGᴰ .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+        B .snd op (λ v → γᴰ v .fst) ,
+        (sym (ϕ .snd op (λ v → γᴰ v .fst) _ refl)
+          ∙ cong (B' .snd op) (funExt λ v → γᴰ v .snd .fst)
+          ∙ op∘γ≡op⟨γ⟩) ,
+        Bᴰ .snd op (λ v → γᴰ v .fst)
+          (λ v → γᴰ v .snd .snd) _ refl
+
+      push-inᴰ : Categoryᴰ.Hom[_][_,_] (ALGᴰ Sig L L) ϕ Bᴰ PushALGᴰ
+      push-inᴰ .fst b bᴰ = b , refl , bᴰ
+      push-inᴰ .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩
+        op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ =
+          ΣPathP
+            ( op∘γ≡op⟨γ⟩
+            , ΣPathP
+                ( isProp→PathP
+                    (λ i → B' .fst .snd
+                      (ϕ .fst (op∘γ≡op⟨γ⟩ i))
+                      (ϕ .fst op⟨γ⟩)) _ _
+                , hSetReasoning.rectifyOut (B .fst)
+                    (λ b → ⟨ Bᴰ .fst b ⟩)
+                    {e' = op∘γ≡op⟨γ⟩}
+                    (hSetReasoning.≡in (B .fst)
+                      (λ b → ⟨ Bᴰ .fst b ⟩)
+                      (λ i → Bᴰ .snd op γ γᴰ
+                        (op∘γ≡op⟨γ⟩ i)
+                        (λ j → op∘γ≡op⟨γ⟩ (i ∧ j)))
+                    ∙ hSetReasoning.≡in (B .fst)
+                        (λ b → ⟨ Bᴰ .fst b ⟩)
+                        op∘γᴰ≡op⟨γᴰ⟩)))
+
+      module _ {Z : Category.ob (ALG Sig L)}
+        (ψ : Homo (_ , B' .snd) (_ , Z .snd))
+        (Zᴰ : Categoryᴰ.ob[_] (ALGᴰ Sig L L) Z)
+        (γᴰ : Categoryᴰ.Hom[_][_,_] (ALGᴰ Sig L L)
+          (ϕ ⋆H ψ) Bᴰ Zᴰ) where
+
+        private
+          module ZᴰR = hSetReasoning (Z .fst) (λ z → ⟨ Zᴰ .fst z ⟩)
+
+        recPush-fᴰ : ∀ b' → ⟨ PushALGᴰ .fst b' ⟩
+          → ⟨ Zᴰ .fst (ψ .fst b') ⟩
+        recPush-fᴰ b' (b , p , bᴰ) =
+          ZᴰR.reind (cong (ψ .fst) p) (γᴰ .fst b bᴰ)
+
+        private
+          op-filler : ∀ op δ δᴰ z (p : Z .snd op δ ≡ z)
+            → (Z .snd op δ , Zᴰ .snd op δ δᴰ _ refl)
+              ≡ (z , Zᴰ .snd op δ δᴰ z p)
+          op-filler op δ δᴰ z p i .fst = p i
+          op-filler op δ δᴰ z p i .snd =
+            Zᴰ .snd op δ δᴰ (p i) (λ j → p (i ∧ j))
+
+          child-path : ∀ {b'} (x : ⟨ PushALGᴰ .fst b' ⟩) →
+            Path (Σ ⟨ Z .fst ⟩ (λ z → ⟨ Zᴰ .fst z ⟩))
+              (ψ .fst (ϕ .fst (x .fst)) ,
+                γᴰ .fst (x .fst) (x .snd .snd))
+              (ψ .fst b' , recPush-fᴰ b' x)
+          child-path (b , p , bᴰ) = ΣPathP
+            ( cong (ψ .fst) p
+            , ZᴰR.rectifyOut (ZᴰR.reind-filler (cong (ψ .fst) p)))
+
+        recPushᴰ : Categoryᴰ.Hom[_][_,_] (ALGᴰ Sig L L)
+          ψ PushALGᴰ Zᴰ
+        recPushᴰ .fst = recPush-fᴰ
+        recPushᴰ .snd op δ δᴰ op⟨δ⟩ op∘δ≡op⟨δ⟩
+          op⟨δᴰ⟩ op∘δᴰ≡op⟨δᴰ⟩ =
+            ZᴰR.rectifyOut $
+              sym (op-filler op (ψ .fst ∘ δ)
+                (λ v → recPush-fᴰ (δ v) (δᴰ v)) _
+                (ψ .snd op δ op⟨δ⟩ op∘δ≡op⟨δ⟩))
+              ∙ sym (cong (∫Algebra (_ , Zᴰ .snd) .snd op)
+                  (funExt (λ v → child-path (δᴰ v))))
+              ∙ op-filler op
+                  (ψ .fst ∘ ϕ .fst ∘ (λ v → δᴰ v .fst))
+                  (λ v → γᴰ .fst (δᴰ v .fst) (δᴰ v .snd .snd))
+                  _ ((ϕ ⋆H ψ) .snd op
+                    (λ v → δᴰ v .fst) _ refl)
+              ∙ ZᴰR.≡in
+                  (γᴰ .snd op
+                    (λ v → δᴰ v .fst)
+                    (λ v → δᴰ v .snd .snd) _ refl _ refl)
+              ∙ ZᴰR.reind-filler
+                  (cong (ψ .fst)
+                    (PushALGᴰ .snd op δ δᴰ op⟨δ⟩
+                      op∘δ≡op⟨δ⟩ .snd .fst))
+              ∙ ZᴰR.≡in
+                  (cong (recPush-fᴰ op⟨δ⟩)
+                    op∘δᴰ≡op⟨δᴰ⟩)
+
+      push-path : ∀ b bᴰ {b'} (p : ϕ .fst b ≡ b') →
+        Path (Σ ⟨ B' .fst ⟩ (λ b' → ⟨ PushALGᴰ .fst b' ⟩))
+          (ϕ .fst b , b , refl , bᴰ)
+          (b' , b , p , bᴰ)
+      push-path b bᴰ p = ΣPathP
+        ( p
+        , ΣPathP
+            ( refl
+            , ΣPathP
+                ( isProp→PathP
+                    (λ i → B' .fst .snd (ϕ .fst b) (p i)) _ _
+                , refl)))
+
+      canonical-homᴰ : ∀ {Z : Category.ob (ALG Sig L)}
+        (ψ : Homo (_ , B' .snd) (_ , Z .snd))
+        (Zᴰ : Categoryᴰ.ob[_] (ALGᴰ Sig L L) Z)
+        (χᴰ : Categoryᴰ.Hom[_][_,_] (ALGᴰ Sig L L) ψ PushALGᴰ Zᴰ)
+        → Categoryᴰ.Hom[_][_,_] (ALGᴰ Sig L L) (ϕ ⋆H ψ) Bᴰ Zᴰ
+      canonical-homᴰ {Z = Z} ψ Zᴰ χᴰ =
+        _⋆Hᴰ_ {A = (_ , B .snd)} {B = (_ , B' .snd)} {C = (_ , Z .snd)}
+          {Aᴰ = (_ , Bᴰ .snd)} {Bᴰ = (_ , PushALGᴰ .snd)}
+          {Cᴰ = (_ , Zᴰ .snd)} {ϕ = ϕ} {ψ = ψ} push-inᴰ χᴰ
+
+      recPush-η-fᴰ : ∀ {Z : Category.ob (ALG Sig L)}
+        (ψ : Homo (_ , B' .snd) (_ , Z .snd))
+        (Zᴰ : Categoryᴰ.ob[_] (ALGᴰ Sig L L) Z)
+        (χᴰ : Categoryᴰ.Hom[_][_,_] (ALGᴰ Sig L L) ψ PushALGᴰ Zᴰ)
+        b' (x : ⟨ PushALGᴰ .fst b' ⟩)
+        → recPush-fᴰ ψ Zᴰ (canonical-homᴰ ψ Zᴰ χᴰ) b' x
+          ≡ χᴰ .fst b' x
+      recPush-η-fᴰ {Z = Z} ψ Zᴰ χᴰ b' (b , p , bᴰ) =
+        ZᴰR.rectifyOut $
+          ZᴰR.reind-filler⁻ (cong (ψ .fst) p)
+          ∙ cong totalχ (push-path b bᴰ p)
+        where
+        module ZᴰR = hSetReasoning (Z .fst) (λ z → ⟨ Zᴰ .fst z ⟩)
+        totalχ : (Σ ⟨ B' .fst ⟩ (λ z → ⟨ PushALGᴰ .fst z ⟩))
+          → Σ ⟨ Z .fst ⟩ (λ z → ⟨ Zᴰ .fst z ⟩)
+        totalχ q = ψ .fst (q .fst) , χᴰ .fst (q .fst) (q .snd)
+
+      push-base : ∫C (C ^opᴰ)
+        [ (𝒞 , B') , (𝒞 , B) ]
+      push-base = _ , ϕ
+
+      push-lift : CartesianLift (Cᴰ ^opᴰᴰ) push-base Bᴰ
+      push-lift = UniversalElementⱽ'.REPRⱽ ue
+        where
+        module Cᴰᶠ = Fibers (Cᴰ ^opᴰᴰ)
+        module Dᴰ = Fibers (ALGᴰ Sig L L)
+
+        Homo≡ : ∀ {X Z : Category.ob (ALG Sig L)}
+          (f g : Homo (_ , X .snd) (_ , Z .snd))
+          → f .fst ≡ g .fst → f ≡ g
+        Homo≡ {Z = Z} f g p i .fst = p i
+        Homo≡ {Z = Z} f g p i .snd =
+          isProp→PathP
+            {B = λ i → isHomoSimpl _ _ (p i)}
+            (λ _ → isPropΠ4 λ _ _ _ _ → Z .fst .snd _ _)
+            (f .snd) (g .snd) i
+
+        CBPVHomo≡ : ∀ {X Z : Category.ob (ALG Sig L)}
+          (f g : ∫C (C ^opᴰ) [ (𝒞 , Z) , (𝒞 , X) ])
+          → f .snd .fst ≡ g .snd .fst → f ≡ g
+        CBPVHomo≡ f g p i .fst = f .fst
+        CBPVHomo≡ f g p i .snd = Homo≡ (f .snd) (g .snd) p i
+
+        ALGᴰHomoP≡ : ∀ {X Z : Category.ob (ALG Sig L)}
+          {Xᴰ : Categoryᴰ.ob[_] (ALGᴰ Sig L L) X}
+          {Zᴰ : Categoryᴰ.ob[_] (ALGᴰ Sig L L) Z}
+          {f g : Homo (_ , X .snd) (_ , Z .snd)}
+          (p : f ≡ g)
+          (fᴰ : Categoryᴰ.Hom[_][_,_] (ALGᴰ Sig L L) f Xᴰ Zᴰ)
+          (gᴰ : Categoryᴰ.Hom[_][_,_] (ALGᴰ Sig L L) g Xᴰ Zᴰ)
+          → PathP
+              (λ i → ∀ x → ⟨ Xᴰ .fst x ⟩ → ⟨ Zᴰ .fst (p i .fst x) ⟩)
+              (fᴰ .fst) (gᴰ .fst)
+          → PathP
+              (λ i → Categoryᴰ.Hom[_][_,_] (ALGᴰ Sig L L) (p i) Xᴰ Zᴰ)
+              fᴰ gᴰ
+        ALGᴰHomoP≡ p fᴰ gᴰ q i .fst = q i
+        ALGᴰHomoP≡ {Zᴰ = Zᴰ} p fᴰ gᴰ q i .snd =
+          isProp→PathP
+            {B = λ i → isHomoᴰSimpl (p i)
+              (_ , _) (_ , Zᴰ .snd) (q i)}
+            (λ _ → isPropΠ6 λ _ _ _ _ _ _ →
+              isPropΠ λ _ → Zᴰ .fst _ .snd _ _)
+            (fᴰ .snd) (gᴰ .snd) i
+
+        ue : UniversalElementⱽ' (Cᴰ ^opᴰᴰ)
+          (𝒞 , B')
+          (CartesianLiftPshSpec
+            ((∫C (C ^opᴰ)) [-, (𝒞 , B) ])
+            (Cᴰ ^opᴰᴰ)
+            ((Cᴰ ^opᴰᴰ) [-][-, Bᴰ ])
+            push-base)
+        ue .UniversalElementⱽ'.vertexⱽ = PushALGᴰ
+        ue .UniversalElementⱽ'.elementⱽ .fst = push-inᴰ .fst
+        ue .UniversalElementⱽ'.elementⱽ .snd =
+          subst
+            (λ hϕ → isHomoᴰSimpl (ϕ .fst , hϕ)
+              (_ , Bᴰ .snd) (_ , PushALGᴰ .snd) (push-inᴰ .fst))
+            (isProp→PathP
+              (λ _ → isPropΠ4 λ _ _ _ _ → B' .fst .snd _ _)
+              (ϕ .snd) _)
+            (push-inᴰ .snd)
+        ue .UniversalElementⱽ'.universalⱽ
+          ((𝒞 , Z) , Zᴰ , ψ) .fst γᴰ =
+            recPushᴰ (ψ .snd) Zᴰ γᴰ
+        ue .UniversalElementⱽ'.universalⱽ
+          ((𝒞 , Z) , Zᴰ , ψ) .snd .fst γᴰ =
+            Cᴰᶠ.rectifyOut {e' = refl} $
+              Cᴰᶠ.reind-filler⁻ _
+              ∙ Cᴰᶠ.≡in
+                  {pth = CBPVHomo≡ _ _ refl}
+                  (ALGᴰHomoP≡ (Homo≡ _ _ refl) _ _
+                    (funExt λ b → funExt λ bᴰ →
+                      hSetReasoning.rectifyOut (Z .fst)
+                        (λ z → ⟨ Zᴰ .fst z ⟩)
+                        (hSetReasoning.reind-filler⁻ (Z .fst)
+                          (λ z → ⟨ Zᴰ .fst z ⟩) refl)))
+        ue .UniversalElementⱽ'.universalⱽ
+          ((𝒞 , Z) , Zᴰ , ψ) .snd .snd χᴰ =
+            cong (ue .UniversalElementⱽ'.universalⱽ
+              ((𝒞 , Z) , Zᴰ , ψ) .fst)
+              (Cᴰᶠ.rectifyOut {e' = refl} $
+                Cᴰᶠ.reind-filler⁻ _
+                ∙ Cᴰᶠ.≡in
+                    {pth = CBPVHomo≡ _ _ refl}
+                    (ALGᴰHomoP≡ (Homo≡ _ _ refl) _ _ refl))
+            ∙ (Dᴰ.rectify {a = B'} {b = Z}
+                {aᴰ = PushALGᴰ} {bᴰ = Zᴰ} $
+                Dᴰ.≡out $ Dᴰ.≡in {a = B'} {b = Z}
+                  {aᴰ = PushALGᴰ} {bᴰ = Zᴰ}
+                  {p = recPushᴰ (ψ .snd) Zᴰ
+                    (canonical-homᴰ (ψ .snd) Zᴰ χᴰ)}
+                  {q = χᴰ}
+                  (ALGᴰHomo≡ Sig _ _
+                    (funExt λ b' → funExt λ x →
+                      recPush-η-fᴰ (ψ .snd) Zᴰ χᴰ b' x)))
+
+  AlgebraCBPV-Fⱽ : hasFⱽ Cᴰ
+  AlgebraCBPV-Fⱽ {A = A} {B = B} f Aᴰ =
+    transportCartesianLift (Cᴰ ^opᴰᴰ) factor≡f composite
+    where
+    module Cᵒᵖ = Category (∫C (C ^opᴰ))
+
+    recf : Homo (_ , FreeALG Sig isSetOp A .snd) (_ , B .snd)
+    recf = recFA (_ , B .snd) f
+
+    composite : CartesianLift (Cᴰ ^opᴰᴰ)
+      ((_ , recf) Cᵒᵖ.⋆ (η-base A)) Aᴰ
+    composite = composeCartesianLifts (Cᴰ ^opᴰᴰ)
+      (η-lift A Aᴰ) (push-lift recf (FreeALGᴰ A Aᴰ))
+
+    factor≡f : ((_ , recf) Cᵒᵖ.⋆ (η-base A)) ≡ (_ , f)
+    factor≡f = ΣPathP (refl , refl)
+
+  AlgebraCBPVⱽ : MultCBPVCatⱽ (AlgebraCBPV Sig isSetOp .fst)
+    (ℓ-suc L) L
+  AlgebraCBPVⱽ .fst = Cᴰ
+  AlgebraCBPVⱽ .snd .fst = AlgebraCBPV-Uⱽ
+  AlgebraCBPVⱽ .snd .snd = AlgebraCBPV-Fⱽ

--- a/Cubical/Categories/Displayed/CBPV/Unary/Instances/Free/AlgEnriched/Additive.agda
+++ b/Cubical/Categories/Displayed/CBPV/Unary/Instances/Free/AlgEnriched/Additive.agda
@@ -1,0 +1,617 @@
+-- Parameterized unary CBPV syntax with finite additives and algebraic operations.
+{-# OPTIONS --lossy-unification --prop #-}
+module Cubical.Categories.Displayed.CBPV.Unary.Instances.Free.AlgEnriched.Additive where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Equiv.Dependent
+open import Cubical.Foundations.HLevels.More
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.More
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit
+open import Cubical.Prop
+
+open import Cubical.Algebra.Signature.Base
+
+open import Cubical.Categories.Category hiding (isIso)
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Functors.More
+open import Cubical.Categories.Instances.Fiber
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.TotalCategory hiding (elim)
+open import Cubical.Categories.Instances.WalkingArrow
+  renaming (WalkingArrow to KIND; Vertex to Kind; l to 𝒱; r to 𝒞; ≤Vertex to ≤Kind)
+open import Cubical.Categories.Limits.Terminal.More
+open import Cubical.Categories.Limits.BinProduct.More
+open import Cubical.Categories.Presheaf
+open import Cubical.Categories.Presheaf.More
+open import Cubical.Categories.Presheaf.Representable
+open import Cubical.Categories.Presheaf.Representable.More
+open import Cubical.Categories.Presheaf.Morphism.Alt
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Displayed.Section renaming (Section to DisplayedSection)
+open import Cubical.Categories.Displayed.Instances.Opposite
+open import Cubical.Categories.Displayed.Instances.Reindex
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Base
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Fibration
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Representable
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Constructions
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.UniversalProperties
+open import Cubical.Categories.Displayed.CBPV.Unary.Base
+open import Cubical.Categories.Displayed.CBPV.Unary.Additive
+open import Cubical.Categories.Displayed.CBPV.Unary.Enrichment.Algebra
+
+private
+  variable
+    ℓ ℓ' ℓᴰ ℓᴰ' ℓD ℓD' ℓCᴰ ℓCᴰ' ℓO ℓA : Level
+
+open Category
+open Categoryᴰ
+open UniversalElement
+open PshHom
+open isIsoOver
+open DisplayedSection
+
+module CBPV (Sig : Signature ℓO ℓA) (BaseTy : Kind → Type ℓ) where
+  open Signature Sig
+  data Ob : Kind → Type ℓ where
+    gen : ∀ {k} → BaseTy k → Ob k
+    [F] : Ob 𝒱 → Ob 𝒞
+    [U] : Ob 𝒞 → Ob 𝒱
+    [1] [0] : Ob 𝒱
+    _[×]_ _[+]_ : Ob 𝒱 → Ob 𝒱 → Ob 𝒱
+    [⊤] : Ob 𝒞
+    _[&]_ : Ob 𝒞 → Ob 𝒞 → Ob 𝒞
+
+  VTy = Ob 𝒱
+  CTy = Ob 𝒞
+
+  module Terms (Fun : ∀ {k₁ k₂} → ≤Kind k₁ k₂ → Ob k₁ → Ob k₂ → Type ℓ') where
+    private
+      variable
+        k k₁ k₂ : Kind
+        Γ Δ Θ Ξ : Ob k
+        A A₁ A₂ : VTy
+        B B₁ B₂ : CTy
+        k≤ k≤' k≤'' : ≤Kind k₁ k₂
+
+    data Tm : (p : ≤Kind k₁ k₂) → Ob k₁ → Ob k₂
+      → Type (ℓ-max (ℓ-max ℓ ℓ') (ℓ-max ℓO ℓA)) where
+      gen : Fun k≤ Γ Δ → Tm k≤ Γ Δ
+      idS : Tm (≤V-refl k) Γ Γ
+      seqS : Tm k≤ Γ Δ → Tm k≤' Δ Θ → Tm (≤V-trans k≤ k≤') Γ Θ
+      IdLS : (f : Tm k≤ Γ Δ) → seqS idS f ≡ f
+      IdRS : (f : Tm k≤ Γ Δ) → seqS f idS ≡ f
+      AssocS : (f : Tm k≤ Γ Δ) (g : Tm k≤' Δ Θ)
+        (h : Tm k≤'' Θ Ξ) → seqS (seqS f g) h ≡ seqS f (seqS g h)
+      isSetTm : isSet (Tm k≤ Γ Δ)
+
+      -- Multiplicative sturcture
+      [ret] : Tm _ A ([F] A)
+      [bind] : Tm _ A B → Tm _ ([F] A) B
+      [Fβ] : (M : Tm _ A B) → seqS [ret] ([bind] M) ≡ M
+      [Fη] : (K : Tm _ ([F] A) B) → K ≡ [bind] (seqS [ret] K)
+      [force] : Tm _ ([U] B) B
+      [thunk] : Tm _ Γ B → Tm {k₁ = 𝒱} _ Γ ([U] B)
+      [Uβ] : (M : Tm _ A B) → seqS ([thunk] M) [force] ≡ M
+      [Uη] : (V : Tm _ Γ ([U] B)) → V ≡ [thunk] (seqS V [force])
+
+      -- Additive sturcture
+
+      -- value products
+      [1I] : Tm _ A [1]
+      [1η] : (V : Tm _ A [1]) → V ≡ [1I]
+      [×I] : Tm _ A A₁ → Tm _ A A₂ → Tm _ A (A₁ [×] A₂)
+      [×π1] : Tm _ (A₁ [×] A₂) A₁
+      [×π2] : Tm _ (A₁ [×] A₂) A₂
+      [×β1] : (V₁ : Tm _ A A₁) (V₂ : Tm _ A A₂) → seqS ([×I] V₁ V₂) [×π1] ≡ V₁
+      [×β2] : (V₁ : Tm _ A A₁) (V₂ : Tm _ A A₂) → seqS ([×I] V₁ V₂) [×π2] ≡ V₂
+      [×η] : (V : Tm _ A (A₁ [×] A₂)) →
+        V ≡ [×I] (seqS V [×π1]) (seqS V [×π2])
+
+      -- value coproducts
+      [0E] : Tm {k₁ = 𝒱} k≤ [0] Γ
+      [0η] : (V : Tm {k₁ = 𝒱} k≤ [0] Γ) → V ≡ [0E]
+      [+I1] : Tm _ A₁ (A₁ [+] A₂)
+      [+I2] : Tm _ A₂ (A₁ [+] A₂)
+      [+E] : Tm {k₁ = 𝒱} k≤ A₁ Γ → Tm {k₁ = 𝒱} k≤ A₂ Γ →
+        Tm {k₁ = 𝒱} k≤ (A₁ [+] A₂) Γ
+      [+β1] : (f : Tm {k₁ = 𝒱} k≤ A₁ Γ) (g : Tm {k₁ = 𝒱} k≤ A₂ Γ) →
+        seqS [+I1] ([+E] f g) ≡ f
+      [+β2] : (f : Tm {k₁ = 𝒱} k≤ A₁ Γ) (g : Tm {k₁ = 𝒱} k≤ A₂ Γ) →
+        seqS [+I2] ([+E] f g) ≡ g
+      [+η] : (f : Tm {k₁ = 𝒱} k≤ (A₁ [+] A₂) Γ) →
+        f ≡ [+E] (seqS [+I1] f) (seqS [+I2] f)
+
+      -- computation products
+      [⊤I] : Tm (≤V-r-⊤ k) Γ [⊤]
+      [⊤η] : (M : Tm (≤V-r-⊤ k) Γ [⊤]) → M ≡ [⊤I]
+      [&I] : Tm (≤V-r-⊤ k) Γ B₁ → Tm (≤V-r-⊤ k) Γ B₂ →
+        Tm (≤V-r-⊤ k) Γ (B₁ [&] B₂)
+      [&π1] : Tm _ (B₁ [&] B₂) B₁
+      [&π2] : Tm _ (B₁ [&] B₂) B₂
+      [&β1] : (M₁ : Tm (≤V-r-⊤ k) Γ B₁) (M₂ : Tm (≤V-r-⊤ k) Γ B₂) →
+        seqS ([&I] M₁ M₂) [&π1] ≡ M₁
+      [&β2] : (M₁ : Tm (≤V-r-⊤ k) Γ B₁) (M₂ : Tm (≤V-r-⊤ k) Γ B₂) →
+        seqS ([&I] M₁ M₂) [&π2] ≡ M₂
+      [&η] : (M : Tm (≤V-r-⊤ k) Γ (B₁ [&] B₂)) →
+        M ≡ [&I] (seqS M [&π1]) (seqS M [&π2])
+
+      -- Algebraic operations
+      [op] : (op : Op) → (Arity op → Tm _ A B) → Tm _ A B
+      [op-homL] : (V : Tm _ A A₁) (op : Op) (γ : Arity op → Tm _ A₁ B)
+        → seqS V ([op] op γ) ≡ [op] op (λ v → seqS V (γ v))
+      [op-homR] : (op : Op) (γ : Arity op → Tm _ A B) (S : Tm _ B B₁)
+        → seqS ([op] op γ) S ≡ [op] op (λ v → seqS (γ v) S)
+
+    CBPV : CBPVCat ℓ (ℓ-max (ℓ-max ℓ ℓ') (ℓ-max ℓO ℓA))
+    CBPV .ob[_] = Ob
+    CBPV .Hom[_][_,_] p = Tm (p .Prop→Type.pf)
+    CBPV .idᴰ = idS
+    CBPV ._⋆ᴰ_ = seqS
+    CBPV .⋆IdLᴰ = IdLS
+    CBPV .⋆IdRᴰ = IdRS
+    CBPV .⋆Assocᴰ = AssocS
+    CBPV .isSetHomᴰ = isSetTm
+
+    module C = Fibers CBPV
+
+    module Cop = Fibers (CBPV ^opᴰ)
+
+    value-terminalⱽ : Terminalⱽ CBPV 𝒱
+    value-terminalⱽ = UniversalElementⱽ'.REPRⱽ ue
+      where
+      ue : UniversalElementⱽ' CBPV 𝒱 UnitPshᴰ
+      ue .UniversalElementⱽ'.vertexⱽ = [1]
+      ue .UniversalElementⱽ'.elementⱽ = tt
+      ue .UniversalElementⱽ'.universalⱽ (𝒱 , A , f) .fst _ = [1I]
+      ue .UniversalElementⱽ'.universalⱽ (𝒱 , A , f) .snd .fst _ = refl
+      ue .UniversalElementⱽ'.universalⱽ (𝒱 , A , f) .snd .snd V = sym ([1η] V)
+
+    value-productⱽ : ∀ A₁ A₂ → BinProductⱽ CBPV A₁ A₂
+    value-productⱽ A₁ A₂ = UniversalElementⱽ'.REPRⱽ ue
+      where
+      ue : UniversalElementⱽ' CBPV 𝒱 (BinProductⱽSpec CBPV A₁ A₂)
+      ue .UniversalElementⱽ'.vertexⱽ = A₁ [×] A₂
+      ue .UniversalElementⱽ'.elementⱽ = [×π1] , [×π2]
+      ue .UniversalElementⱽ'.universalⱽ (𝒱 , A , f) .fst V = [×I] (V .fst) (V .snd)
+      ue .UniversalElementⱽ'.universalⱽ (𝒱 , A , f) .snd .fst V =
+        ΣPathP
+          ( C.rectifyOut {e' = refl}
+              (C.reind-filler⁻ _ ∙ C.≡in {pth = refl} ([×β1] (V .fst) (V .snd)))
+          , C.rectifyOut {e' = refl}
+              (C.reind-filler⁻ _ ∙ C.≡in {pth = refl} ([×β2] (V .fst) (V .snd))))
+      ue .UniversalElementⱽ'.universalⱽ (𝒱 , A , f) .snd .snd V =
+        cong₂ [×I]
+          (C.rectifyOut {e' = refl} (C.reind-filler⁻ _))
+          (C.rectifyOut {e' = refl} (C.reind-filler⁻ _))
+        ∙ sym ([×η] V)
+
+    value-initialⱽ : Initialⱽ CBPV 𝒱
+    value-initialⱽ = UniversalElementⱽ'.REPRⱽ ue
+      where
+      ue : UniversalElementⱽ' (CBPV ^opᴰ) 𝒱 UnitPshᴰ
+      ue .UniversalElementⱽ'.vertexⱽ = [0]
+      ue .UniversalElementⱽ'.elementⱽ = tt
+      ue .UniversalElementⱽ'.universalⱽ (k , A , f) .fst _ = [0E]
+      ue .UniversalElementⱽ'.universalⱽ (k , A , f) .snd .fst _ = refl
+      ue .UniversalElementⱽ'.universalⱽ (k , A , f) .snd .snd V = sym ([0η] V)
+
+    value-coproductⱽ : ∀ A₁ A₂ → BinCoProductⱽ CBPV A₁ A₂
+    value-coproductⱽ A₁ A₂ = UniversalElementⱽ'.REPRⱽ ue
+      where
+      ue : UniversalElementⱽ' (CBPV ^opᴰ) 𝒱
+        (BinProductⱽSpec (CBPV ^opᴰ) A₁ A₂)
+      ue .UniversalElementⱽ'.vertexⱽ = A₁ [+] A₂
+      ue .UniversalElementⱽ'.elementⱽ = [+I1] , [+I2]
+      ue .UniversalElementⱽ'.universalⱽ (k , A , f) .fst V = [+E] (V .fst) (V .snd)
+      ue .UniversalElementⱽ'.universalⱽ (k , A , f) .snd .fst V =
+        ΣPathP
+          ( Cop.rectifyOut {e' = refl}
+              (Cop.reind-filler⁻ _ ∙ Cop.≡in {pth = refl} ([+β1] (V .fst) (V .snd)))
+          , Cop.rectifyOut {e' = refl}
+              (Cop.reind-filler⁻ _ ∙ Cop.≡in {pth = refl} ([+β2] (V .fst) (V .snd))))
+      ue .UniversalElementⱽ'.universalⱽ (k , A , f) .snd .snd V =
+        cong₂ [+E]
+          (Cop.rectifyOut {e' = refl} (Cop.reind-filler⁻ _))
+          (Cop.rectifyOut {e' = refl} (Cop.reind-filler⁻ _))
+        ∙ sym ([+η] V)
+
+    computation-terminalⱽ : Terminalⱽ CBPV 𝒞
+    computation-terminalⱽ = UniversalElementⱽ'.REPRⱽ ue
+      where
+      ue : UniversalElementⱽ' CBPV 𝒞 UnitPshᴰ
+      ue .UniversalElementⱽ'.vertexⱽ = [⊤]
+      ue .UniversalElementⱽ'.elementⱽ = tt
+      ue .UniversalElementⱽ'.universalⱽ (k , B , f) .fst _ = [⊤I]
+      ue .UniversalElementⱽ'.universalⱽ (k , B , f) .snd .fst _ = refl
+      ue .UniversalElementⱽ'.universalⱽ (k , B , f) .snd .snd M = sym ([⊤η] M)
+
+    computation-productⱽ : ∀ B₁ B₂ → BinProductⱽ CBPV B₁ B₂
+    computation-productⱽ B₁ B₂ = UniversalElementⱽ'.REPRⱽ ue
+      where
+      ue : UniversalElementⱽ' CBPV 𝒞 (BinProductⱽSpec CBPV B₁ B₂)
+      ue .UniversalElementⱽ'.vertexⱽ = B₁ [&] B₂
+      ue .UniversalElementⱽ'.elementⱽ = [&π1] , [&π2]
+      ue .UniversalElementⱽ'.universalⱽ (k , B , f) .fst M = [&I] (M .fst) (M .snd)
+      ue .UniversalElementⱽ'.universalⱽ (k , B , f) .snd .fst M =
+        ΣPathP
+          ( C.rectifyOut {e' = refl}
+              (C.reind-filler⁻ _ ∙ C.≡in {pth = refl} ([&β1] (M .fst) (M .snd)))
+          , C.rectifyOut {e' = refl}
+              (C.reind-filler⁻ _ ∙ C.≡in {pth = refl} ([&β2] (M .fst) (M .snd))))
+      ue .UniversalElementⱽ'.universalⱽ (k , B , f) .snd .snd M =
+        cong₂ [&I]
+          (C.rectifyOut {e' = refl} (C.reind-filler⁻ _))
+          (C.rectifyOut {e' = refl} (C.reind-filler⁻ _))
+        ∙ sym ([&η] M)
+
+    [U]-UMPPath : hasU CBPV
+    [U]-UMPPath B = UniversalElementⱽ'.REPRⱽ ue
+      where
+      ue : UniversalElementⱽ' CBPV 𝒱
+        (CartesianLiftPshSpec (KIND [-, 𝒞 ]) CBPV (CBPV [-][-, B ]) (ı tt))
+      ue .UniversalElementⱽ'.vertexⱽ = [U] B
+      ue .UniversalElementⱽ'.elementⱽ = [force]
+      ue .UniversalElementⱽ'.universalⱽ (𝒱 , A , f) .fst = [thunk]
+      ue .UniversalElementⱽ'.universalⱽ (𝒱 , A , f) .snd .fst M =
+        C.rectifyOut {e' = refl}
+          (C.reind-filler⁻ _ ∙ C.≡in {pth = refl} ([Uβ] M))
+      ue .UniversalElementⱽ'.universalⱽ (𝒱 , A , f) .snd .snd V =
+        cong [thunk] (C.rectifyOut {e' = refl} (C.reind-filler⁻ _))
+        ∙ sym ([Uη] V)
+
+    [F]-UMPPath : hasF CBPV
+    [F]-UMPPath A = UniversalElementⱽ'.REPRⱽ ue
+      where
+      ue : UniversalElementⱽ' (CBPV ^opᴰ) 𝒞
+        (CartesianLiftPshSpec ((KIND ^op) [-, 𝒱 ]) (CBPV ^opᴰ)
+          ((CBPV ^opᴰ) [-][-, A ]) (ı tt))
+      ue .UniversalElementⱽ'.vertexⱽ = [F] A
+      ue .UniversalElementⱽ'.elementⱽ = [ret]
+      ue .UniversalElementⱽ'.universalⱽ (𝒞 , B , f) .fst = [bind]
+      ue .UniversalElementⱽ'.universalⱽ (𝒞 , B , f) .snd .fst M =
+        Cop.rectifyOut {e' = refl}
+          (Cop.reind-filler⁻ _ ∙ Cop.≡in {pth = refl} ([Fβ] M))
+      ue .UniversalElementⱽ'.universalⱽ (𝒞 , B , f) .snd .snd K =
+        cong [bind] (Cop.rectifyOut {e' = refl} (Cop.reind-filler⁻ _))
+        ∙ sym ([Fη] K)
+
+    MultCBPV : MultCBPVCat _ _
+    MultCBPV = CBPV , [U]-UMPPath , [F]-UMPPath
+
+    AlgebraEff : ∀ (A : Ob 𝒱) (B : Ob 𝒞)
+      → AlgebraWithCarrier (CBPV [ _ ][ A , B ])
+    AlgebraEff A B = [op]
+
+    Subst-Homo : ∀ {A A'} (V : Tm _ A A') B
+      → isHomoSimpl (_ , AlgebraEff A' B) (_ , AlgebraEff A B)
+          (seqS {k≤ = tt} V)
+    Subst-Homo V B op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+      sym ([op-homL] V op γ) ∙ cong (seqS V) op∘γ≡op⟨γ⟩
+
+    Plug-Homo : ∀ {B B'} (S : Tm _ B B') A
+      → isHomoSimpl (_ , AlgebraEff A B) (_ , AlgebraEff A B')
+          (λ M → seqS {k≤' = tt} M S)
+    Plug-Homo S A op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+      sym ([op-homR] op γ S) ∙ cong (λ M → seqS M S) op∘γ≡op⟨γ⟩
+
+    CBPVAlg : AlgebraEnrichment CBPV Sig
+    CBPVAlg .fst = AlgebraEff
+    CBPVAlg .snd .fst = Subst-Homo
+    CBPVAlg .snd .snd = Plug-Homo
+
+    AddCBPV : AddCBPVCat _ _
+    AddCBPV = MultCBPV , value-terminalⱽ , value-productⱽ
+      , value-initialⱽ , value-coproductⱽ
+      , computation-terminalⱽ , computation-productⱽ
+
+    module Elim
+      (D : AddCBPVCatᴰ AddCBPV ℓᴰ ℓᴰ')
+      (DAlg : AlgebraEnrichmentᴰ Sig CBPVAlg (D .fst .fst))
+      where
+      private
+        Dᴰ = D .fst .fst
+        module Dᴰ = Fibers Dᴰ
+        module Dᴰop = Fibers (Dᴰ ^opᴰᴰ)
+
+      module _ (ı-Ob : ∀ {k} (X : BaseTy k) → Dᴰ.ob[ k , gen X ]) where
+        elim-F-obᴰ : ∀ {k} (X : Ob k) → Dᴰ.ob[ k , X ]
+        elim-F-obᴰ (gen X) = ı-Ob X
+        elim-F-obᴰ ([F] A) = D .fst .snd .snd (elim-F-obᴰ A) .fst
+        elim-F-obᴰ ([U] B) = D .fst .snd .fst (elim-F-obᴰ B) .fst
+        elim-F-obᴰ [1] = D .snd .fst .fst
+        elim-F-obᴰ (A₁ [×] A₂) =
+          D .snd .snd .fst A₁ A₂ (elim-F-obᴰ A₁) (elim-F-obᴰ A₂) .fst
+        elim-F-obᴰ [0] = D .snd .snd .snd .fst .fst
+        elim-F-obᴰ (A₁ [+] A₂) =
+          D .snd .snd .snd .snd .fst A₁ A₂ (elim-F-obᴰ A₁) (elim-F-obᴰ A₂) .fst
+        elim-F-obᴰ [⊤] = D .snd .snd .snd .snd .snd .fst .fst
+        elim-F-obᴰ (B₁ [&] B₂) =
+          D .snd .snd .snd .snd .snd .snd B₁ B₂ (elim-F-obᴰ B₁) (elim-F-obᴰ B₂) .fst
+
+        private
+          module DA = AddCBPVCatᴰNotation AddCBPV D
+
+          value-π₁≡[×π1] : ∀ {A₁ A₂} →
+            BinProductⱽNotation.π₁ CBPV (value-productⱽ A₁ A₂) ≡ [×π1]
+          value-π₁≡[×π1] = C.rectifyOut {e' = refl}
+            (C.reind-filler⁻ (Category.⋆IdR KIND _) ∙ C.≡in {pth = refl} (IdLS [×π1]))
+
+          value-π₂≡[×π2] : ∀ {A₁ A₂} →
+            BinProductⱽNotation.π₂ CBPV (value-productⱽ A₁ A₂) ≡ [×π2]
+          value-π₂≡[×π2] = C.rectifyOut {e' = refl}
+            (C.reind-filler⁻ (Category.⋆IdR KIND _) ∙ C.≡in {pth = refl} (IdLS [×π2]))
+
+          value-σ₁≡[+I1] : ∀ {A₁ A₂} →
+            BinProductⱽNotation.π₁ (CBPV ^opᴰ) (value-coproductⱽ A₁ A₂) ≡ [+I1]
+          value-σ₁≡[+I1] = Cop.rectifyOut {e' = refl}
+            (Cop.reind-filler⁻ (Category.⋆IdR (KIND ^op) _) ∙ Cop.≡in {pth = refl} (IdRS [+I1]))
+
+          value-σ₂≡[+I2] : ∀ {A₁ A₂} →
+            BinProductⱽNotation.π₂ (CBPV ^opᴰ) (value-coproductⱽ A₁ A₂) ≡ [+I2]
+          value-σ₂≡[+I2] = Cop.rectifyOut {e' = refl}
+            (Cop.reind-filler⁻ (Category.⋆IdR (KIND ^op) _) ∙ Cop.≡in {pth = refl} (IdRS [+I2]))
+
+          computation-π₁≡[&π1] : ∀ {B₁ B₂} →
+            BinProductⱽNotation.π₁ CBPV (computation-productⱽ B₁ B₂) ≡ [&π1]
+          computation-π₁≡[&π1] = C.rectifyOut {e' = refl}
+            (C.reind-filler⁻ (Category.⋆IdR KIND _) ∙ C.≡in {pth = refl} (IdLS [&π1]))
+
+          computation-π₂≡[&π2] : ∀ {B₁ B₂} →
+            BinProductⱽNotation.π₂ CBPV (computation-productⱽ B₁ B₂) ≡ [&π2]
+          computation-π₂≡[&π2] = C.rectifyOut {e' = refl}
+            (C.reind-filler⁻ (Category.⋆IdR KIND _) ∙ C.≡in {pth = refl} (IdLS [&π2]))
+
+        retᴰ : ∀ {A} → Dᴰ.Hom[ ı tt , [ret] ][ elim-F-obᴰ A , elim-F-obᴰ ([F] A) ]
+        retᴰ = Dᴰ.reind
+          (Cop.reind-filler⁻ _ ∙ Cop.≡in {pth = refl} (IdRS [ret]))
+          (D .fst .snd .snd (elim-F-obᴰ _) .snd .fst .PshHom.N-ob _ Dᴰop.idᴰ)
+
+        bindᴰ : ∀ {A B} (M : Tm _ A B)
+          → Dᴰ.Hom[ ı tt , M ][ elim-F-obᴰ A , elim-F-obᴰ B ]
+          → Dᴰ.Hom[ Category.id KIND , [bind] M ][ elim-F-obᴰ ([F] A) , elim-F-obᴰ B ]
+        bindᴰ {A = A} M Mᴰ = D .fst .snd .snd (elim-F-obᴰ A)
+          .snd .snd _ _ .isIsoOver.inv _ Mᴰ
+
+        module _
+          (ı-Fun : ∀ {k₁ k₂ Γ Δ} {k≤ : ≤Kind k₁ k₂} (M : Fun k≤ Γ Δ)
+            → Dᴰ.Hom[ ı k≤ , gen M ][ elim-F-obᴰ Γ , elim-F-obᴰ Δ ])
+          where
+          elim-F-homᴰ : (M : Tm k≤ Γ Δ)
+            → Dᴰ.Hom[ ı k≤ , M ][ elim-F-obᴰ Γ , elim-F-obᴰ Δ ]
+          elim-F-homᴰ (gen f) = ı-Fun f
+          elim-F-homᴰ idS = Dᴰ.idᴰ
+          elim-F-homᴰ (seqS M N) = elim-F-homᴰ M Dᴰ.⋆ᴰ elim-F-homᴰ N
+          elim-F-homᴰ (IdLS M i) = Dᴰ.⋆IdLᴰ (elim-F-homᴰ M) i
+          elim-F-homᴰ (IdRS M i) = Dᴰ.⋆IdRᴰ (elim-F-homᴰ M) i
+          elim-F-homᴰ (AssocS L M N i) =
+            Dᴰ.⋆Assocᴰ (elim-F-homᴰ L) (elim-F-homᴰ M) (elim-F-homᴰ N) i
+          elim-F-homᴰ (isSetTm M N p q i j) = isSet→isSetDep
+            (λ _ → Dᴰ.isSetHomᴰ) (elim-F-homᴰ M) (elim-F-homᴰ N)
+            (cong elim-F-homᴰ p) (cong elim-F-homᴰ q) (isSetTm M N p q) i j
+          elim-F-homᴰ [ret] = retᴰ
+          elim-F-homᴰ ([bind] M) = bindᴰ M (elim-F-homᴰ M)
+          elim-F-homᴰ ([Fβ] M i) =
+            Fβᴰ Dᴰ (MultCBPV .snd .snd) (D .fst .snd .snd)
+              (Cop.reind-filler⁻ _ ∙ Cop.≡in {pth = refl} (IdRS [ret]))
+              M (λ i → ı tt , [Fβ] M i) (elim-F-homᴰ M) i
+          elim-F-homᴰ ([Fη] K i) =
+            Fηᴰ Dᴰ (MultCBPV .snd .snd) (D .fst .snd .snd)
+              (Cop.reind-filler⁻ _ ∙ Cop.≡in {pth = refl} (IdRS [ret]))
+              K (λ i → Category.id KIND , [Fη] K i) (elim-F-homᴰ K) i
+          elim-F-homᴰ [force] = Dᴰ.reind
+            (C.reind-filler⁻ _ ∙ C.≡in {pth = refl} (IdLS [force]))
+            (forceᴰ Dᴰ (MultCBPV .snd .fst) (D .fst .snd .fst))
+          elim-F-homᴰ ([thunk] M) =
+            thunkᴰ Dᴰ (MultCBPV .snd .fst) (D .fst .snd .fst) M (elim-F-homᴰ M)
+          elim-F-homᴰ ([Uβ] M i) =
+            Uβᴰ Dᴰ (MultCBPV .snd .fst) (D .fst .snd .fst)
+              (C.reind-filler⁻ _ ∙ C.≡in {pth = refl} (IdLS [force]))
+              M (λ i → ı tt , [Uβ] M i) (elim-F-homᴰ M) i
+          elim-F-homᴰ ([Uη] V i) =
+            Uηᴰ Dᴰ (MultCBPV .snd .fst) (D .fst .snd .fst)
+              (C.reind-filler⁻ _ ∙ C.≡in {pth = refl} (IdLS [force]))
+              V (λ i → Category.id KIND , [Uη] V i) (elim-F-homᴰ V) i
+          elim-F-homᴰ [1I] = Dᴰ.reind (ΣPathP (refl , refl)) DA.value-terminal-introᴰ
+          elim-F-homᴰ ([1η] V i) =
+            DA.value-terminal-ηᴰ (ΣPathP (refl , refl))
+              (λ i → ı _ , [1η] V i)
+              (elim-F-homᴰ V) i
+          elim-F-homᴰ ([×I] V₁ V₂) = Dᴰ.reind (ΣPathP (refl , refl))
+            (DA.value-pairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (elim-F-homᴰ V₁) (elim-F-homᴰ V₂))
+          elim-F-homᴰ [×π1] = Dᴰ.reind
+            (ΣPathP (refl , value-π₁≡[×π1]))
+            (DA.value-πᴰ₁ (elim-F-obᴰ _) (elim-F-obᴰ _))
+          elim-F-homᴰ [×π2] = Dᴰ.reind
+            (ΣPathP (refl , value-π₂≡[×π2]))
+            (DA.value-πᴰ₂ (elim-F-obᴰ _) (elim-F-obᴰ _))
+          elim-F-homᴰ ([×β1] V₁ V₂ i) =
+            DA.value-×βᴰ₁-on (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (ΣPathP (refl , value-π₁≡[×π1]))
+              (λ i → ı _ , [×β1] V₁ V₂ i)
+              (elim-F-homᴰ V₁) (elim-F-homᴰ V₂) i
+          elim-F-homᴰ ([×β2] V₁ V₂ i) =
+            DA.value-×βᴰ₂-on (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (ΣPathP (refl , value-π₂≡[×π2]))
+              (λ i → ı _ , [×β2] V₁ V₂ i)
+              (elim-F-homᴰ V₁) (elim-F-homᴰ V₂) i
+          elim-F-homᴰ ([×η] M i) =
+            DA.value-×ηᴰ-on (elim-F-obᴰ _) (elim-F-obᴰ _)
+              value-π₁≡[×π1] value-π₂≡[×π2]
+              (λ i → ı _ , [×η] M i) (elim-F-homᴰ M) i
+          elim-F-homᴰ [0E] = Dᴰ.reind (ΣPathP (refl , refl)) DA.value-initial-elimᴰ
+          elim-F-homᴰ ([0η] M i) =
+            DA.value-initial-ηᴰ (ΣPathP (refl , refl))
+              (λ i → ı _ , [0η] M i) (elim-F-homᴰ M) i
+          elim-F-homᴰ [+I1] = Dᴰ.reind
+            (ΣPathP (refl , value-σ₁≡[+I1]))
+            (DA.value-σᴰ₁ (elim-F-obᴰ _) (elim-F-obᴰ _))
+          elim-F-homᴰ [+I2] = Dᴰ.reind
+            (ΣPathP (refl , value-σ₂≡[+I2]))
+            (DA.value-σᴰ₂ (elim-F-obᴰ _) (elim-F-obᴰ _))
+          elim-F-homᴰ ([+E] f g) = Dᴰ.reind (ΣPathP (refl , refl))
+            (DA.value-copairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (elim-F-homᴰ f) (elim-F-homᴰ g))
+          elim-F-homᴰ ([+β1] M₁ M₂ i) =
+            DA.value-+βᴰ₁-on (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (ΣPathP (refl , value-σ₁≡[+I1]))
+              (λ i → ı _ , [+β1] M₁ M₂ i)
+              (elim-F-homᴰ M₁) (elim-F-homᴰ M₂) i
+          elim-F-homᴰ ([+β2] M₁ M₂ i) =
+            DA.value-+βᴰ₂-on (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (ΣPathP (refl , value-σ₂≡[+I2]))
+              (λ i → ı _ , [+β2] M₁ M₂ i)
+              (elim-F-homᴰ M₁) (elim-F-homᴰ M₂) i
+          elim-F-homᴰ ([+η] M i) =
+            DA.value-+ηᴰ-on (elim-F-obᴰ _) (elim-F-obᴰ _)
+              value-σ₁≡[+I1] value-σ₂≡[+I2]
+              (λ i → ı _ , [+η] M i) (elim-F-homᴰ M) i
+          elim-F-homᴰ [⊤I] = Dᴰ.reind (ΣPathP (refl , refl)) DA.computation-terminal-introᴰ
+          elim-F-homᴰ ([⊤η] M i) =
+            DA.computation-terminal-ηᴰ (ΣPathP (refl , refl))
+              (λ i → ı _ , [⊤η] M i)
+              (elim-F-homᴰ M) i
+          elim-F-homᴰ ([&I] M₁ M₂) = Dᴰ.reind (ΣPathP (refl , refl))
+            (DA.computation-pairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (elim-F-homᴰ M₁) (elim-F-homᴰ M₂))
+          elim-F-homᴰ [&π1] = Dᴰ.reind
+            (ΣPathP (refl , computation-π₁≡[&π1]))
+            (DA.computation-πᴰ₁ (elim-F-obᴰ _) (elim-F-obᴰ _))
+          elim-F-homᴰ [&π2] = Dᴰ.reind
+            (ΣPathP (refl , computation-π₂≡[&π2]))
+            (DA.computation-πᴰ₂ (elim-F-obᴰ _) (elim-F-obᴰ _))
+          elim-F-homᴰ ([&β1] M₁ M₂ i) =
+            DA.computation-×βᴰ₁-on (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (ΣPathP (refl , computation-π₁≡[&π1]))
+              (λ i → ı _ , [&β1] M₁ M₂ i)
+              (elim-F-homᴰ M₁) (elim-F-homᴰ M₂) i
+          elim-F-homᴰ ([&β2] M₁ M₂ i) =
+            DA.computation-×βᴰ₂-on (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (ΣPathP (refl , computation-π₂≡[&π2]))
+              (λ i → ı _ , [&β2] M₁ M₂ i)
+              (elim-F-homᴰ M₁) (elim-F-homᴰ M₂) i
+          elim-F-homᴰ ([&η] M i) =
+            DA.computation-×ηᴰ-on (elim-F-obᴰ _) (elim-F-obᴰ _)
+              computation-π₁≡[&π1] computation-π₂≡[&π2]
+              (λ i → ı _ , [&η] M i) (elim-F-homᴰ M) i
+          elim-F-homᴰ ([op] op γ) =
+            DAlg .fst (elim-F-obᴰ _) (elim-F-obᴰ _)
+              op γ (λ v → elim-F-homᴰ (γ v)) ([op] op γ) refl
+          elim-F-homᴰ ([op-homL] V op γ i) =
+            hSetReasoning.rectifyOut (_ , isSetTm)
+              (λ N → Dᴰ.Hom[ ı _ , N ][ elim-F-obᴰ _ , elim-F-obᴰ _ ])
+              {e' = [op-homL] V op γ}
+              ((λ j → seqS V ([op] op γ) , sym homo-law j)
+                ∙ (λ j → [op-homL] V op γ j , op-path j)) i
+            where
+            base-square : Square
+              (Subst-Homo V _ op γ ([op] op γ) refl)
+              refl refl ([op-homL] V op γ)
+            base-square = isSet→Square isSetTm refl ([op-homL] V op γ)
+              (Subst-Homo V _ op γ ([op] op γ) refl) refl
+
+            op-path : PathP
+              (λ i → Dᴰ.Hom[ ı _ , [op-homL] V op γ i ][
+                elim-F-obᴰ _ , elim-F-obᴰ _ ])
+              (DAlg .fst (elim-F-obᴰ _) (elim-F-obᴰ _)
+                op (λ v → seqS V (γ v))
+                (λ v → elim-F-homᴰ V Dᴰ.⋆ᴰ elim-F-homᴰ (γ v))
+                (seqS V ([op] op γ)) (base-square i0))
+              (DAlg .fst (elim-F-obᴰ _) (elim-F-obᴰ _)
+                op (λ v → seqS V (γ v))
+                (λ v → elim-F-homᴰ V Dᴰ.⋆ᴰ elim-F-homᴰ (γ v))
+                ([op] op (λ v → seqS V (γ v))) refl)
+            op-path i =
+              DAlg .fst (elim-F-obᴰ _) (elim-F-obᴰ _)
+                op (λ v → seqS V (γ v))
+                (λ v → elim-F-homᴰ V Dᴰ.⋆ᴰ elim-F-homᴰ (γ v))
+                ([op-homL] V op γ i) (λ j → base-square i j)
+
+            op-sourceᴰ = DAlg .fst (elim-F-obᴰ _) (elim-F-obᴰ _)
+              op γ (λ v → elim-F-homᴰ (γ v)) ([op] op γ) refl
+
+            homo-law = DAlg .snd .fst (elim-F-homᴰ V)
+              op γ (λ v → elim-F-homᴰ (γ v))
+              ([op] op γ) refl op-sourceᴰ refl
+          elim-F-homᴰ ([op-homR] op γ S i) =
+            hSetReasoning.rectifyOut (_ , isSetTm)
+              (λ N → Dᴰ.Hom[ ı _ , N ][ elim-F-obᴰ _ , elim-F-obᴰ _ ])
+              {e' = [op-homR] op γ S}
+              ((λ j → seqS ([op] op γ) S , sym homo-law j)
+                ∙ (λ j → [op-homR] op γ S j , op-path j)) i
+            where
+            base-square : Square
+              (Plug-Homo S _ op γ ([op] op γ) refl)
+              refl refl ([op-homR] op γ S)
+            base-square = isSet→Square isSetTm refl ([op-homR] op γ S)
+              (Plug-Homo S _ op γ ([op] op γ) refl) refl
+
+            op-path : PathP
+              (λ i → Dᴰ.Hom[ ı _ , [op-homR] op γ S i ][
+                elim-F-obᴰ _ , elim-F-obᴰ _ ])
+              (DAlg .fst (elim-F-obᴰ _) (elim-F-obᴰ _)
+                op (λ v → seqS (γ v) S)
+                (λ v → elim-F-homᴰ (γ v) Dᴰ.⋆ᴰ elim-F-homᴰ S)
+                (seqS ([op] op γ) S) (base-square i0))
+              (DAlg .fst (elim-F-obᴰ _) (elim-F-obᴰ _)
+                op (λ v → seqS (γ v) S)
+                (λ v → elim-F-homᴰ (γ v) Dᴰ.⋆ᴰ elim-F-homᴰ S)
+                ([op] op (λ v → seqS (γ v) S)) refl)
+            op-path i =
+              DAlg .fst (elim-F-obᴰ _) (elim-F-obᴰ _)
+                op (λ v → seqS (γ v) S)
+                (λ v → elim-F-homᴰ (γ v) Dᴰ.⋆ᴰ elim-F-homᴰ S)
+                ([op-homR] op γ S i) (λ j → base-square i j)
+
+            op-sourceᴰ = DAlg .fst (elim-F-obᴰ _) (elim-F-obᴰ _)
+              op γ (λ v → elim-F-homᴰ (γ v)) ([op] op γ) refl
+
+            homo-law = DAlg .snd .snd (elim-F-homᴰ S)
+              op γ (λ v → elim-F-homᴰ (γ v))
+              ([op] op γ) refl op-sourceᴰ refl
+
+          elim : GlobalSection Dᴰ
+          elim .F-obᴰ d = elim-F-obᴰ (d .snd)
+          elim .F-homᴰ f = elim-F-homᴰ (f .snd)
+          elim .F-idᴰ = refl
+          elim .F-seqᴰ _ _ = refl
+
+    module LocalElim
+      {C : CBPVCat ℓD ℓD'}
+      (F : Functorⱽ (AddCBPV .fst .fst) C)
+      (Cⱽ : AddCBPVCatⱽ C ℓCᴰ ℓCᴰ')
+      (CAlg : AlgebraEnrichment C Sig)
+      (FAlg : PreservesAlgebraEnrichment Sig F CBPVAlg CAlg)
+      (CᴰAlg : AlgebraEnrichmentᴰ Sig CAlg (Cⱽ .fst .fst))
+      where
+      private
+        module Cᴰ = Fibers (Cⱽ .fst .fst)
+
+        reindexed : AddCBPVCatᴰ AddCBPV ℓCᴰ ℓCᴰ'
+        reindexed = AddCBPVCatⱽ→ᴰ (AddCBPVCatⱽReindex Cⱽ F)
+
+        reindexedAlg :
+          AlgebraEnrichmentᴰ Sig CBPVAlg (reindexed .fst .fst)
+        reindexedAlg = AlgebraEnrichmentᴰReindex
+          Sig F CBPVAlg CAlg FAlg (Cⱽ .fst .fst) CᴰAlg
+
+      module _
+        (ı-ob : ∀ {k} (X : BaseTy k)
+          → Cᴰ.ob[ k , F .Functorᴰ.F-obᴰ (gen X) ])
+        where
+        local-obᴰ : ∀ Γ → Cᴰ.ob[ k , F .Functorᴰ.F-obᴰ Γ ]
+        local-obᴰ = Elim.elim-F-obᴰ reindexed reindexedAlg ı-ob
+
+        localElim :
+          (ı-hom : ∀ {k1 k2 Γ Δ} {k≤ : ≤Kind k1 k2} (M : Fun k≤ Γ Δ)
+            → Cᴰ.Hom[ _ , F .Functorᴰ.F-homᴰ (gen M) ][
+                local-obᴰ Γ , local-obᴰ Δ ])
+          → DisplayedSection (∫F F) (Cⱽ .fst .fst)
+        localElim ı-hom =
+          GlobalSectionReindex→Section (Cⱽ .fst .fst) (∫F F)
+            (Elim.elim reindexed reindexedAlg ı-ob ı-hom)

--- a/Cubical/Categories/Displayed/CBPV/Unary/Instances/Free/AlgEnriched/Additive.agda
+++ b/Cubical/Categories/Displayed/CBPV/Unary/Instances/Free/AlgEnriched/Additive.agda
@@ -416,14 +416,14 @@ module CBPV (Sig : Signature ℓO ℓA) (BaseTy : Kind → Type ℓ) where
             Uηᴰ Dᴰ (MultCBPV .snd .fst) (D .fst .snd .fst)
               (C.reind-filler⁻ _ ∙ C.≡in {pth = refl} (IdLS [force]))
               V (λ i → Category.id KIND , [Uη] V i) (elim-F-homᴰ V) i
-          elim-F-homᴰ [1I] = Dᴰ.reind (ΣPathP (refl , refl)) DA.value-terminal-introᴰ
+          elim-F-homᴰ [1I] = DA.value-terminal-introᴰ
           elim-F-homᴰ ([1η] V i) =
-            DA.value-terminal-ηᴰ (ΣPathP (refl , refl))
+            DA.value-terminal-ηᴰ-on
               (λ i → ı _ , [1η] V i)
               (elim-F-homᴰ V) i
-          elim-F-homᴰ ([×I] V₁ V₂) = Dᴰ.reind (ΣPathP (refl , refl))
-            (DA.value-pairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
-              (elim-F-homᴰ V₁) (elim-F-homᴰ V₂))
+          elim-F-homᴰ ([×I] V₁ V₂) =
+            DA.value-pairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (elim-F-homᴰ V₁) (elim-F-homᴰ V₂)
           elim-F-homᴰ [×π1] = Dᴰ.reind
             (ΣPathP (refl , value-π₁≡[×π1]))
             (DA.value-πᴰ₁ (elim-F-obᴰ _) (elim-F-obᴰ _))
@@ -444,9 +444,9 @@ module CBPV (Sig : Signature ℓO ℓA) (BaseTy : Kind → Type ℓ) where
             DA.value-×ηᴰ-on (elim-F-obᴰ _) (elim-F-obᴰ _)
               value-π₁≡[×π1] value-π₂≡[×π2]
               (λ i → ı _ , [×η] M i) (elim-F-homᴰ M) i
-          elim-F-homᴰ [0E] = Dᴰ.reind (ΣPathP (refl , refl)) DA.value-initial-elimᴰ
+          elim-F-homᴰ [0E] = DA.value-initial-elimᴰ
           elim-F-homᴰ ([0η] M i) =
-            DA.value-initial-ηᴰ (ΣPathP (refl , refl))
+            DA.value-initial-ηᴰ-on
               (λ i → ı _ , [0η] M i) (elim-F-homᴰ M) i
           elim-F-homᴰ [+I1] = Dᴰ.reind
             (ΣPathP (refl , value-σ₁≡[+I1]))
@@ -454,9 +454,9 @@ module CBPV (Sig : Signature ℓO ℓA) (BaseTy : Kind → Type ℓ) where
           elim-F-homᴰ [+I2] = Dᴰ.reind
             (ΣPathP (refl , value-σ₂≡[+I2]))
             (DA.value-σᴰ₂ (elim-F-obᴰ _) (elim-F-obᴰ _))
-          elim-F-homᴰ ([+E] f g) = Dᴰ.reind (ΣPathP (refl , refl))
-            (DA.value-copairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
-              (elim-F-homᴰ f) (elim-F-homᴰ g))
+          elim-F-homᴰ ([+E] f g) =
+            DA.value-copairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (elim-F-homᴰ f) (elim-F-homᴰ g)
           elim-F-homᴰ ([+β1] M₁ M₂ i) =
             DA.value-+βᴰ₁-on (elim-F-obᴰ _) (elim-F-obᴰ _)
               (ΣPathP (refl , value-σ₁≡[+I1]))
@@ -471,14 +471,14 @@ module CBPV (Sig : Signature ℓO ℓA) (BaseTy : Kind → Type ℓ) where
             DA.value-+ηᴰ-on (elim-F-obᴰ _) (elim-F-obᴰ _)
               value-σ₁≡[+I1] value-σ₂≡[+I2]
               (λ i → ı _ , [+η] M i) (elim-F-homᴰ M) i
-          elim-F-homᴰ [⊤I] = Dᴰ.reind (ΣPathP (refl , refl)) DA.computation-terminal-introᴰ
+          elim-F-homᴰ [⊤I] = DA.computation-terminal-introᴰ
           elim-F-homᴰ ([⊤η] M i) =
-            DA.computation-terminal-ηᴰ (ΣPathP (refl , refl))
+            DA.computation-terminal-ηᴰ-on
               (λ i → ı _ , [⊤η] M i)
               (elim-F-homᴰ M) i
-          elim-F-homᴰ ([&I] M₁ M₂) = Dᴰ.reind (ΣPathP (refl , refl))
-            (DA.computation-pairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
-              (elim-F-homᴰ M₁) (elim-F-homᴰ M₂))
+          elim-F-homᴰ ([&I] M₁ M₂) =
+            DA.computation-pairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (elim-F-homᴰ M₁) (elim-F-homᴰ M₂)
           elim-F-homᴰ [&π1] = Dᴰ.reind
             (ΣPathP (refl , computation-π₁≡[&π1]))
             (DA.computation-πᴰ₁ (elim-F-obᴰ _) (elim-F-obᴰ _))

--- a/Cubical/Categories/Displayed/CBPV/Unary/Instances/Free/BoolState/Additive.agda
+++ b/Cubical/Categories/Displayed/CBPV/Unary/Instances/Free/BoolState/Additive.agda
@@ -456,14 +456,14 @@ module CBPV (BaseTy : Kind → Type ℓ) where
             Uηᴰ Dᴰ (MultCBPV .snd .fst) (D .fst .snd .fst)
               (C.reind-filler⁻ _ ∙ C.≡in {pth = refl} (IdLS [force]))
               V (λ i → Category.id KIND , [Uη] V i) (elim-F-homᴰ V) i
-          elim-F-homᴰ [1I] = Dᴰ.reind (ΣPathP (refl , refl)) DA.value-terminal-introᴰ
+          elim-F-homᴰ [1I] = DA.value-terminal-introᴰ
           elim-F-homᴰ ([1η] V i) =
-            DA.value-terminal-ηᴰ (ΣPathP (refl , refl))
+            DA.value-terminal-ηᴰ-on
               (λ i → ı _ , [1η] V i)
               (elim-F-homᴰ V) i
-          elim-F-homᴰ ([×I] V₁ V₂) = Dᴰ.reind (ΣPathP (refl , refl))
-            (DA.value-pairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
-              (elim-F-homᴰ V₁) (elim-F-homᴰ V₂))
+          elim-F-homᴰ ([×I] V₁ V₂) =
+            DA.value-pairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (elim-F-homᴰ V₁) (elim-F-homᴰ V₂)
           elim-F-homᴰ [×π1] = Dᴰ.reind
             (ΣPathP (refl , value-π₁≡[×π1]))
             (DA.value-πᴰ₁ (elim-F-obᴰ _) (elim-F-obᴰ _))
@@ -484,9 +484,9 @@ module CBPV (BaseTy : Kind → Type ℓ) where
             DA.value-×ηᴰ-on (elim-F-obᴰ _) (elim-F-obᴰ _)
               value-π₁≡[×π1] value-π₂≡[×π2]
               (λ i → ı _ , [×η] M i) (elim-F-homᴰ M) i
-          elim-F-homᴰ [0E] = Dᴰ.reind (ΣPathP (refl , refl)) DA.value-initial-elimᴰ
+          elim-F-homᴰ [0E] = DA.value-initial-elimᴰ
           elim-F-homᴰ ([0η] M i) =
-            DA.value-initial-ηᴰ (ΣPathP (refl , refl))
+            DA.value-initial-ηᴰ-on
               (λ i → ı _ , [0η] M i) (elim-F-homᴰ M) i
           elim-F-homᴰ [+I1] = Dᴰ.reind
             (ΣPathP (refl , value-σ₁≡[+I1]))
@@ -494,9 +494,9 @@ module CBPV (BaseTy : Kind → Type ℓ) where
           elim-F-homᴰ [+I2] = Dᴰ.reind
             (ΣPathP (refl , value-σ₂≡[+I2]))
             (DA.value-σᴰ₂ (elim-F-obᴰ _) (elim-F-obᴰ _))
-          elim-F-homᴰ ([+E] f g) = Dᴰ.reind (ΣPathP (refl , refl))
-            (DA.value-copairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
-              (elim-F-homᴰ f) (elim-F-homᴰ g))
+          elim-F-homᴰ ([+E] f g) =
+            DA.value-copairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (elim-F-homᴰ f) (elim-F-homᴰ g)
           elim-F-homᴰ ([+β1] M₁ M₂ i) =
             DA.value-+βᴰ₁-on (elim-F-obᴰ _) (elim-F-obᴰ _)
               (ΣPathP (refl , value-σ₁≡[+I1]))
@@ -511,14 +511,14 @@ module CBPV (BaseTy : Kind → Type ℓ) where
             DA.value-+ηᴰ-on (elim-F-obᴰ _) (elim-F-obᴰ _)
               value-σ₁≡[+I1] value-σ₂≡[+I2]
               (λ i → ı _ , [+η] M i) (elim-F-homᴰ M) i
-          elim-F-homᴰ [⊤I] = Dᴰ.reind (ΣPathP (refl , refl)) DA.computation-terminal-introᴰ
+          elim-F-homᴰ [⊤I] = DA.computation-terminal-introᴰ
           elim-F-homᴰ ([⊤η] M i) =
-            DA.computation-terminal-ηᴰ (ΣPathP (refl , refl))
+            DA.computation-terminal-ηᴰ-on
               (λ i → ı _ , [⊤η] M i)
               (elim-F-homᴰ M) i
-          elim-F-homᴰ ([&I] M₁ M₂) = Dᴰ.reind (ΣPathP (refl , refl))
-            (DA.computation-pairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
-              (elim-F-homᴰ M₁) (elim-F-homᴰ M₂))
+          elim-F-homᴰ ([&I] M₁ M₂) =
+            DA.computation-pairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (elim-F-homᴰ M₁) (elim-F-homᴰ M₂)
           elim-F-homᴰ [&π1] = Dᴰ.reind
             (ΣPathP (refl , computation-π₁≡[&π1]))
             (DA.computation-πᴰ₁ (elim-F-obᴰ _) (elim-F-obᴰ _))

--- a/Cubical/Categories/Displayed/CBPV/Unary/Instances/Free/ModelEnriched/Additive.agda
+++ b/Cubical/Categories/Displayed/CBPV/Unary/Instances/Free/ModelEnriched/Additive.agda
@@ -1,0 +1,734 @@
+-- Parameterized unary CBPV syntax with finite additives and algebraic effects.
+{-# OPTIONS --lossy-unification --prop #-}
+module Cubical.Categories.Displayed.CBPV.Unary.Instances.Free.ModelEnriched.Additive where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Equiv.Dependent
+open import Cubical.Foundations.HLevels.More
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.More
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit
+open import Cubical.Prop
+
+open import Cubical.Algebra.Theory.Base
+  hiding (ℓ; ℓᴰ; ℓᴰᴰ; ℓ'; ℓᴰ'; ℓᴰᴰ'; ℓ''; ℓᴰ''; ℓO; ℓA; ℓE)
+
+open import Cubical.Categories.Category hiding (isIso)
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Functors.More
+open import Cubical.Categories.Instances.Fiber
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.TotalCategory hiding (elim)
+open import Cubical.Categories.Instances.WalkingArrow
+  renaming (WalkingArrow to KIND; Vertex to Kind; l to 𝒱; r to 𝒞; ≤Vertex to ≤Kind)
+open import Cubical.Categories.Limits.Terminal.More
+open import Cubical.Categories.Limits.BinProduct.More
+open import Cubical.Categories.Presheaf
+open import Cubical.Categories.Presheaf.More
+open import Cubical.Categories.Presheaf.Representable
+open import Cubical.Categories.Presheaf.Representable.More
+open import Cubical.Categories.Presheaf.Morphism.Alt
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Displayed.Section renaming (Section to DisplayedSection)
+open import Cubical.Categories.Displayed.Instances.Opposite
+open import Cubical.Categories.Displayed.Instances.Reindex
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Base
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Fibration
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Representable
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Constructions
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.UniversalProperties
+open import Cubical.Categories.Displayed.CBPV.Unary.Base
+open import Cubical.Categories.Displayed.CBPV.Unary.Additive
+open import Cubical.Categories.Displayed.CBPV.Unary.Enrichment.Algebra
+open import Cubical.Categories.Displayed.CBPV.Unary.Enrichment.Model
+
+private
+  variable
+    ℓ ℓ' ℓᴰ ℓᴰ' ℓD ℓD' ℓCᴰ ℓCᴰ' ℓO ℓA ℓE ℓEA : Level
+
+open Category
+open Categoryᴰ
+open UniversalElement
+open PshHom
+open isIsoOver
+open DisplayedSection
+
+module CBPV (T : Theory ℓO ℓA ℓE ℓEA) (BaseTy : Kind → Type ℓ) where
+  open Theory T
+  data Ob : Kind → Type ℓ where
+    gen : ∀ {k} → BaseTy k → Ob k
+    [F] : Ob 𝒱 → Ob 𝒞
+    [U] : Ob 𝒞 → Ob 𝒱
+    [1] [0] : Ob 𝒱
+    _[×]_ _[+]_ : Ob 𝒱 → Ob 𝒱 → Ob 𝒱
+    [⊤] : Ob 𝒞
+    _[&]_ : Ob 𝒞 → Ob 𝒞 → Ob 𝒞
+
+  VTy = Ob 𝒱
+  CTy = Ob 𝒞
+
+  module Terms (Fun : ∀ {k₁ k₂} → ≤Kind k₁ k₂ → Ob k₁ → Ob k₂ → Type ℓ') where
+    private
+      variable
+        k k₁ k₂ : Kind
+        Γ Δ Θ Ξ : Ob k
+        A A₁ A₂ : VTy
+        B B₁ B₂ : CTy
+        k≤ k≤' k≤'' : ≤Kind k₁ k₂
+
+    data Tm : (p : ≤Kind k₁ k₂) → Ob k₁ → Ob k₂
+      → Type
+          (ℓ-max (ℓ-max (ℓ-max ℓ ℓ') (ℓ-max ℓO ℓA))
+            (ℓ-max ℓE ℓEA)) where
+      gen : Fun k≤ Γ Δ → Tm k≤ Γ Δ
+      idS : Tm (≤V-refl k) Γ Γ
+      seqS : Tm k≤ Γ Δ → Tm k≤' Δ Θ → Tm (≤V-trans k≤ k≤') Γ Θ
+      IdLS : (f : Tm k≤ Γ Δ) → seqS idS f ≡ f
+      IdRS : (f : Tm k≤ Γ Δ) → seqS f idS ≡ f
+      AssocS : (f : Tm k≤ Γ Δ) (g : Tm k≤' Δ Θ)
+        (h : Tm k≤'' Θ Ξ) → seqS (seqS f g) h ≡ seqS f (seqS g h)
+      isSetTm : isSet (Tm k≤ Γ Δ)
+
+      -- Multiplicative sturcture
+      [ret] : Tm _ A ([F] A)
+      [bind] : Tm _ A B → Tm _ ([F] A) B
+      [Fβ] : (M : Tm _ A B) → seqS [ret] ([bind] M) ≡ M
+      [Fη] : (K : Tm _ ([F] A) B) → K ≡ [bind] (seqS [ret] K)
+      [force] : Tm _ ([U] B) B
+      [thunk] : Tm _ Γ B → Tm {k₁ = 𝒱} _ Γ ([U] B)
+      [Uβ] : (M : Tm _ A B) → seqS ([thunk] M) [force] ≡ M
+      [Uη] : (V : Tm _ Γ ([U] B)) → V ≡ [thunk] (seqS V [force])
+
+      -- Additive sturcture
+
+      -- value products
+      [1I] : Tm _ A [1]
+      [1η] : (V : Tm _ A [1]) → V ≡ [1I]
+      [×I] : Tm _ A A₁ → Tm _ A A₂ → Tm _ A (A₁ [×] A₂)
+      [×π1] : Tm _ (A₁ [×] A₂) A₁
+      [×π2] : Tm _ (A₁ [×] A₂) A₂
+      [×β1] : (V₁ : Tm _ A A₁) (V₂ : Tm _ A A₂) → seqS ([×I] V₁ V₂) [×π1] ≡ V₁
+      [×β2] : (V₁ : Tm _ A A₁) (V₂ : Tm _ A A₂) → seqS ([×I] V₁ V₂) [×π2] ≡ V₂
+      [×η] : (V : Tm _ A (A₁ [×] A₂)) →
+        V ≡ [×I] (seqS V [×π1]) (seqS V [×π2])
+
+      -- value coproducts
+      [0E] : Tm {k₁ = 𝒱} k≤ [0] Γ
+      [0η] : (V : Tm {k₁ = 𝒱} k≤ [0] Γ) → V ≡ [0E]
+      [+I1] : Tm _ A₁ (A₁ [+] A₂)
+      [+I2] : Tm _ A₂ (A₁ [+] A₂)
+      [+E] : Tm {k₁ = 𝒱} k≤ A₁ Γ → Tm {k₁ = 𝒱} k≤ A₂ Γ →
+        Tm {k₁ = 𝒱} k≤ (A₁ [+] A₂) Γ
+      [+β1] : (f : Tm {k₁ = 𝒱} k≤ A₁ Γ) (g : Tm {k₁ = 𝒱} k≤ A₂ Γ) →
+        seqS [+I1] ([+E] f g) ≡ f
+      [+β2] : (f : Tm {k₁ = 𝒱} k≤ A₁ Γ) (g : Tm {k₁ = 𝒱} k≤ A₂ Γ) →
+        seqS [+I2] ([+E] f g) ≡ g
+      [+η] : (f : Tm {k₁ = 𝒱} k≤ (A₁ [+] A₂) Γ) →
+        f ≡ [+E] (seqS [+I1] f) (seqS [+I2] f)
+
+      -- computation products
+      [⊤I] : Tm (≤V-r-⊤ k) Γ [⊤]
+      [⊤η] : (M : Tm (≤V-r-⊤ k) Γ [⊤]) → M ≡ [⊤I]
+      [&I] : Tm (≤V-r-⊤ k) Γ B₁ → Tm (≤V-r-⊤ k) Γ B₂ →
+        Tm (≤V-r-⊤ k) Γ (B₁ [&] B₂)
+      [&π1] : Tm _ (B₁ [&] B₂) B₁
+      [&π2] : Tm _ (B₁ [&] B₂) B₂
+      [&β1] : (M₁ : Tm (≤V-r-⊤ k) Γ B₁) (M₂ : Tm (≤V-r-⊤ k) Γ B₂) →
+        seqS ([&I] M₁ M₂) [&π1] ≡ M₁
+      [&β2] : (M₁ : Tm (≤V-r-⊤ k) Γ B₁) (M₂ : Tm (≤V-r-⊤ k) Γ B₂) →
+        seqS ([&I] M₁ M₂) [&π2] ≡ M₂
+      [&η] : (M : Tm (≤V-r-⊤ k) Γ (B₁ [&] B₂)) →
+        M ≡ [&I] (seqS M [&π1]) (seqS M [&π2])
+
+      -- Algebraic operations
+      [op] : (op : Op) → (Arity op → Tm _ A B) → Tm _ A B
+
+      -- Equations of the theory. The auxiliary free-algebra constructor
+      -- keeps all recursive occurrences of Tm strictly positive.
+      [freeAlg] : ∀ e → |FreeAlgebra| (EqArity e)
+        → (EqArity e → Tm _ A B) → Tm _ A B
+      [freeAlgEqn] : ∀ e (γ : EqArity e → Tm _ A B)
+        → [freeAlg] e (lhs e) γ ≡ [freeAlg] e (rhs e) γ
+      [freeAlg-var] : ∀ e v (γ : EqArity e → Tm _ A B)
+        → γ v ≡ [freeAlg] e (S.var v) γ
+      [freeAlg-op] : ∀ e op γ (γ' : EqArity e → Tm _ A B)
+        → [op] op (λ v → [freeAlg] e (γ v) γ')
+          ≡ [freeAlg] e (S.app op γ) γ'
+
+      [op-homL] : (V : Tm _ A A₁) (op : Op) (γ : Arity op → Tm _ A₁ B)
+        → seqS V ([op] op γ) ≡ [op] op (λ v → seqS V (γ v))
+      [op-homR] : (op : Op) (γ : Arity op → Tm _ A B) (S : Tm _ B B₁)
+        → seqS ([op] op γ) S ≡ [op] op (λ v → seqS (γ v) S)
+
+    CBPV : CBPVCat ℓ
+      (ℓ-max (ℓ-max (ℓ-max ℓ ℓ') (ℓ-max ℓO ℓA))
+        (ℓ-max ℓE ℓEA))
+    CBPV .ob[_] = Ob
+    CBPV .Hom[_][_,_] p = Tm (p .Prop→Type.pf)
+    CBPV .idᴰ = idS
+    CBPV ._⋆ᴰ_ = seqS
+    CBPV .⋆IdLᴰ = IdLS
+    CBPV .⋆IdRᴰ = IdRS
+    CBPV .⋆Assocᴰ = AssocS
+    CBPV .isSetHomᴰ = isSetTm
+
+    module C = Fibers CBPV
+
+    module Cop = Fibers (CBPV ^opᴰ)
+
+    value-terminalⱽ : Terminalⱽ CBPV 𝒱
+    value-terminalⱽ = UniversalElementⱽ'.REPRⱽ ue
+      where
+      ue : UniversalElementⱽ' CBPV 𝒱 UnitPshᴰ
+      ue .UniversalElementⱽ'.vertexⱽ = [1]
+      ue .UniversalElementⱽ'.elementⱽ = tt
+      ue .UniversalElementⱽ'.universalⱽ (𝒱 , A , f) .fst _ = [1I]
+      ue .UniversalElementⱽ'.universalⱽ (𝒱 , A , f) .snd .fst _ = refl
+      ue .UniversalElementⱽ'.universalⱽ (𝒱 , A , f) .snd .snd V = sym ([1η] V)
+
+    value-productⱽ : ∀ A₁ A₂ → BinProductⱽ CBPV A₁ A₂
+    value-productⱽ A₁ A₂ = UniversalElementⱽ'.REPRⱽ ue
+      where
+      ue : UniversalElementⱽ' CBPV 𝒱 (BinProductⱽSpec CBPV A₁ A₂)
+      ue .UniversalElementⱽ'.vertexⱽ = A₁ [×] A₂
+      ue .UniversalElementⱽ'.elementⱽ = [×π1] , [×π2]
+      ue .UniversalElementⱽ'.universalⱽ (𝒱 , A , f) .fst V = [×I] (V .fst) (V .snd)
+      ue .UniversalElementⱽ'.universalⱽ (𝒱 , A , f) .snd .fst V =
+        ΣPathP
+          ( C.rectifyOut {e' = refl}
+              (C.reind-filler⁻ _ ∙ C.≡in {pth = refl} ([×β1] (V .fst) (V .snd)))
+          , C.rectifyOut {e' = refl}
+              (C.reind-filler⁻ _ ∙ C.≡in {pth = refl} ([×β2] (V .fst) (V .snd))))
+      ue .UniversalElementⱽ'.universalⱽ (𝒱 , A , f) .snd .snd V =
+        cong₂ [×I]
+          (C.rectifyOut {e' = refl} (C.reind-filler⁻ _))
+          (C.rectifyOut {e' = refl} (C.reind-filler⁻ _))
+        ∙ sym ([×η] V)
+
+    value-initialⱽ : Initialⱽ CBPV 𝒱
+    value-initialⱽ = UniversalElementⱽ'.REPRⱽ ue
+      where
+      ue : UniversalElementⱽ' (CBPV ^opᴰ) 𝒱 UnitPshᴰ
+      ue .UniversalElementⱽ'.vertexⱽ = [0]
+      ue .UniversalElementⱽ'.elementⱽ = tt
+      ue .UniversalElementⱽ'.universalⱽ (k , A , f) .fst _ = [0E]
+      ue .UniversalElementⱽ'.universalⱽ (k , A , f) .snd .fst _ = refl
+      ue .UniversalElementⱽ'.universalⱽ (k , A , f) .snd .snd V = sym ([0η] V)
+
+    value-coproductⱽ : ∀ A₁ A₂ → BinCoProductⱽ CBPV A₁ A₂
+    value-coproductⱽ A₁ A₂ = UniversalElementⱽ'.REPRⱽ ue
+      where
+      ue : UniversalElementⱽ' (CBPV ^opᴰ) 𝒱
+        (BinProductⱽSpec (CBPV ^opᴰ) A₁ A₂)
+      ue .UniversalElementⱽ'.vertexⱽ = A₁ [+] A₂
+      ue .UniversalElementⱽ'.elementⱽ = [+I1] , [+I2]
+      ue .UniversalElementⱽ'.universalⱽ (k , A , f) .fst V = [+E] (V .fst) (V .snd)
+      ue .UniversalElementⱽ'.universalⱽ (k , A , f) .snd .fst V =
+        ΣPathP
+          ( Cop.rectifyOut {e' = refl}
+              (Cop.reind-filler⁻ _ ∙ Cop.≡in {pth = refl} ([+β1] (V .fst) (V .snd)))
+          , Cop.rectifyOut {e' = refl}
+              (Cop.reind-filler⁻ _ ∙ Cop.≡in {pth = refl} ([+β2] (V .fst) (V .snd))))
+      ue .UniversalElementⱽ'.universalⱽ (k , A , f) .snd .snd V =
+        cong₂ [+E]
+          (Cop.rectifyOut {e' = refl} (Cop.reind-filler⁻ _))
+          (Cop.rectifyOut {e' = refl} (Cop.reind-filler⁻ _))
+        ∙ sym ([+η] V)
+
+    computation-terminalⱽ : Terminalⱽ CBPV 𝒞
+    computation-terminalⱽ = UniversalElementⱽ'.REPRⱽ ue
+      where
+      ue : UniversalElementⱽ' CBPV 𝒞 UnitPshᴰ
+      ue .UniversalElementⱽ'.vertexⱽ = [⊤]
+      ue .UniversalElementⱽ'.elementⱽ = tt
+      ue .UniversalElementⱽ'.universalⱽ (k , B , f) .fst _ = [⊤I]
+      ue .UniversalElementⱽ'.universalⱽ (k , B , f) .snd .fst _ = refl
+      ue .UniversalElementⱽ'.universalⱽ (k , B , f) .snd .snd M = sym ([⊤η] M)
+
+    computation-productⱽ : ∀ B₁ B₂ → BinProductⱽ CBPV B₁ B₂
+    computation-productⱽ B₁ B₂ = UniversalElementⱽ'.REPRⱽ ue
+      where
+      ue : UniversalElementⱽ' CBPV 𝒞 (BinProductⱽSpec CBPV B₁ B₂)
+      ue .UniversalElementⱽ'.vertexⱽ = B₁ [&] B₂
+      ue .UniversalElementⱽ'.elementⱽ = [&π1] , [&π2]
+      ue .UniversalElementⱽ'.universalⱽ (k , B , f) .fst M = [&I] (M .fst) (M .snd)
+      ue .UniversalElementⱽ'.universalⱽ (k , B , f) .snd .fst M =
+        ΣPathP
+          ( C.rectifyOut {e' = refl}
+              (C.reind-filler⁻ _ ∙ C.≡in {pth = refl} ([&β1] (M .fst) (M .snd)))
+          , C.rectifyOut {e' = refl}
+              (C.reind-filler⁻ _ ∙ C.≡in {pth = refl} ([&β2] (M .fst) (M .snd))))
+      ue .UniversalElementⱽ'.universalⱽ (k , B , f) .snd .snd M =
+        cong₂ [&I]
+          (C.rectifyOut {e' = refl} (C.reind-filler⁻ _))
+          (C.rectifyOut {e' = refl} (C.reind-filler⁻ _))
+        ∙ sym ([&η] M)
+
+    [U]-UMPPath : hasU CBPV
+    [U]-UMPPath B = UniversalElementⱽ'.REPRⱽ ue
+      where
+      ue : UniversalElementⱽ' CBPV 𝒱
+        (CartesianLiftPshSpec (KIND [-, 𝒞 ]) CBPV (CBPV [-][-, B ]) (ı tt))
+      ue .UniversalElementⱽ'.vertexⱽ = [U] B
+      ue .UniversalElementⱽ'.elementⱽ = [force]
+      ue .UniversalElementⱽ'.universalⱽ (𝒱 , A , f) .fst = [thunk]
+      ue .UniversalElementⱽ'.universalⱽ (𝒱 , A , f) .snd .fst M =
+        C.rectifyOut {e' = refl}
+          (C.reind-filler⁻ _ ∙ C.≡in {pth = refl} ([Uβ] M))
+      ue .UniversalElementⱽ'.universalⱽ (𝒱 , A , f) .snd .snd V =
+        cong [thunk] (C.rectifyOut {e' = refl} (C.reind-filler⁻ _))
+        ∙ sym ([Uη] V)
+
+    [F]-UMPPath : hasF CBPV
+    [F]-UMPPath A = UniversalElementⱽ'.REPRⱽ ue
+      where
+      ue : UniversalElementⱽ' (CBPV ^opᴰ) 𝒞
+        (CartesianLiftPshSpec ((KIND ^op) [-, 𝒱 ]) (CBPV ^opᴰ)
+          ((CBPV ^opᴰ) [-][-, A ]) (ı tt))
+      ue .UniversalElementⱽ'.vertexⱽ = [F] A
+      ue .UniversalElementⱽ'.elementⱽ = [ret]
+      ue .UniversalElementⱽ'.universalⱽ (𝒞 , B , f) .fst = [bind]
+      ue .UniversalElementⱽ'.universalⱽ (𝒞 , B , f) .snd .fst M =
+        Cop.rectifyOut {e' = refl}
+          (Cop.reind-filler⁻ _ ∙ Cop.≡in {pth = refl} ([Fβ] M))
+      ue .UniversalElementⱽ'.universalⱽ (𝒞 , B , f) .snd .snd K =
+        cong [bind] (Cop.rectifyOut {e' = refl} (Cop.reind-filler⁻ _))
+        ∙ sym ([Fη] K)
+
+    MultCBPV : MultCBPVCat _ _
+    MultCBPV = CBPV , [U]-UMPPath , [F]-UMPPath
+
+    AlgebraEff : ∀ (A : Ob 𝒱) (B : Ob 𝒞)
+      → AlgebraWithCarrier (CBPV [ _ ][ A , B ])
+    AlgebraEff A B = [op]
+
+    freeAlg≡interp : ∀ {A B} e (t : |FreeAlgebra| (EqArity e))
+      (γ : EqArity e → Tm _ A B)
+      → interp (_ , AlgebraEff A B) γ t ≡ [freeAlg] e t γ
+    freeAlg≡interp e (S.var v) γ = [freeAlg-var] e v γ
+    freeAlg≡interp e (S.app op γ) γ' =
+      (λ i → [op] op (λ v → freeAlg≡interp e (γ v) γ' i))
+      ∙ [freeAlg-op] e op γ γ'
+
+    ModelEff : ∀ (A : Ob 𝒱) (B : Ob 𝒞) →
+      Σ[ α ∈ AlgebraWithCarrier (CBPV [ _ ][ A , B ]) ]
+        IsModel (_ , α)
+    ModelEff A B .fst = AlgebraEff A B
+    ModelEff A B .snd e γ =
+      freeAlg≡interp e (lhs e) γ
+      ∙ [freeAlgEqn] e γ
+      ∙ sym (freeAlg≡interp e (rhs e) γ)
+
+    Subst-Homo : ∀ {A A'} (V : Tm _ A A') B
+      → isHomoSimpl (_ , AlgebraEff A' B) (_ , AlgebraEff A B)
+          (seqS {k≤ = tt} V)
+    Subst-Homo V B op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+      sym ([op-homL] V op γ) ∙ cong (seqS V) op∘γ≡op⟨γ⟩
+
+    Plug-Homo : ∀ {B B'} (S : Tm _ B B') A
+      → isHomoSimpl (_ , AlgebraEff A B) (_ , AlgebraEff A B')
+          (λ M → seqS {k≤' = tt} M S)
+    Plug-Homo S A op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+      sym ([op-homR] op γ S) ∙ cong (λ M → seqS M S) op∘γ≡op⟨γ⟩
+
+    CBPVAlg : AlgebraEnrichment CBPV S
+    CBPVAlg .fst = AlgebraEff
+    CBPVAlg .snd .fst = Subst-Homo
+    CBPVAlg .snd .snd = Plug-Homo
+
+    CBPVModel : ModelEnrichment CBPV T
+    CBPVModel .fst = ModelEff
+    CBPVModel .snd .fst = Subst-Homo
+    CBPVModel .snd .snd = Plug-Homo
+
+    AddCBPV : AddCBPVCat _ _
+    AddCBPV = MultCBPV , value-terminalⱽ , value-productⱽ
+      , value-initialⱽ , value-coproductⱽ
+      , computation-terminalⱽ , computation-productⱽ
+
+    module Elim
+      (D : AddCBPVCatᴰ AddCBPV ℓᴰ ℓᴰ')
+      (DModel : ModelEnrichmentᴰ T CBPVModel (D .fst .fst))
+      where
+      private
+        Dᴰ = D .fst .fst
+        module Dᴰ = Fibers Dᴰ
+        module Dᴰop = Fibers (Dᴰ ^opᴰᴰ)
+
+        DAlg : AlgebraEnrichmentᴰ S CBPVAlg Dᴰ
+        DAlg .fst Aᴰ Bᴰ = DModel .fst Aᴰ Bᴰ .fst
+        DAlg .snd = DModel .snd
+
+      module _ (ı-Ob : ∀ {k} (X : BaseTy k) → Dᴰ.ob[ k , gen X ]) where
+        elim-F-obᴰ : ∀ {k} (X : Ob k) → Dᴰ.ob[ k , X ]
+        elim-F-obᴰ (gen X) = ı-Ob X
+        elim-F-obᴰ ([F] A) = D .fst .snd .snd (elim-F-obᴰ A) .fst
+        elim-F-obᴰ ([U] B) = D .fst .snd .fst (elim-F-obᴰ B) .fst
+        elim-F-obᴰ [1] = D .snd .fst .fst
+        elim-F-obᴰ (A₁ [×] A₂) =
+          D .snd .snd .fst A₁ A₂ (elim-F-obᴰ A₁) (elim-F-obᴰ A₂) .fst
+        elim-F-obᴰ [0] = D .snd .snd .snd .fst .fst
+        elim-F-obᴰ (A₁ [+] A₂) =
+          D .snd .snd .snd .snd .fst A₁ A₂ (elim-F-obᴰ A₁) (elim-F-obᴰ A₂) .fst
+        elim-F-obᴰ [⊤] = D .snd .snd .snd .snd .snd .fst .fst
+        elim-F-obᴰ (B₁ [&] B₂) =
+          D .snd .snd .snd .snd .snd .snd B₁ B₂ (elim-F-obᴰ B₁) (elim-F-obᴰ B₂) .fst
+
+        private
+          module DA = AddCBPVCatᴰNotation AddCBPV D
+
+          value-π₁≡[×π1] : ∀ {A₁ A₂} →
+            BinProductⱽNotation.π₁ CBPV (value-productⱽ A₁ A₂) ≡ [×π1]
+          value-π₁≡[×π1] = C.rectifyOut {e' = refl}
+            (C.reind-filler⁻ (Category.⋆IdR KIND _) ∙ C.≡in {pth = refl} (IdLS [×π1]))
+
+          value-π₂≡[×π2] : ∀ {A₁ A₂} →
+            BinProductⱽNotation.π₂ CBPV (value-productⱽ A₁ A₂) ≡ [×π2]
+          value-π₂≡[×π2] = C.rectifyOut {e' = refl}
+            (C.reind-filler⁻ (Category.⋆IdR KIND _) ∙ C.≡in {pth = refl} (IdLS [×π2]))
+
+          value-σ₁≡[+I1] : ∀ {A₁ A₂} →
+            BinProductⱽNotation.π₁ (CBPV ^opᴰ) (value-coproductⱽ A₁ A₂) ≡ [+I1]
+          value-σ₁≡[+I1] = Cop.rectifyOut {e' = refl}
+            (Cop.reind-filler⁻ (Category.⋆IdR (KIND ^op) _) ∙ Cop.≡in {pth = refl} (IdRS [+I1]))
+
+          value-σ₂≡[+I2] : ∀ {A₁ A₂} →
+            BinProductⱽNotation.π₂ (CBPV ^opᴰ) (value-coproductⱽ A₁ A₂) ≡ [+I2]
+          value-σ₂≡[+I2] = Cop.rectifyOut {e' = refl}
+            (Cop.reind-filler⁻ (Category.⋆IdR (KIND ^op) _) ∙ Cop.≡in {pth = refl} (IdRS [+I2]))
+
+          computation-π₁≡[&π1] : ∀ {B₁ B₂} →
+            BinProductⱽNotation.π₁ CBPV (computation-productⱽ B₁ B₂) ≡ [&π1]
+          computation-π₁≡[&π1] = C.rectifyOut {e' = refl}
+            (C.reind-filler⁻ (Category.⋆IdR KIND _) ∙ C.≡in {pth = refl} (IdLS [&π1]))
+
+          computation-π₂≡[&π2] : ∀ {B₁ B₂} →
+            BinProductⱽNotation.π₂ CBPV (computation-productⱽ B₁ B₂) ≡ [&π2]
+          computation-π₂≡[&π2] = C.rectifyOut {e' = refl}
+            (C.reind-filler⁻ (Category.⋆IdR KIND _) ∙ C.≡in {pth = refl} (IdLS [&π2]))
+
+        retᴰ : ∀ {A} → Dᴰ.Hom[ ı tt , [ret] ][ elim-F-obᴰ A , elim-F-obᴰ ([F] A) ]
+        retᴰ = Dᴰ.reind
+          (Cop.reind-filler⁻ _ ∙ Cop.≡in {pth = refl} (IdRS [ret]))
+          (D .fst .snd .snd (elim-F-obᴰ _) .snd .fst .PshHom.N-ob _ Dᴰop.idᴰ)
+
+        bindᴰ : ∀ {A B} (M : Tm _ A B)
+          → Dᴰ.Hom[ ı tt , M ][ elim-F-obᴰ A , elim-F-obᴰ B ]
+          → Dᴰ.Hom[ Category.id KIND , [bind] M ][ elim-F-obᴰ ([F] A) , elim-F-obᴰ B ]
+        bindᴰ {A = A} M Mᴰ = D .fst .snd .snd (elim-F-obᴰ A)
+          .snd .snd _ _ .isIsoOver.inv _ Mᴰ
+
+        private
+          module HomReasoning {A : Ob 𝒱} {B : Ob 𝒞} = hSetReasoning
+            (CBPV [ _ ][ A , B ] , isSetTm)
+            (λ M → Dᴰ.Hom[ ı tt , M ][ elim-F-obᴰ A , elim-F-obᴰ B ])
+
+        freeAlgTmᴰ : ∀ {A : Ob 𝒱} {B : Ob 𝒞}
+          e (t : |FreeAlgebra| (EqArity e))
+          (ρ : EqArity e → Tm _ A B)
+          (ρᴰ : (v : EqArity e) →
+            Dᴰ.Hom[ ı tt , ρ v ][ elim-F-obᴰ A , elim-F-obᴰ B ])
+          → Dᴰ.Hom[ ı tt , [freeAlg] e t ρ ][
+              elim-F-obᴰ A , elim-F-obᴰ B ]
+        freeAlgTmᴰ {A} {B} e t ρ ρᴰ =
+          HomReasoning.reind (freeAlg≡interp e t ρ)
+            (interpᴰ
+              (_ , DAlg .fst (elim-F-obᴰ A) (elim-F-obᴰ B))
+              ρ ρᴰ t)
+
+        freeAlgTmᴰ-filler : ∀ {A : Ob 𝒱} {B : Ob 𝒞}
+          e (t : |FreeAlgebra| (EqArity e))
+          (ρ : EqArity e → Tm _ A B)
+          (ρᴰ : (v : EqArity e) →
+            Dᴰ.Hom[ ı tt , ρ v ][ elim-F-obᴰ A , elim-F-obᴰ B ])
+          → Path
+              (Σ[ M ∈ Tm tt A B ]
+                Dᴰ.Hom[ ı tt , M ][ elim-F-obᴰ A , elim-F-obᴰ B ])
+              ( interp (_ , AlgebraEff A B) ρ t
+              , interpᴰ
+                  (_ , DAlg .fst (elim-F-obᴰ A) (elim-F-obᴰ B))
+                  ρ ρᴰ t)
+              ([freeAlg] e t ρ , freeAlgTmᴰ e t ρ ρᴰ)
+        freeAlgTmᴰ-filler e t ρ ρᴰ =
+          HomReasoning.reind-filler (freeAlg≡interp e t ρ)
+
+        module _
+          (ı-Fun : ∀ {k₁ k₂ Γ Δ} {k≤ : ≤Kind k₁ k₂} (M : Fun k≤ Γ Δ)
+            → Dᴰ.Hom[ ı k≤ , gen M ][ elim-F-obᴰ Γ , elim-F-obᴰ Δ ])
+          where
+          elim-F-homᴰ : (M : Tm k≤ Γ Δ)
+            → Dᴰ.Hom[ ı k≤ , M ][ elim-F-obᴰ Γ , elim-F-obᴰ Δ ]
+          elim-F-homᴰ (gen f) = ı-Fun f
+          elim-F-homᴰ idS = Dᴰ.idᴰ
+          elim-F-homᴰ (seqS M N) = elim-F-homᴰ M Dᴰ.⋆ᴰ elim-F-homᴰ N
+          elim-F-homᴰ (IdLS M i) = Dᴰ.⋆IdLᴰ (elim-F-homᴰ M) i
+          elim-F-homᴰ (IdRS M i) = Dᴰ.⋆IdRᴰ (elim-F-homᴰ M) i
+          elim-F-homᴰ (AssocS L M N i) =
+            Dᴰ.⋆Assocᴰ (elim-F-homᴰ L) (elim-F-homᴰ M) (elim-F-homᴰ N) i
+          elim-F-homᴰ (isSetTm M N p q i j) = isSet→isSetDep
+            (λ _ → Dᴰ.isSetHomᴰ) (elim-F-homᴰ M) (elim-F-homᴰ N)
+            (cong elim-F-homᴰ p) (cong elim-F-homᴰ q) (isSetTm M N p q) i j
+          elim-F-homᴰ [ret] = retᴰ
+          elim-F-homᴰ ([bind] M) = bindᴰ M (elim-F-homᴰ M)
+          elim-F-homᴰ ([Fβ] M i) =
+            Fβᴰ Dᴰ (MultCBPV .snd .snd) (D .fst .snd .snd)
+              (Cop.reind-filler⁻ _ ∙ Cop.≡in {pth = refl} (IdRS [ret]))
+              M (λ i → ı tt , [Fβ] M i) (elim-F-homᴰ M) i
+          elim-F-homᴰ ([Fη] K i) =
+            Fηᴰ Dᴰ (MultCBPV .snd .snd) (D .fst .snd .snd)
+              (Cop.reind-filler⁻ _ ∙ Cop.≡in {pth = refl} (IdRS [ret]))
+              K (λ i → Category.id KIND , [Fη] K i) (elim-F-homᴰ K) i
+          elim-F-homᴰ [force] = Dᴰ.reind
+            (C.reind-filler⁻ _ ∙ C.≡in {pth = refl} (IdLS [force]))
+            (forceᴰ Dᴰ (MultCBPV .snd .fst) (D .fst .snd .fst))
+          elim-F-homᴰ ([thunk] M) =
+            thunkᴰ Dᴰ (MultCBPV .snd .fst) (D .fst .snd .fst) M (elim-F-homᴰ M)
+          elim-F-homᴰ ([Uβ] M i) =
+            Uβᴰ Dᴰ (MultCBPV .snd .fst) (D .fst .snd .fst)
+              (C.reind-filler⁻ _ ∙ C.≡in {pth = refl} (IdLS [force]))
+              M (λ i → ı tt , [Uβ] M i) (elim-F-homᴰ M) i
+          elim-F-homᴰ ([Uη] V i) =
+            Uηᴰ Dᴰ (MultCBPV .snd .fst) (D .fst .snd .fst)
+              (C.reind-filler⁻ _ ∙ C.≡in {pth = refl} (IdLS [force]))
+              V (λ i → Category.id KIND , [Uη] V i) (elim-F-homᴰ V) i
+          elim-F-homᴰ [1I] = Dᴰ.reind (ΣPathP (refl , refl)) DA.value-terminal-introᴰ
+          elim-F-homᴰ ([1η] V i) =
+            DA.value-terminal-ηᴰ (ΣPathP (refl , refl))
+              (λ i → ı _ , [1η] V i)
+              (elim-F-homᴰ V) i
+          elim-F-homᴰ ([×I] V₁ V₂) = Dᴰ.reind (ΣPathP (refl , refl))
+            (DA.value-pairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (elim-F-homᴰ V₁) (elim-F-homᴰ V₂))
+          elim-F-homᴰ [×π1] = Dᴰ.reind
+            (ΣPathP (refl , value-π₁≡[×π1]))
+            (DA.value-πᴰ₁ (elim-F-obᴰ _) (elim-F-obᴰ _))
+          elim-F-homᴰ [×π2] = Dᴰ.reind
+            (ΣPathP (refl , value-π₂≡[×π2]))
+            (DA.value-πᴰ₂ (elim-F-obᴰ _) (elim-F-obᴰ _))
+          elim-F-homᴰ ([×β1] V₁ V₂ i) =
+            DA.value-×βᴰ₁-on (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (ΣPathP (refl , value-π₁≡[×π1]))
+              (λ i → ı _ , [×β1] V₁ V₂ i)
+              (elim-F-homᴰ V₁) (elim-F-homᴰ V₂) i
+          elim-F-homᴰ ([×β2] V₁ V₂ i) =
+            DA.value-×βᴰ₂-on (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (ΣPathP (refl , value-π₂≡[×π2]))
+              (λ i → ı _ , [×β2] V₁ V₂ i)
+              (elim-F-homᴰ V₁) (elim-F-homᴰ V₂) i
+          elim-F-homᴰ ([×η] M i) =
+            DA.value-×ηᴰ-on (elim-F-obᴰ _) (elim-F-obᴰ _)
+              value-π₁≡[×π1] value-π₂≡[×π2]
+              (λ i → ı _ , [×η] M i) (elim-F-homᴰ M) i
+          elim-F-homᴰ [0E] = Dᴰ.reind (ΣPathP (refl , refl)) DA.value-initial-elimᴰ
+          elim-F-homᴰ ([0η] M i) =
+            DA.value-initial-ηᴰ (ΣPathP (refl , refl))
+              (λ i → ı _ , [0η] M i) (elim-F-homᴰ M) i
+          elim-F-homᴰ [+I1] = Dᴰ.reind
+            (ΣPathP (refl , value-σ₁≡[+I1]))
+            (DA.value-σᴰ₁ (elim-F-obᴰ _) (elim-F-obᴰ _))
+          elim-F-homᴰ [+I2] = Dᴰ.reind
+            (ΣPathP (refl , value-σ₂≡[+I2]))
+            (DA.value-σᴰ₂ (elim-F-obᴰ _) (elim-F-obᴰ _))
+          elim-F-homᴰ ([+E] f g) = Dᴰ.reind (ΣPathP (refl , refl))
+            (DA.value-copairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (elim-F-homᴰ f) (elim-F-homᴰ g))
+          elim-F-homᴰ ([+β1] M₁ M₂ i) =
+            DA.value-+βᴰ₁-on (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (ΣPathP (refl , value-σ₁≡[+I1]))
+              (λ i → ı _ , [+β1] M₁ M₂ i)
+              (elim-F-homᴰ M₁) (elim-F-homᴰ M₂) i
+          elim-F-homᴰ ([+β2] M₁ M₂ i) =
+            DA.value-+βᴰ₂-on (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (ΣPathP (refl , value-σ₂≡[+I2]))
+              (λ i → ı _ , [+β2] M₁ M₂ i)
+              (elim-F-homᴰ M₁) (elim-F-homᴰ M₂) i
+          elim-F-homᴰ ([+η] M i) =
+            DA.value-+ηᴰ-on (elim-F-obᴰ _) (elim-F-obᴰ _)
+              value-σ₁≡[+I1] value-σ₂≡[+I2]
+              (λ i → ı _ , [+η] M i) (elim-F-homᴰ M) i
+          elim-F-homᴰ [⊤I] = Dᴰ.reind (ΣPathP (refl , refl)) DA.computation-terminal-introᴰ
+          elim-F-homᴰ ([⊤η] M i) =
+            DA.computation-terminal-ηᴰ (ΣPathP (refl , refl))
+              (λ i → ı _ , [⊤η] M i)
+              (elim-F-homᴰ M) i
+          elim-F-homᴰ ([&I] M₁ M₂) = Dᴰ.reind (ΣPathP (refl , refl))
+            (DA.computation-pairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (elim-F-homᴰ M₁) (elim-F-homᴰ M₂))
+          elim-F-homᴰ [&π1] = Dᴰ.reind
+            (ΣPathP (refl , computation-π₁≡[&π1]))
+            (DA.computation-πᴰ₁ (elim-F-obᴰ _) (elim-F-obᴰ _))
+          elim-F-homᴰ [&π2] = Dᴰ.reind
+            (ΣPathP (refl , computation-π₂≡[&π2]))
+            (DA.computation-πᴰ₂ (elim-F-obᴰ _) (elim-F-obᴰ _))
+          elim-F-homᴰ ([&β1] M₁ M₂ i) =
+            DA.computation-×βᴰ₁-on (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (ΣPathP (refl , computation-π₁≡[&π1]))
+              (λ i → ı _ , [&β1] M₁ M₂ i)
+              (elim-F-homᴰ M₁) (elim-F-homᴰ M₂) i
+          elim-F-homᴰ ([&β2] M₁ M₂ i) =
+            DA.computation-×βᴰ₂-on (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (ΣPathP (refl , computation-π₂≡[&π2]))
+              (λ i → ı _ , [&β2] M₁ M₂ i)
+              (elim-F-homᴰ M₁) (elim-F-homᴰ M₂) i
+          elim-F-homᴰ ([&η] M i) =
+            DA.computation-×ηᴰ-on (elim-F-obᴰ _) (elim-F-obᴰ _)
+              computation-π₁≡[&π1] computation-π₂≡[&π2]
+              (λ i → ı _ , [&η] M i) (elim-F-homᴰ M) i
+          elim-F-homᴰ ([op] op γ) =
+            DAlg .fst (elim-F-obᴰ _) (elim-F-obᴰ _)
+              op γ (λ v → elim-F-homᴰ (γ v)) ([op] op γ) refl
+          elim-F-homᴰ ([freeAlg] e t ρ) =
+            freeAlgTmᴰ e t ρ (λ v → elim-F-homᴰ (ρ v))
+          elim-F-homᴰ ([freeAlgEqn] e ρ i) =
+            HomReasoning.rectifyOut {e' = [freeAlgEqn] e ρ}
+              ( sym
+                  (freeAlgTmᴰ-filler e (lhs e) ρ
+                    (λ v → elim-F-homᴰ (ρ v)))
+              ∙ HomReasoning.≡in
+                  (DModel .fst (elim-F-obᴰ _) (elim-F-obᴰ _) .snd
+                    e ρ (λ v → elim-F-homᴰ (ρ v)))
+              ∙ freeAlgTmᴰ-filler e (rhs e) ρ
+                  (λ v → elim-F-homᴰ (ρ v))) i
+          elim-F-homᴰ ([freeAlg-var] e v ρ i) =
+            HomReasoning.rectifyOut {e' = [freeAlg-var] e v ρ}
+              (freeAlgTmᴰ-filler e (S.var v) ρ
+                (λ x → elim-F-homᴰ (ρ x))) i
+          elim-F-homᴰ ([freeAlg-op] e op γ ρ i) =
+            HomReasoning.rectifyOut {e' = [freeAlg-op] e op γ ρ}
+              ( sym
+                  (cong
+                    (∫Algebra
+                      (_ , DAlg .fst (elim-F-obᴰ _) (elim-F-obᴰ _))
+                      .snd op)
+                    (funExt λ v →
+                      freeAlgTmᴰ-filler e (γ v) ρ
+                        (λ x → elim-F-homᴰ (ρ x))))
+              ∙ Algebraᴰ-op-filler
+                  (_ , DAlg .fst (elim-F-obᴰ _) (elim-F-obᴰ _))
+                  op
+                  (λ v → interp (_ , AlgebraEff _ _) ρ (γ v))
+                  (λ v → interpᴰ
+                    (_ , DAlg .fst (elim-F-obᴰ _) (elim-F-obᴰ _))
+                    ρ (λ x → elim-F-homᴰ (ρ x)) (γ v))
+                  (interp (_ , AlgebraEff _ _) ρ (S.app op γ))
+                  (recFA (_ , AlgebraEff _ _) ρ .snd
+                    op γ (S.app op γ) refl)
+              ∙ freeAlgTmᴰ-filler e (S.app op γ) ρ
+                  (λ x → elim-F-homᴰ (ρ x))) i
+          elim-F-homᴰ ([op-homL] V op γ i) =
+            hSetReasoning.rectifyOut (_ , isSetTm)
+              (λ N → Dᴰ.Hom[ ı _ , N ][ elim-F-obᴰ _ , elim-F-obᴰ _ ])
+              {e' = [op-homL] V op γ}
+              ((λ j → seqS V ([op] op γ) , sym homo-law j)
+                ∙ (λ j → [op-homL] V op γ j , op-path j)) i
+            where
+            base-square : Square
+              (Subst-Homo V _ op γ ([op] op γ) refl)
+              refl refl ([op-homL] V op γ)
+            base-square = isSet→Square isSetTm refl ([op-homL] V op γ)
+              (Subst-Homo V _ op γ ([op] op γ) refl) refl
+
+            op-path : PathP
+              (λ i → Dᴰ.Hom[ ı _ , [op-homL] V op γ i ][
+                elim-F-obᴰ _ , elim-F-obᴰ _ ])
+              (DAlg .fst (elim-F-obᴰ _) (elim-F-obᴰ _)
+                op (λ v → seqS V (γ v))
+                (λ v → elim-F-homᴰ V Dᴰ.⋆ᴰ elim-F-homᴰ (γ v))
+                (seqS V ([op] op γ)) (base-square i0))
+              (DAlg .fst (elim-F-obᴰ _) (elim-F-obᴰ _)
+                op (λ v → seqS V (γ v))
+                (λ v → elim-F-homᴰ V Dᴰ.⋆ᴰ elim-F-homᴰ (γ v))
+                ([op] op (λ v → seqS V (γ v))) refl)
+            op-path i =
+              DAlg .fst (elim-F-obᴰ _) (elim-F-obᴰ _)
+                op (λ v → seqS V (γ v))
+                (λ v → elim-F-homᴰ V Dᴰ.⋆ᴰ elim-F-homᴰ (γ v))
+                ([op-homL] V op γ i) (λ j → base-square i j)
+
+            op-sourceᴰ = DAlg .fst (elim-F-obᴰ _) (elim-F-obᴰ _)
+              op γ (λ v → elim-F-homᴰ (γ v)) ([op] op γ) refl
+
+            homo-law = DAlg .snd .fst (elim-F-homᴰ V)
+              op γ (λ v → elim-F-homᴰ (γ v))
+              ([op] op γ) refl op-sourceᴰ refl
+          elim-F-homᴰ ([op-homR] op γ S i) =
+            hSetReasoning.rectifyOut (_ , isSetTm)
+              (λ N → Dᴰ.Hom[ ı _ , N ][ elim-F-obᴰ _ , elim-F-obᴰ _ ])
+              {e' = [op-homR] op γ S}
+              ((λ j → seqS ([op] op γ) S , sym homo-law j)
+                ∙ (λ j → [op-homR] op γ S j , op-path j)) i
+            where
+            base-square : Square
+              (Plug-Homo S _ op γ ([op] op γ) refl)
+              refl refl ([op-homR] op γ S)
+            base-square = isSet→Square isSetTm refl ([op-homR] op γ S)
+              (Plug-Homo S _ op γ ([op] op γ) refl) refl
+
+            op-path : PathP
+              (λ i → Dᴰ.Hom[ ı _ , [op-homR] op γ S i ][
+                elim-F-obᴰ _ , elim-F-obᴰ _ ])
+              (DAlg .fst (elim-F-obᴰ _) (elim-F-obᴰ _)
+                op (λ v → seqS (γ v) S)
+                (λ v → elim-F-homᴰ (γ v) Dᴰ.⋆ᴰ elim-F-homᴰ S)
+                (seqS ([op] op γ) S) (base-square i0))
+              (DAlg .fst (elim-F-obᴰ _) (elim-F-obᴰ _)
+                op (λ v → seqS (γ v) S)
+                (λ v → elim-F-homᴰ (γ v) Dᴰ.⋆ᴰ elim-F-homᴰ S)
+                ([op] op (λ v → seqS (γ v) S)) refl)
+            op-path i =
+              DAlg .fst (elim-F-obᴰ _) (elim-F-obᴰ _)
+                op (λ v → seqS (γ v) S)
+                (λ v → elim-F-homᴰ (γ v) Dᴰ.⋆ᴰ elim-F-homᴰ S)
+                ([op-homR] op γ S i) (λ j → base-square i j)
+
+            op-sourceᴰ = DAlg .fst (elim-F-obᴰ _) (elim-F-obᴰ _)
+              op γ (λ v → elim-F-homᴰ (γ v)) ([op] op γ) refl
+
+            homo-law = DAlg .snd .snd (elim-F-homᴰ S)
+              op γ (λ v → elim-F-homᴰ (γ v))
+              ([op] op γ) refl op-sourceᴰ refl
+
+          elim : GlobalSection Dᴰ
+          elim .F-obᴰ d = elim-F-obᴰ (d .snd)
+          elim .F-homᴰ f = elim-F-homᴰ (f .snd)
+          elim .F-idᴰ = refl
+          elim .F-seqᴰ _ _ = refl
+
+    module LocalElim
+      {C : CBPVCat ℓD ℓD'}
+      (F : Functorⱽ (AddCBPV .fst .fst) C)
+      (Cⱽ : AddCBPVCatⱽ C ℓCᴰ ℓCᴰ')
+      (CModel : ModelEnrichment C T)
+      (FModel : PreservesModelEnrichment T F CBPVModel CModel)
+      (CᴰModel : ModelEnrichmentᴰ T CModel (Cⱽ .fst .fst))
+      where
+      private
+        module Cᴰ = Fibers (Cⱽ .fst .fst)
+
+        reindexed : AddCBPVCatᴰ AddCBPV ℓCᴰ ℓCᴰ'
+        reindexed = AddCBPVCatⱽ→ᴰ (AddCBPVCatⱽReindex Cⱽ F)
+
+        reindexedModel :
+          ModelEnrichmentᴰ T CBPVModel (reindexed .fst .fst)
+        reindexedModel = ModelEnrichmentᴰReindex
+          T F CBPVModel CModel FModel (Cⱽ .fst .fst) CᴰModel
+
+      module _
+        (ı-ob : ∀ {k} (X : BaseTy k)
+          → Cᴰ.ob[ k , F .Functorᴰ.F-obᴰ (gen X) ])
+        where
+        local-obᴰ : ∀ Γ → Cᴰ.ob[ k , F .Functorᴰ.F-obᴰ Γ ]
+        local-obᴰ = Elim.elim-F-obᴰ reindexed reindexedModel ı-ob
+
+        localElim :
+          (ı-hom : ∀ {k1 k2 Γ Δ} {k≤ : ≤Kind k1 k2} (M : Fun k≤ Γ Δ)
+            → Cᴰ.Hom[ _ , F .Functorᴰ.F-homᴰ (gen M) ][
+                local-obᴰ Γ , local-obᴰ Δ ])
+          → DisplayedSection (∫F F) (Cⱽ .fst .fst)
+        localElim ı-hom =
+          GlobalSectionReindex→Section (Cⱽ .fst .fst) (∫F F)
+            (Elim.elim reindexed reindexedModel ı-ob ı-hom)

--- a/Cubical/Categories/Displayed/CBPV/Unary/Instances/Free/ModelEnriched/Additive.agda
+++ b/Cubical/Categories/Displayed/CBPV/Unary/Instances/Free/ModelEnriched/Additive.agda
@@ -495,14 +495,14 @@ module CBPV (T : Theory ℓO ℓA ℓE ℓEA) (BaseTy : Kind → Type ℓ) where
             Uηᴰ Dᴰ (MultCBPV .snd .fst) (D .fst .snd .fst)
               (C.reind-filler⁻ _ ∙ C.≡in {pth = refl} (IdLS [force]))
               V (λ i → Category.id KIND , [Uη] V i) (elim-F-homᴰ V) i
-          elim-F-homᴰ [1I] = Dᴰ.reind (ΣPathP (refl , refl)) DA.value-terminal-introᴰ
+          elim-F-homᴰ [1I] = DA.value-terminal-introᴰ
           elim-F-homᴰ ([1η] V i) =
-            DA.value-terminal-ηᴰ (ΣPathP (refl , refl))
+            DA.value-terminal-ηᴰ-on
               (λ i → ı _ , [1η] V i)
               (elim-F-homᴰ V) i
-          elim-F-homᴰ ([×I] V₁ V₂) = Dᴰ.reind (ΣPathP (refl , refl))
-            (DA.value-pairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
-              (elim-F-homᴰ V₁) (elim-F-homᴰ V₂))
+          elim-F-homᴰ ([×I] V₁ V₂) =
+            DA.value-pairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (elim-F-homᴰ V₁) (elim-F-homᴰ V₂)
           elim-F-homᴰ [×π1] = Dᴰ.reind
             (ΣPathP (refl , value-π₁≡[×π1]))
             (DA.value-πᴰ₁ (elim-F-obᴰ _) (elim-F-obᴰ _))
@@ -523,9 +523,9 @@ module CBPV (T : Theory ℓO ℓA ℓE ℓEA) (BaseTy : Kind → Type ℓ) where
             DA.value-×ηᴰ-on (elim-F-obᴰ _) (elim-F-obᴰ _)
               value-π₁≡[×π1] value-π₂≡[×π2]
               (λ i → ı _ , [×η] M i) (elim-F-homᴰ M) i
-          elim-F-homᴰ [0E] = Dᴰ.reind (ΣPathP (refl , refl)) DA.value-initial-elimᴰ
+          elim-F-homᴰ [0E] = DA.value-initial-elimᴰ
           elim-F-homᴰ ([0η] M i) =
-            DA.value-initial-ηᴰ (ΣPathP (refl , refl))
+            DA.value-initial-ηᴰ-on
               (λ i → ı _ , [0η] M i) (elim-F-homᴰ M) i
           elim-F-homᴰ [+I1] = Dᴰ.reind
             (ΣPathP (refl , value-σ₁≡[+I1]))
@@ -533,9 +533,9 @@ module CBPV (T : Theory ℓO ℓA ℓE ℓEA) (BaseTy : Kind → Type ℓ) where
           elim-F-homᴰ [+I2] = Dᴰ.reind
             (ΣPathP (refl , value-σ₂≡[+I2]))
             (DA.value-σᴰ₂ (elim-F-obᴰ _) (elim-F-obᴰ _))
-          elim-F-homᴰ ([+E] f g) = Dᴰ.reind (ΣPathP (refl , refl))
-            (DA.value-copairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
-              (elim-F-homᴰ f) (elim-F-homᴰ g))
+          elim-F-homᴰ ([+E] f g) =
+            DA.value-copairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (elim-F-homᴰ f) (elim-F-homᴰ g)
           elim-F-homᴰ ([+β1] M₁ M₂ i) =
             DA.value-+βᴰ₁-on (elim-F-obᴰ _) (elim-F-obᴰ _)
               (ΣPathP (refl , value-σ₁≡[+I1]))
@@ -550,14 +550,14 @@ module CBPV (T : Theory ℓO ℓA ℓE ℓEA) (BaseTy : Kind → Type ℓ) where
             DA.value-+ηᴰ-on (elim-F-obᴰ _) (elim-F-obᴰ _)
               value-σ₁≡[+I1] value-σ₂≡[+I2]
               (λ i → ı _ , [+η] M i) (elim-F-homᴰ M) i
-          elim-F-homᴰ [⊤I] = Dᴰ.reind (ΣPathP (refl , refl)) DA.computation-terminal-introᴰ
+          elim-F-homᴰ [⊤I] = DA.computation-terminal-introᴰ
           elim-F-homᴰ ([⊤η] M i) =
-            DA.computation-terminal-ηᴰ (ΣPathP (refl , refl))
+            DA.computation-terminal-ηᴰ-on
               (λ i → ı _ , [⊤η] M i)
               (elim-F-homᴰ M) i
-          elim-F-homᴰ ([&I] M₁ M₂) = Dᴰ.reind (ΣPathP (refl , refl))
-            (DA.computation-pairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
-              (elim-F-homᴰ M₁) (elim-F-homᴰ M₂))
+          elim-F-homᴰ ([&I] M₁ M₂) =
+            DA.computation-pairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (elim-F-homᴰ M₁) (elim-F-homᴰ M₂)
           elim-F-homᴰ [&π1] = Dᴰ.reind
             (ΣPathP (refl , computation-π₁≡[&π1]))
             (DA.computation-πᴰ₁ (elim-F-obᴰ _) (elim-F-obᴰ _))

--- a/Cubical/Categories/Displayed/CBPV/Unary/Instances/Free/Pure/Additive.agda
+++ b/Cubical/Categories/Displayed/CBPV/Unary/Instances/Free/Pure/Additive.agda
@@ -381,14 +381,14 @@ module CBPV (BaseTy : Kind → Type ℓ) where
             Uηᴰ Dᴰ (MultCBPV .snd .fst) (D .fst .snd .fst)
               (C.reind-filler⁻ _ ∙ C.≡in {pth = refl} (IdLS [force]))
               V (λ i → Category.id KIND , [Uη] V i) (elim-F-homᴰ V) i
-          elim-F-homᴰ [1I] = Dᴰ.reind (ΣPathP (refl , refl)) DA.value-terminal-introᴰ
+          elim-F-homᴰ [1I] = DA.value-terminal-introᴰ
           elim-F-homᴰ ([1η] V i) =
-            DA.value-terminal-ηᴰ (ΣPathP (refl , refl))
+            DA.value-terminal-ηᴰ-on
               (λ i → ı _ , [1η] V i)
               (elim-F-homᴰ V) i
-          elim-F-homᴰ ([×I] V₁ V₂) = Dᴰ.reind (ΣPathP (refl , refl))
-            (DA.value-pairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
-              (elim-F-homᴰ V₁) (elim-F-homᴰ V₂))
+          elim-F-homᴰ ([×I] V₁ V₂) =
+            DA.value-pairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (elim-F-homᴰ V₁) (elim-F-homᴰ V₂)
           elim-F-homᴰ [×π1] = Dᴰ.reind
             (ΣPathP (refl , value-π₁≡[×π1]))
             (DA.value-πᴰ₁ (elim-F-obᴰ _) (elim-F-obᴰ _))
@@ -409,9 +409,9 @@ module CBPV (BaseTy : Kind → Type ℓ) where
             DA.value-×ηᴰ-on (elim-F-obᴰ _) (elim-F-obᴰ _)
               value-π₁≡[×π1] value-π₂≡[×π2]
               (λ i → ı _ , [×η] M i) (elim-F-homᴰ M) i
-          elim-F-homᴰ [0E] = Dᴰ.reind (ΣPathP (refl , refl)) DA.value-initial-elimᴰ
+          elim-F-homᴰ [0E] = DA.value-initial-elimᴰ
           elim-F-homᴰ ([0η] M i) =
-            DA.value-initial-ηᴰ (ΣPathP (refl , refl))
+            DA.value-initial-ηᴰ-on
               (λ i → ı _ , [0η] M i) (elim-F-homᴰ M) i
           elim-F-homᴰ [+I1] = Dᴰ.reind
             (ΣPathP (refl , value-σ₁≡[+I1]))
@@ -419,9 +419,9 @@ module CBPV (BaseTy : Kind → Type ℓ) where
           elim-F-homᴰ [+I2] = Dᴰ.reind
             (ΣPathP (refl , value-σ₂≡[+I2]))
             (DA.value-σᴰ₂ (elim-F-obᴰ _) (elim-F-obᴰ _))
-          elim-F-homᴰ ([+E] f g) = Dᴰ.reind (ΣPathP (refl , refl))
-            (DA.value-copairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
-              (elim-F-homᴰ f) (elim-F-homᴰ g))
+          elim-F-homᴰ ([+E] f g) =
+            DA.value-copairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (elim-F-homᴰ f) (elim-F-homᴰ g)
           elim-F-homᴰ ([+β1] M₁ M₂ i) =
             DA.value-+βᴰ₁-on (elim-F-obᴰ _) (elim-F-obᴰ _)
               (ΣPathP (refl , value-σ₁≡[+I1]))
@@ -436,14 +436,14 @@ module CBPV (BaseTy : Kind → Type ℓ) where
             DA.value-+ηᴰ-on (elim-F-obᴰ _) (elim-F-obᴰ _)
               value-σ₁≡[+I1] value-σ₂≡[+I2]
               (λ i → ı _ , [+η] M i) (elim-F-homᴰ M) i
-          elim-F-homᴰ [⊤I] = Dᴰ.reind (ΣPathP (refl , refl)) DA.computation-terminal-introᴰ
+          elim-F-homᴰ [⊤I] = DA.computation-terminal-introᴰ
           elim-F-homᴰ ([⊤η] M i) =
-            DA.computation-terminal-ηᴰ (ΣPathP (refl , refl))
+            DA.computation-terminal-ηᴰ-on
               (λ i → ı _ , [⊤η] M i)
               (elim-F-homᴰ M) i
-          elim-F-homᴰ ([&I] M₁ M₂) = Dᴰ.reind (ΣPathP (refl , refl))
-            (DA.computation-pairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
-              (elim-F-homᴰ M₁) (elim-F-homᴰ M₂))
+          elim-F-homᴰ ([&I] M₁ M₂) =
+            DA.computation-pairᴰ (elim-F-obᴰ _) (elim-F-obᴰ _)
+              (elim-F-homᴰ M₁) (elim-F-homᴰ M₂)
           elim-F-homᴰ [&π1] = Dᴰ.reind
             (ΣPathP (refl , computation-π₁≡[&π1]))
             (DA.computation-πᴰ₁ (elim-F-obᴰ _) (elim-F-obᴰ _))

--- a/Cubical/Categories/Displayed/CBPV/Unary/Instances/Model/Additive.agda
+++ b/Cubical/Categories/Displayed/CBPV/Unary/Instances/Model/Additive.agda
@@ -1,0 +1,539 @@
+-- Additive structure for the Set/Model unary CBPV model.
+{-# OPTIONS --prop --lossy-unification #-}
+module Cubical.Categories.Displayed.CBPV.Unary.Instances.Model.Additive where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Structure
+open import Cubical.Functions.FunExtEquiv
+
+open import Cubical.Data.Empty as Empty
+open import Cubical.Data.Sigma
+open import Cubical.Data.Sum as Sum
+open import Cubical.Data.Unit
+import Cubical.Data.Equality as Eq
+
+open import Cubical.Algebra.Theory.Base
+  hiding (ℓ; ℓᴰ; ℓᴰᴰ; ℓ'; ℓᴰ'; ℓᴰᴰ'; ℓ''; ℓᴰ''; ℓO; ℓA; ℓE)
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Adjoint.UniversalElements
+open import Cubical.Categories.Instances.Fiber
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.TotalCategory
+open import Cubical.Categories.Instances.WalkingArrow
+  renaming (WalkingArrow to KIND; l to 𝒱; r to 𝒞)
+open import Cubical.Categories.Presheaf.Constructions
+open import Cubical.Categories.Presheaf.Morphism.Alt
+open import Cubical.Categories.Presheaf.Representable
+open import Cubical.Categories.Presheaf.Representable.More
+
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Instances.Algebra.Model
+open import Cubical.Categories.Displayed.Instances.Algebra.DisplayedModel
+open import Cubical.Categories.Displayed.Instances.Opposite
+open import Cubical.Categories.Displayed.Instances.Sets.Base
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Fibration
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Eq.Conversion.CartesianV
+import Cubical.Categories.Displayed.Presheaf.Uncurried.Eq.Base as EqPsh
+open import Cubical.Categories.Displayed.CBPV.Unary.Additive
+open import Cubical.Categories.Displayed.CBPV.Unary.Instances.Model.Base
+open import Cubical.Categories.Displayed.CBPV.Unary.Instances.Model.Multiplicative
+
+private
+  variable
+    ℓO ℓA ℓE ℓEA : Level
+
+open Category
+open UniversalElement
+
+module _ (T : Theory ℓO ℓA ℓE ℓEA) where
+  open Theory T
+
+  private
+    L = ModelLevel T
+    C = ModelCBPVEq T .fst
+    Cop = C ^opᴰ
+
+    MODELOb→Model : Category.ob (MODEL T L) → Model L
+    MODELOb→Model B .fst .fst = ⟨ B .fst ⟩
+    MODELOb→Model B .fst .snd = B .snd .fst
+    MODELOb→Model B .snd .fst = B .snd .snd
+    MODELOb→Model B .snd .snd = B .fst .snd
+
+    MODELᴰOb→Modelᴰ : ∀ {B : Category.ob (MODEL T L)}
+      → Categoryᴰ.ob[_] (MODELᴰ T L L) B
+      → Modelᴰ (MODELOb→Model B) L
+    MODELᴰOb→Modelᴰ Bᴰ .fst .fst b = ⟨ Bᴰ .fst b ⟩
+    MODELᴰOb→Modelᴰ Bᴰ .fst .snd = Bᴰ .snd .fst
+    MODELᴰOb→Modelᴰ Bᴰ .snd .fst = Bᴰ .snd .snd
+    MODELᴰOb→Modelᴰ Bᴰ .snd .snd b = Bᴰ .fst b .snd
+
+    KIND-idR : EqPsh.EqIdR KIND
+    KIND-idR _ = Eq.refl
+
+    KIND^op-idR : EqPsh.EqIdR (KIND ^op)
+    KIND^op-idR _ = Eq.refl
+
+  ModelValueTerminalEqⱽ : EqTerminalⱽ C 𝒱
+  ModelValueTerminalEqⱽ = EqPsh.UEⱽ→Reprⱽ _ KIND-idR ue
+    where
+    ue : EqPsh.UEⱽ
+      (EqPsh.UnitⱽPsh {Cᴰ = C} {P = KIND [-, 𝒱 ]}) KIND-idR
+    ue .EqPsh.UEⱽ.v = Unit* , isSetUnit*
+    ue .EqPsh.UEⱽ.e = tt
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .fst _ _ = tt*
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .snd .snd h =
+      funExt λ _ → refl
+
+  ModelValueProductEqⱽ : ∀ A₁ A₂ → EqBinProductⱽ C {k = 𝒱} A₁ A₂
+  ModelValueProductEqⱽ A₁ A₂ = EqPsh.UEⱽ→Reprⱽ _ KIND-idR ue
+    where
+    ue : EqPsh.UEⱽ
+      ((EqPsh._[-][-,_] C A₁) EqPsh.×ⱽPsh (EqPsh._[-][-,_] C A₂))
+      KIND-idR
+    ue .EqPsh.UEⱽ.v .fst = A₁ .fst × A₂ .fst
+    ue .EqPsh.UEⱽ.v .snd = isSet× (A₁ .snd) (A₂ .snd)
+    ue .EqPsh.UEⱽ.e = fst , snd
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .fst
+      (p , q) x = p x , q x
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .snd .snd _ = refl
+
+  ModelValueInitialEqⱽ : EqInitialⱽ C 𝒱
+  ModelValueInitialEqⱽ = EqPsh.UEⱽ→Reprⱽ _ KIND^op-idR ue
+    where
+    ue : EqPsh.UEⱽ
+      (EqPsh.UnitⱽPsh {Cᴰ = Cop} {P = (KIND ^op) [-, 𝒱 ]})
+      KIND^op-idR
+    ue .EqPsh.UEⱽ.v = ⊥* , isProp→isSet isProp⊥*
+    ue .EqPsh.UEⱽ.e = tt
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .fst _ = λ ()
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .fst _ = λ ()
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .snd .snd h =
+      funExt λ ()
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .snd .snd h =
+      funExt λ ()
+
+  ModelValueCoProductEqⱽ : ∀ A₁ A₂ →
+    EqBinCoProductⱽ C {k = 𝒱} A₁ A₂
+  ModelValueCoProductEqⱽ A₁ A₂ =
+    EqPsh.UEⱽ→Reprⱽ _ KIND^op-idR ue
+    where
+    case-η : ∀ {X : Type L} (h : A₁ .fst ⊎ A₂ .fst → X) →
+      Sum.rec (λ x → h (inl x)) (λ x → h (inr x)) ≡ h
+    case-η h = funExt λ { (inl _) → refl ; (inr _) → refl }
+
+    ue : EqPsh.UEⱽ
+      ((EqPsh._[-][-,_] Cop A₁) EqPsh.×ⱽPsh
+       (EqPsh._[-][-,_] Cop A₂))
+      KIND^op-idR
+    ue .EqPsh.UEⱽ.v .fst = A₁ .fst ⊎ A₂ .fst
+    ue .EqPsh.UEⱽ.v .snd = isSet⊎ (A₁ .snd) (A₂ .snd)
+    ue .EqPsh.UEⱽ.e = inl , inr
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .fst
+      (p , q) = Sum.rec p q
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .fst
+      (p , q) = Sum.rec p q
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .snd .snd h =
+      case-η h
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .snd .snd h =
+      case-η h
+
+  ModelComputationTerminalEqⱽ : EqTerminalⱽ C 𝒞
+  ModelComputationTerminalEqⱽ = EqPsh.UEⱽ→Reprⱽ _ KIND-idR ue
+    where
+    ue : EqPsh.UEⱽ
+      (EqPsh.UnitⱽPsh {Cᴰ = C} {P = KIND [-, 𝒞 ]}) KIND-idR
+    ue .EqPsh.UEⱽ.v = TerminalMODEL T .vertex
+    ue .EqPsh.UEⱽ.e = tt
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .fst _ _ = tt*
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .fst _ .fst _ = tt*
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .fst _ .snd
+      _ _ _ _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .snd .snd h =
+      funExt λ _ → refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .snd .snd h =
+      Σ≡Prop (λ _ → isPropΠ4 λ _ _ _ _ → isSetUnit* _ _)
+        (funExt λ _ → refl)
+
+  ModelComputationProductEqⱽ : ∀ B₁ B₂ →
+    EqBinProductⱽ C {k = 𝒞} B₁ B₂
+  ModelComputationProductEqⱽ B₁ B₂ =
+    EqPsh.UEⱽ→Reprⱽ _ KIND-idR ue
+    where
+    ue : EqPsh.UEⱽ
+      ((EqPsh._[-][-,_] C B₁) EqPsh.×ⱽPsh
+       (EqPsh._[-][-,_] C B₂))
+      KIND-idR
+    ue .EqPsh.UEⱽ.v =
+      BinProductsMODEL T (B₁ , B₂) .vertex
+    ue .EqPsh.UEⱽ.e .fst .fst = fst
+    ue .EqPsh.UEⱽ.e .fst .snd _ _ _ p = cong fst p
+    ue .EqPsh.UEⱽ.e .snd .fst = snd
+    ue .EqPsh.UEⱽ.e .snd .snd _ _ _ p = cong snd p
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .fst
+      (p , q) x = p x , q x
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .fst
+      (p , q) = ×intro p q
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒱 , A , f) .snd .snd _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso (𝒞 , B , f) .snd .snd h =
+      Σ≡Prop
+        (λ _ → isPropΠ4 λ _ _ _ _ →
+          isSet× (B₁ .fst .snd) (B₂ .fst .snd) _ _)
+        refl
+
+  ModelAddCBPVEqWithFree : LeftAdjoint (MODELForget T)
+    → AddCBPVCatEq (ℓ-suc L) L
+  ModelAddCBPVEqWithFree Free .fst = ModelCBPVEqWithFree T Free
+  ModelAddCBPVEqWithFree Free .snd .fst = ModelValueTerminalEqⱽ
+  ModelAddCBPVEqWithFree Free .snd .snd .fst = ModelValueProductEqⱽ
+  ModelAddCBPVEqWithFree Free .snd .snd .snd .fst = ModelValueInitialEqⱽ
+  ModelAddCBPVEqWithFree Free .snd .snd .snd .snd .fst =
+    ModelValueCoProductEqⱽ
+  ModelAddCBPVEqWithFree Free .snd .snd .snd .snd .snd .fst =
+    ModelComputationTerminalEqⱽ
+  ModelAddCBPVEqWithFree Free .snd .snd .snd .snd .snd .snd =
+    ModelComputationProductEqⱽ
+
+  ModelAddCBPVWithFree : LeftAdjoint (MODELForget T)
+    → AddCBPVCat (ℓ-suc L) L
+  ModelAddCBPVWithFree Free = forgetAddEq (ModelAddCBPVEqWithFree Free)
+
+  ModelAddCBPVEq : AddCBPVCatEq (ℓ-suc L) L
+  ModelAddCBPVEq = ModelAddCBPVEqWithFree (MODELFree T)
+
+  ModelAddCBPV : AddCBPVCat (ℓ-suc L) L
+  ModelAddCBPV = ModelAddCBPVWithFree (MODELFree T)
+
+  private
+    Cᴰ = ModelCBPVᴰ T
+
+    CBPVIdR : EqPsh.EqIdR (∫C C)
+    CBPVIdR {x = 𝒱 , A} {y = 𝒱 , B} f = Eq.refl
+    CBPVIdR {x = 𝒱 , A} {y = 𝒞 , B} f = Eq.refl
+    CBPVIdR {x = 𝒞 , A} {y = 𝒱 , B} ()
+    CBPVIdR {x = 𝒞 , A} {y = 𝒞 , B} f = Eq.refl
+
+    CBPVAssoc : EqPsh.ReprEqAssoc (∫C C)
+    CBPVAssoc (𝒱 , A)
+      {c = 𝒱 , W} {c' = 𝒱 , X} {c'' = 𝒱 , Y}
+      _ _ _ _ Eq.refl = Eq.refl
+    CBPVAssoc (𝒞 , B)
+      {c = 𝒱 , W} {c' = 𝒱 , X} {c'' = 𝒱 , Y}
+      _ _ _ _ Eq.refl = Eq.refl
+    CBPVAssoc (𝒞 , B)
+      {c = 𝒱 , W} {c' = 𝒞 , X} {c'' = 𝒞 , Y}
+      _ _ _ _ Eq.refl = Eq.refl
+    CBPVAssoc (𝒞 , B)
+      {c = 𝒞 , W} {c' = 𝒞 , X} {c'' = 𝒞 , Y}
+      _ _ _ _ Eq.refl = Eq.refl
+    CBPVAssoc x f g p f⋆g e = Eq.pathToEq
+      (sym (D.⋆Assoc f g p) ∙ cong (λ fg → fg D.⋆ p) (Eq.eqToPath e))
+      where module D = Category (∫C C)
+
+    CBPVAssoc^op : EqPsh.ReprEqAssoc ((∫C C) ^op)
+    CBPVAssoc^op (𝒱 , A)
+      {c = 𝒱 , W} {c' = 𝒱 , X} {c'' = 𝒱 , Y}
+      _ _ _ _ Eq.refl = Eq.refl
+    CBPVAssoc^op (𝒱 , A)
+      {c = 𝒞 , W} {c' = 𝒱 , X} {c'' = 𝒱 , Y}
+      _ _ _ _ Eq.refl = Eq.refl
+    CBPVAssoc^op x f g p f⋆g e = Eq.pathToEq
+      (sym (D.⋆Assoc f g p) ∙ cong (λ fg → fg D.⋆ p) (Eq.eqToPath e))
+      where module D = Category ((∫C C) ^op)
+
+    CBPVIdR^op : EqPsh.EqIdR ((∫C C) ^op)
+    CBPVIdR^op {x = 𝒱 , X} {y = 𝒱 , Y} f = Eq.refl
+    CBPVIdR^op {x = 𝒞 , X} {y = 𝒱 , Y} f = Eq.refl
+    CBPVIdR^op {x = 𝒱 , X} {y = 𝒞 , Y} ()
+    CBPVIdR^op {x = 𝒞 , X} {y = 𝒞 , Y} f = Eq.refl
+
+  ModelCBPVValueTerminalsⱽ : ValueTerminalsⱽ Cᴰ
+  ModelCBPVValueTerminalsⱽ A =
+    EqTerminalⱽ→Terminalⱽ CBPVAssoc Cᴰ
+      (EqPsh.UEⱽ→Reprⱽ _ CBPVIdR ue)
+    where
+    ue : EqPsh.UEⱽ
+      (EqPsh.UnitⱽPsh {Cᴰ = Cᴰ} {P = (∫C C) [-, (𝒱 , A) ]})
+      CBPVIdR
+    ue .EqPsh.UEⱽ.v _ = Unit* , isSetUnit*
+    ue .EqPsh.UEⱽ.e = tt
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .fst _ _ _ = tt*
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , ()) .fst
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , ()) .snd .fst
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .snd .snd _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , ()) .snd .snd
+
+  ModelCBPVValueBinProductsⱽ : ValueBinProductsⱽ Cᴰ
+  ModelCBPVValueBinProductsⱽ {A} A₁ᴰ A₂ᴰ =
+    EqBinProductⱽ→BinProductⱽ CBPVAssoc Cᴰ
+      (EqPsh.UEⱽ→Reprⱽ _ CBPVIdR ue)
+    where
+    ue : EqPsh.UEⱽ
+      ((Cᴰ EqPsh.[-][-, A₁ᴰ ]) EqPsh.×ⱽPsh
+       (Cᴰ EqPsh.[-][-, A₂ᴰ ]))
+      CBPVIdR
+    ue .EqPsh.UEⱽ.v x =
+      (A₁ᴰ x .fst × A₂ᴰ x .fst) , isSet× (A₁ᴰ x .snd) (A₂ᴰ x .snd)
+    ue .EqPsh.UEⱽ.e = (λ _ → fst) , (λ _ → snd)
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .fst (p , q) x xᴰ = p x xᴰ , q x xᴰ
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , ()) .fst
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , ()) .snd .fst
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .snd .snd _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , ()) .snd .snd
+
+  ModelCBPVValueInitialsⱽ : ValueInitialsⱽ Cᴰ
+  ModelCBPVValueInitialsⱽ A =
+    EqTerminalⱽ→Terminalⱽ CBPVAssoc^op (Cᴰ ^opᴰ)
+      (EqPsh.UEⱽ→Reprⱽ _ CBPVIdR^op ue)
+    where
+    ue : EqPsh.UEⱽ
+      (EqPsh.UnitⱽPsh {Cᴰ = Cᴰ ^opᴰ}
+        {P = ((∫C C) ^op) [-, (𝒱 , A) ]})
+      CBPVIdR^op
+    ue .EqPsh.UEⱽ.v _ = ⊥* , isProp→isSet isProp⊥*
+    ue .EqPsh.UEⱽ.e = tt
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .fst _ _ ()
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .fst _ _ ()
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .snd .snd h = funExt₂ λ _ ()
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .snd .snd h = funExt₂ λ _ ()
+
+  ModelCBPVValueBinCoProductsⱽ : ValueBinCoProductsⱽ Cᴰ
+  ModelCBPVValueBinCoProductsⱽ {A} A₁ᴰ A₂ᴰ =
+    EqBinProductⱽ→BinProductⱽ CBPVAssoc^op (Cᴰ ^opᴰ)
+      (EqPsh.UEⱽ→Reprⱽ _ CBPVIdR^op ue)
+    where
+    case-η : ∀ {X : A .fst → Type L}
+      (h : ∀ a → A₁ᴰ a .fst ⊎ A₂ᴰ a .fst → X a) →
+      (λ a → Sum.rec (λ x → h a (inl x)) (λ x → h a (inr x))) ≡ h
+    case-η h = funExt₂ λ _ → λ { (inl _) → refl ; (inr _) → refl }
+
+    ue : EqPsh.UEⱽ
+      (((Cᴰ ^opᴰ) EqPsh.[-][-, A₁ᴰ ]) EqPsh.×ⱽPsh
+       ((Cᴰ ^opᴰ) EqPsh.[-][-, A₂ᴰ ]))
+      CBPVIdR^op
+    ue .EqPsh.UEⱽ.v a =
+      (A₁ᴰ a .fst ⊎ A₂ᴰ a .fst) , isSet⊎ (A₁ᴰ a .snd) (A₂ᴰ a .snd)
+    ue .EqPsh.UEⱽ.e = (λ _ → inl) , (λ _ → inr)
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .fst (p , q) a = Sum.rec (p a) (q a)
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .fst (p , q) a = Sum.rec (p a) (q a)
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .snd .snd h = case-η h
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .snd .snd h = case-η h
+
+  ModelCBPVValueCartesianLifts : hasVerticalCartesianLiftsAt Cᴰ 𝒱
+  ModelCBPVValueCartesianLifts {A} {B} f Bᴰ =
+    EqCartesianLift→CartesianLift CBPVAssoc Cᴰ Bᴰ (𝒱 , A) (_ , f)
+      (EqPsh.UEⱽ→Reprⱽ _ CBPVIdR ue)
+    where
+    ue : EqPsh.CartesianLiftUE Cᴰ CBPVAssoc CBPVIdR (_ , f) Bᴰ
+    ue .EqPsh.UEⱽ.v x = Bᴰ (f x)
+    ue .EqPsh.UEⱽ.e _ xᴰ = xᴰ
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , g) .fst h = h
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , g) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , g) .snd .snd _ = refl
+
+  ModelCBPVValueOpcartesianLifts :
+    hasVerticalOpcartesianLiftsAt Cᴰ 𝒱
+  ModelCBPVValueOpcartesianLifts {A} {B} f Aᴰ =
+    EqCartesianLift→CartesianLift CBPVAssoc^op (Cᴰ ^opᴰ)
+      Aᴰ (𝒱 , B) (_ , f) (EqPsh.UEⱽ→Reprⱽ _ CBPVIdR^op ue)
+    where
+    ue : EqPsh.CartesianLiftUE (Cᴰ ^opᴰ)
+      CBPVAssoc^op CBPVIdR^op (_ , f) Aᴰ
+    ue .EqPsh.UEⱽ.v b .fst =
+      Σ[ a ∈ A .fst ] (f a ≡ b) × Aᴰ a .fst
+    ue .EqPsh.UEⱽ.v b .snd =
+      isSetΣ (A .snd) λ a →
+        isSet× (isProp→isSet (B .snd _ _)) (Aᴰ a .snd)
+    ue .EqPsh.UEⱽ.e a aᴰ = a , refl , aᴰ
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , g) .fst h b (a , p , aᴰ) =
+        subst (λ b' → Xᴰ (g .snd b') .fst) p (h a aᴰ)
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , g) .fst h b (a , p , aᴰ) =
+        subst (λ b' → Xᴰ .fst (g .snd b') .fst) p (h a aᴰ)
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , g) .snd .fst h =
+        funExt₂ λ _ _ → transportRefl _
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , g) .snd .fst h =
+        funExt₂ λ _ _ → transportRefl _
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , g) .snd .snd h =
+        funExt λ b → funExt λ { (a , p , aᴰ) →
+          J (λ b' p' →
+            subst (λ b'' → Xᴰ (g .snd b'') .fst) p'
+              (h (f a) (a , refl , aᴰ)) ≡ h b' (a , p' , aᴰ))
+            (transportRefl _) p }
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , g) .snd .snd h =
+        funExt λ b → funExt λ { (a , p , aᴰ) →
+          J (λ b' p' →
+            subst (λ b'' → Xᴰ .fst (g .snd b'') .fst) p'
+              (h (f a) (a , refl , aᴰ)) ≡ h b' (a , p' , aᴰ))
+            (transportRefl _) p }
+
+  ModelCBPVComputationTerminalsⱽ : ComputationTerminalsⱽ Cᴰ
+  ModelCBPVComputationTerminalsⱽ B =
+    EqTerminalⱽ→Terminalⱽ CBPVAssoc Cᴰ
+      (EqPsh.UEⱽ→Reprⱽ _ CBPVIdR ue)
+    where
+    ue : EqPsh.UEⱽ
+      (EqPsh.UnitⱽPsh {Cᴰ = Cᴰ} {P = (∫C C) [-, (𝒞 , B) ]})
+      CBPVIdR
+    ue .EqPsh.UEⱽ.v = TerminalsⱽMODELᴰ T B .fst
+    ue .EqPsh.UEⱽ.e = tt
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .fst _ _ _ = tt*
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .fst _ .fst _ _ = tt*
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .fst _ .snd _ _ _ _ _ _ _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .snd .snd h = funExt₂ λ _ _ → refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .snd .snd h =
+        MODELᴰHomo≡ T _ h (funExt₂ λ _ _ → refl)
+
+  ModelCBPVComputationBinProductsⱽ : ComputationBinProductsⱽ Cᴰ
+  ModelCBPVComputationBinProductsⱽ {B} B₁ᴰ B₂ᴰ =
+    EqBinProductⱽ→BinProductⱽ CBPVAssoc Cᴰ
+      (EqPsh.UEⱽ→Reprⱽ _ CBPVIdR ue)
+    where
+    ue : EqPsh.UEⱽ
+      ((Cᴰ EqPsh.[-][-, B₁ᴰ ]) EqPsh.×ⱽPsh
+       (Cᴰ EqPsh.[-][-, B₂ᴰ ]))
+      CBPVIdR
+    ue .EqPsh.UEⱽ.v = BinProductsⱽMODELᴰ T B₁ᴰ B₂ᴰ .fst
+    ue .EqPsh.UEⱽ.e .fst .fst _ = fst
+    ue .EqPsh.UEⱽ.e .fst .snd _ _ _ _ _ _ p = cong fst p
+    ue .EqPsh.UEⱽ.e .snd .fst _ = snd
+    ue .EqPsh.UEⱽ.e .snd .snd _ _ _ _ _ _ p = cong snd p
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .fst (p , q) x xᴰ = p x xᴰ , q x xᴰ
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .fst (p , q) .fst x xᴰ =
+        p .fst x xᴰ , q .fst x xᴰ
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .fst (p , q) .snd
+      op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ i =
+        p .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩
+          op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ i ,
+        q .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩
+          op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ i
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , f) .snd .snd h = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , f) .snd .snd h = MODELᴰHomo≡ T _ h refl
+
+  ModelCBPVComputationCartesianLifts :
+    hasVerticalCartesianLiftsAt Cᴰ 𝒞
+  ModelCBPVComputationCartesianLifts {A} {B} f Bᴰ =
+    EqCartesianLift→CartesianLift CBPVAssoc Cᴰ Bᴰ (𝒞 , A) (_ , f)
+      (EqPsh.UEⱽ→Reprⱽ _ CBPVIdR ue)
+    where
+    pullModelᴰ : Modelᴰ (MODELOb→Model A) L
+    pullModelᴰ = Theory._*_ T f (MODELᴰOb→Modelᴰ Bᴰ)
+
+    pullᴰ : Fibers.ob[_] Cᴰ (𝒞 , A)
+    pullᴰ .fst a = Bᴰ .fst (f .fst a)
+    pullᴰ .snd .fst = pullModelᴰ .fst .snd
+    pullᴰ .snd .snd = pullModelᴰ .snd .fst
+
+    ue : EqPsh.CartesianLiftUE Cᴰ CBPVAssoc CBPVIdR (_ , f) Bᴰ
+    ue .EqPsh.UEⱽ.v = pullᴰ
+    ue .EqPsh.UEⱽ.e .fst _ aᴰ = aᴰ
+    ue .EqPsh.UEⱽ.e .snd
+      op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ =
+        op∘γᴰ≡op⟨γᴰ⟩
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , g) .fst h = h
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , g) .fst h = h
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , g) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , g) .snd .fst h = MODELᴰHomo≡ T _ h refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , X) , Xᴰ , g) .snd .snd _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , X) , Xᴰ , g) .snd .snd h = MODELᴰHomo≡ T _ h refl
+
+  ModelAddCBPVⱽWithFree : (Free : FreeMODELConstruction T) →
+    AddCBPVCatⱽ (ModelAddCBPVWithFree (Free .fst) .fst .fst)
+      (ℓ-suc L) L
+  ModelAddCBPVⱽWithFree Free .fst = ModelCBPVⱽWithFree T Free
+  ModelAddCBPVⱽWithFree Free .snd .fst = ModelCBPVValueTerminalsⱽ
+  ModelAddCBPVⱽWithFree Free .snd .snd .fst =
+    ModelCBPVValueBinProductsⱽ
+  ModelAddCBPVⱽWithFree Free .snd .snd .snd .fst =
+    ModelCBPVValueCartesianLifts
+  ModelAddCBPVⱽWithFree Free .snd .snd .snd .snd .fst =
+    ModelCBPVValueInitialsⱽ
+  ModelAddCBPVⱽWithFree Free .snd .snd .snd .snd .snd .fst =
+    ModelCBPVValueBinCoProductsⱽ
+  ModelAddCBPVⱽWithFree Free .snd .snd .snd .snd .snd .snd .fst =
+    ModelCBPVValueOpcartesianLifts
+  ModelAddCBPVⱽWithFree Free .snd .snd .snd .snd .snd .snd .snd .fst =
+    ModelCBPVComputationTerminalsⱽ
+  ModelAddCBPVⱽWithFree Free .snd .snd .snd .snd .snd .snd .snd .snd .fst =
+    ModelCBPVComputationBinProductsⱽ
+  ModelAddCBPVⱽWithFree Free .snd .snd .snd .snd .snd .snd .snd .snd .snd =
+    ModelCBPVComputationCartesianLifts
+
+  ModelAddCBPVⱽ :
+    AddCBPVCatⱽ (ModelAddCBPV .fst .fst) (ℓ-suc L) L
+  ModelAddCBPVⱽ =
+    ModelAddCBPVⱽWithFree (CanonicalFreeMODELConstruction T)

--- a/Cubical/Categories/Displayed/CBPV/Unary/Instances/Model/Base.agda
+++ b/Cubical/Categories/Displayed/CBPV/Unary/Instances/Model/Base.agda
@@ -1,0 +1,197 @@
+{-# OPTIONS --prop --lossy-unification #-}
+module Cubical.Categories.Displayed.CBPV.Unary.Instances.Model.Base where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.More
+open import Cubical.Foundations.Structure
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Adjoint.UniversalElements
+open import Cubical.Categories.Instances.Fiber
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.WalkingArrow
+  renaming (l to 𝒱; r to 𝒞)
+
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Displayed.Instances.Algebra.Model
+open import Cubical.Categories.Displayed.Instances.Algebra.DisplayedModel
+open import Cubical.Categories.Displayed.Instances.Sets.Base
+open import Cubical.Categories.Displayed.CBPV.Unary.Base
+open import Cubical.Categories.Displayed.CBPV.Unary.Enrichment.Model
+open import Cubical.Categories.Displayed.CBPV.Unary.Instances.Displayed.FromU
+open import Cubical.Categories.Displayed.CBPV.Unary.Instances.FromU
+
+open import Cubical.Algebra.Theory.Base
+  hiding (ℓ; ℓᴰ; ℓᴰᴰ; ℓ'; ℓᴰ'; ℓᴰᴰ'; ℓ''; ℓᴰ''; ℓO; ℓA; ℓE)
+
+private
+  variable
+    ℓ ℓᴰ ℓO ℓA ℓE ℓEA : Level
+
+open Category
+open Functorᴰ
+
+module _ (T : Theory ℓO ℓA ℓE ℓEA) where
+  open Theory T
+
+  private
+    L = ModelLevel T
+
+  ModelCBPVEqWithFree : LeftAdjoint (MODELForget T)
+    → MultCBPVCatEq (ℓ-suc L) L
+  ModelCBPVEqWithFree = U→MultCBPVEq (MODELForget T)
+
+  ModelCBPVWithFree : LeftAdjoint (MODELForget T)
+    → MultCBPVCat (ℓ-suc L) L
+  ModelCBPVWithFree Free = forgetEq (ModelCBPVEqWithFree Free)
+
+  ModelCBPVEq : MultCBPVCatEq (ℓ-suc L) L
+  ModelCBPVEq = ModelCBPVEqWithFree (MODELFree T)
+
+  ModelCBPV : MultCBPVCat (ℓ-suc L) L
+  ModelCBPV = ModelCBPVWithFree (MODELFree T)
+
+  MODELForgetᴰ : Functorᴰ (MODELForget T) (MODELᴰ T L L) (SETᴰ L L)
+  MODELForgetᴰ .F-obᴰ Bᴰ = Bᴰ .fst
+  MODELForgetᴰ .F-homᴰ fᴰ = fᴰ .fst
+  MODELForgetᴰ .F-idᴰ = refl
+  MODELForgetᴰ .F-seqᴰ _ _ = refl
+
+  ModelCBPVᴰWithFree : (Free : LeftAdjoint (MODELForget T)) →
+    CBPVCatᴰ (ModelCBPVWithFree Free .fst) (ℓ-suc L) L
+  ModelCBPVᴰWithFree Free =
+    U→CBPVᴰ (MODELForget T) MODELForgetᴰ
+
+  ModelCBPVᴰ : CBPVCatᴰ (ModelCBPV .fst) (ℓ-suc L) L
+  ModelCBPVᴰ = ModelCBPVᴰWithFree (MODELFree T)
+
+  private
+    HomAlgebra : (A : hSet L) (B : MODEL T L .ob) → Algebra L
+    HomAlgebra A B .fst = ⟨ A ⟩ → ⟨ B .fst ⟩
+    HomAlgebra A B .snd op γ x = B .snd .fst op (λ v → γ v x)
+
+    evalHomo : (A : hSet L) (B : MODEL T L .ob) (x : ⟨ A ⟩)
+      → Homo (HomAlgebra A B) (_ , B .snd .fst)
+    evalHomo A B x .fst f = f x
+    evalHomo A B x .snd op γ op⟨γ⟩ p i = p i x
+
+    HomIsModel : (A : hSet L) (B : MODEL T L .ob)
+      → IsModel (HomAlgebra A B)
+    HomIsModel A B e γ = funExt λ x →
+      sym (interpHomo (evalHomo A B x) γ (lhs e))
+      ∙ B .snd .snd e (λ v → γ v x)
+      ∙ interpHomo (evalHomo A B x) γ (rhs e)
+
+    HomModel : (A : hSet L) (B : MODEL T L .ob) → Model L
+    HomModel A B .fst = HomAlgebra A B
+    HomModel A B .snd .fst = HomIsModel A B
+    HomModel A B .snd .snd = isSetΠ λ _ → B .fst .snd
+
+    HomAlgebraᴰ : (A : hSet L) (B : MODEL T L .ob)
+      (Aᴰ : ⟨ A ⟩ → hSet L)
+      (Bᴰ : Categoryᴰ.ob[_] (MODELᴰ T L L) B)
+      → Algebraᴰ (HomAlgebra A B) L
+    HomAlgebraᴰ A B Aᴰ Bᴰ .fst f =
+      (x : ⟨ A ⟩) → ⟨ Aᴰ x ⟩ → ⟨ Bᴰ .fst (f x) ⟩
+    HomAlgebraᴰ A B Aᴰ Bᴰ .snd
+      op γ γᴰ op⟨γ⟩ p x xᴰ =
+        Bᴰ .snd .fst op (λ v → γ v x) (λ v → γᴰ v x xᴰ)
+          (op⟨γ⟩ x) (λ i → p i x)
+
+    interpHomᴰAt : (A : hSet L) (B : MODEL T L .ob)
+      (Aᴰ : ⟨ A ⟩ → hSet L)
+      (Bᴰ : Categoryᴰ.ob[_] (MODELᴰ T L L) B)
+      {V : Type ℓ}
+      (ρ : V → HomAlgebra A B .fst)
+      (ρᴰ : (v : V) → HomAlgebraᴰ A B Aᴰ Bᴰ .fst (ρ v))
+      (t : |FreeAlgebra| V) (x : ⟨ A ⟩) (xᴰ : ⟨ Aᴰ x ⟩)
+      → interpᴰ (HomAlgebraᴰ A B Aᴰ Bᴰ) ρ ρᴰ t x xᴰ
+        ≡ interpᴰ
+            (evalHomo A B x S.* (_ , Bᴰ .snd .fst))
+            ρ (λ v → ρᴰ v x xᴰ) t
+    interpHomᴰAt A B Aᴰ Bᴰ ρ ρᴰ (var v) x xᴰ = refl
+    interpHomᴰAt A B Aᴰ Bᴰ ρ ρᴰ (app op γ) x xᴰ =
+      cong
+        (λ γᴰ → Bᴰ .snd .fst op
+          (λ v → interp (HomAlgebra A B) ρ (γ v) x) γᴰ
+          (interp (HomAlgebra A B) ρ (app op γ) x)
+          (λ i → recFA (HomAlgebra A B) ρ .snd
+            op γ (app op γ) refl i x))
+        (funExt λ v → interpHomᴰAt A B Aᴰ Bᴰ ρ ρᴰ (γ v) x xᴰ)
+
+  ModelCBPVModel : ModelEnrichment (ModelCBPV .fst) T
+  ModelCBPVModel .fst A B .fst = HomModel A B .fst .snd
+  ModelCBPVModel .fst A B .snd = HomModel A B .snd .fst
+  ModelCBPVModel .snd .fst V B op γ op⟨γ⟩ p =
+    λ i x → p i (V x)
+  ModelCBPVModel .snd .snd S A op γ op⟨γ⟩ p =
+    funExt λ x → S .snd op (λ v → γ v x) (op⟨γ⟩ x)
+      (λ i → p i x)
+
+  module _
+    (C : CBPVCat ℓ L) (CModel : ModelEnrichment C T)
+    (P : Fibers.ob[_] C 𝒱)
+    where
+    private module C = Fibers C
+
+    points : Functorⱽ C (ModelCBPV .fst)
+    points .F-obᴰ {x = 𝒱} A = C.Hom[ _ ][ P , A ] , C.isSetHomᴰ
+    points .F-obᴰ {x = 𝒞} B =
+      ((C.Hom[ _ ][ P , B ] , C.isSetHomᴰ) , CModel .fst P B)
+    points .F-homᴰ {x = 𝒱} {y = 𝒱} f M = M C.⋆ᴰ f
+    points .F-homᴰ {x = 𝒱} {y = 𝒞} f M = M C.⋆ᴰ f
+    points .F-homᴰ {x = 𝒞} {y = 𝒞} f =
+      (λ M → M C.⋆ᴰ f) , CModel .snd .snd f P
+    points .F-idᴰ {x = 𝒱} = funExt C.⋆IdRᴰ
+    points .F-idᴰ {x = 𝒞} =
+      Σ≡Prop (λ _ → isPropΠ4 λ _ _ _ _ → C.isSetHomᴰ _ _)
+        (funExt C.⋆IdRᴰ)
+    points .F-seqᴰ {x = 𝒱} {y = 𝒱} {z = 𝒱} f g =
+      funExt λ M → sym (C.⋆Assocᴰ M f g)
+    points .F-seqᴰ {x = 𝒱} {y = 𝒱} {z = 𝒞} f g =
+      funExt λ M → sym (C.⋆Assocᴰ M f g)
+    points .F-seqᴰ {x = 𝒱} {y = 𝒞} {z = 𝒞} f g =
+      funExt λ M → sym (C.⋆Assocᴰ M f g)
+    points .F-seqᴰ {x = 𝒞} {y = 𝒞} {z = 𝒞} f g =
+      Σ≡Prop (λ _ → isPropΠ4 λ _ _ _ _ → C.isSetHomᴰ _ _)
+        (funExt λ M → sym (C.⋆Assocᴰ M f g))
+
+    pointsPreservesModel :
+      PreservesModelEnrichment T points CModel ModelCBPVModel
+    pointsPreservesModel A B op γ op⟨γ⟩ p =
+      funExt λ V → CModel .snd .fst V B op γ op⟨γ⟩ p
+
+  ModelCBPVModelᴰ : ModelEnrichmentᴰ T ModelCBPVModel ModelCBPVᴰ
+  ModelCBPVModelᴰ .fst {A = A} {B = B} Aᴰ Bᴰ .fst =
+    HomAlgebraᴰ A B Aᴰ Bᴰ .snd
+  ModelCBPVModelᴰ .fst {A = A} {B = B} Aᴰ Bᴰ .snd e ρ ρᴰ i x xᴰ =
+    hSetReasoning.rectifyOut (B .fst) (λ b → ⟨ Bᴰ .fst b ⟩)
+      {e' = cong (λ f → f x) (HomIsModel A B e ρ)}
+      ( (λ j →
+          interp (HomAlgebra A B) ρ (lhs e) x
+          , interpHomᴰAt A B Aᴰ Bᴰ ρ ρᴰ (lhs e) x xᴰ j)
+      ∙ sym (interpPullback (evalHomo A B x)
+          (_ , Bᴰ .snd .fst) ρ (λ v → ρᴰ v x xᴰ) (lhs e))
+      ∙ ΣPathP
+          ( B .snd .snd e (λ v → ρ v x)
+          , Bᴰ .snd .snd e (λ v → ρ v x)
+              (λ v → ρᴰ v x xᴰ))
+      ∙ interpPullback (evalHomo A B x)
+          (_ , Bᴰ .snd .fst) ρ (λ v → ρᴰ v x xᴰ) (rhs e)
+      ∙ (λ j →
+          interp (HomAlgebra A B) ρ (rhs e) x
+          , interpHomᴰAt A B Aᴰ Bᴰ ρ ρᴰ (rhs e) x xᴰ (~ j))) i
+  ModelCBPVModelᴰ .snd .fst {V = V} Vᴰ
+    op γ γᴰ op⟨γ⟩ p op⟨γᴰ⟩ pᴰ i x xᴰ =
+      pᴰ i (V x) (Vᴰ x xᴰ)
+  ModelCBPVModelᴰ .snd .snd {S = S} Sᴰ
+    op γ γᴰ op⟨γ⟩ p op⟨γᴰ⟩ pᴰ i x xᴰ =
+      Sᴰ .snd op (λ v → γ v x) (λ v → γᴰ v x xᴰ)
+        (op⟨γ⟩ x) (λ j → p j x)
+        (op⟨γᴰ⟩ x xᴰ) (λ j → pᴰ j x xᴰ) i

--- a/Cubical/Categories/Displayed/CBPV/Unary/Instances/Model/ConcreteFree.agda
+++ b/Cubical/Categories/Displayed/CBPV/Unary/Instances/Model/ConcreteFree.agda
@@ -1,0 +1,184 @@
+{-# OPTIONS --prop --lossy-unification #-}
+module Cubical.Categories.Displayed.CBPV.Unary.Instances.Model.ConcreteFree where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Isomorphism.More
+open import Cubical.Foundations.More
+open import Cubical.Foundations.Structure
+
+open import Cubical.Data.Sigma
+
+open import Cubical.Algebra.Theory.Base
+  hiding (ℓ; ℓᴰ; ℓᴰᴰ; ℓ'; ℓᴰ'; ℓᴰᴰ'; ℓ''; ℓᴰ''; ℓO; ℓA; ℓE)
+
+open import Cubical.Categories.Adjoint.UniversalElements
+open import Cubical.Categories.Category
+open import Cubical.Categories.Instances.Fiber
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.TotalCategory
+open import Cubical.Categories.Instances.WalkingArrow
+  renaming (l to 𝒱; r to 𝒞)
+open import Cubical.Categories.Presheaf.Representable
+
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Instances.Algebra.Model
+open import Cubical.Categories.Displayed.Instances.Algebra.DisplayedModel
+open import Cubical.Categories.Displayed.Instances.Opposite
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Fibration
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Representable
+open import Cubical.Categories.Displayed.CBPV.Unary.Instances.Model.Base
+open import Cubical.Categories.Displayed.CBPV.Unary.Instances.Model.Multiplicative
+
+open Category
+open UniversalElement
+
+private
+  variable
+    ℓO ℓA ℓE ℓEA : Level
+
+module _ (T : Theory ℓO ℓA ℓE ℓEA) where
+  open Theory T
+
+  private
+    L = ModelLevel T
+
+  Model→MODEL : Model L → Category.ob (MODEL T L)
+  Model→MODEL M .fst = M .fst .fst , M .snd .snd
+  Model→MODEL M .snd .fst = M .fst .snd
+  Model→MODEL M .snd .snd = M .snd .fst
+
+  MODEL→Model : Category.ob (MODEL T L) → Model L
+  MODEL→Model M .fst = ⟨ M .fst ⟩ , M .snd .fst
+  MODEL→Model M .snd .fst = M .snd .snd
+  MODEL→Model M .snd .snd = M .fst .snd
+
+  private
+    Modelᴰ→MODELᴰ : (M : Model L) (Mᴰ : Modelᴰ M L) →
+      Categoryᴰ.ob[_] (MODELᴰ T L L) (Model→MODEL M)
+    Modelᴰ→MODELᴰ M Mᴰ .fst x =
+      Mᴰ .fst .fst x , Mᴰ .snd .snd x
+    Modelᴰ→MODELᴰ M Mᴰ .snd .fst = Mᴰ .fst .snd
+    Modelᴰ→MODELᴰ M Mᴰ .snd .snd = Mᴰ .snd .fst
+
+    MODELᴰ→Modelᴰ : {M : Category.ob (MODEL T L)} →
+      Categoryᴰ.ob[_] (MODELᴰ T L L) M → Modelᴰ (MODEL→Model M) L
+    MODELᴰ→Modelᴰ Mᴰ .fst .fst x = ⟨ Mᴰ .fst x ⟩
+    MODELᴰ→Modelᴰ Mᴰ .fst .snd = Mᴰ .snd .fst
+    MODELᴰ→Modelᴰ Mᴰ .snd .fst = Mᴰ .snd .snd
+    MODELᴰ→Modelᴰ Mᴰ .snd .snd x = Mᴰ .fst x .snd
+
+  FreeRestriction :
+    (FreeModel : hSet L → Model L)
+    (η : (A : hSet L) → ⟨ A ⟩ → FreeModel A .fst .fst)
+    (A : hSet L) (B : Model L) →
+    Homo (FreeModel A .fst) (B .fst) → ⟨ A ⟩ → B .fst .fst
+  FreeRestriction FreeModel η A B ϕ x = ϕ .fst (η A x)
+
+  FreeRestrictionᴰ :
+    (FreeModel : hSet L → Model L)
+    (η : (A : hSet L) → ⟨ A ⟩ → FreeModel A .fst .fst)
+    (FreeModelᴰ : (A : hSet L) (Aᴰ : ⟨ A ⟩ → hSet L) →
+      Modelᴰ (FreeModel A) L)
+    (ηᴰ : (A : hSet L) (Aᴰ : ⟨ A ⟩ → hSet L)
+      (x : ⟨ A ⟩) → ⟨ Aᴰ x ⟩ →
+      FreeModelᴰ A Aᴰ .fst .fst (η A x))
+    (A : hSet L) (Aᴰ : ⟨ A ⟩ → hSet L)
+    {B : Model L} (ϕ : Homo (FreeModel A .fst) (B .fst))
+    (Bᴰ : Modelᴰ B L) →
+    Homoᴰ ϕ (FreeModelᴰ A Aᴰ .fst) (Bᴰ .fst) →
+    (x : ⟨ A ⟩) → ⟨ Aᴰ x ⟩ →
+      Bᴰ .fst .fst (ϕ .fst (η A x))
+  FreeRestrictionᴰ FreeModel η FreeModelᴰ ηᴰ A Aᴰ ϕ Bᴰ ϕᴰ x xᴰ =
+    ϕᴰ .fst (η A x) (ηᴰ A Aᴰ x xᴰ)
+
+  module _
+    (FreeModel : hSet L → Model L)
+    (η : (A : hSet L) → ⟨ A ⟩ → FreeModel A .fst .fst)
+    (FreeUniversal : (A : hSet L) (B : Model L) →
+      isEquiv (FreeRestriction FreeModel η A B))
+    (FreeModelᴰ : (A : hSet L) (Aᴰ : ⟨ A ⟩ → hSet L) →
+      Modelᴰ (FreeModel A) L)
+    (ηᴰ : (A : hSet L) (Aᴰ : ⟨ A ⟩ → hSet L)
+      (x : ⟨ A ⟩) → ⟨ Aᴰ x ⟩ →
+      FreeModelᴰ A Aᴰ .fst .fst (η A x))
+    (FreeUniversalᴰ : (A : hSet L) (Aᴰ : ⟨ A ⟩ → hSet L)
+      {B : Model L} (ϕ : Homo (FreeModel A .fst) (B .fst))
+      (Bᴰ : Modelᴰ B L) →
+      isEquiv
+        (FreeRestrictionᴰ FreeModel η FreeModelᴰ ηᴰ A Aᴰ ϕ Bᴰ))
+    where
+
+    ConcreteFreeMODEL : hSet L → Category.ob (MODEL T L)
+    ConcreteFreeMODEL A = Model→MODEL (FreeModel A)
+
+    ConcreteMODELFree : LeftAdjoint (MODELForget T)
+    ConcreteMODELFree A .vertex = ConcreteFreeMODEL A
+    ConcreteMODELFree A .element = η A
+    ConcreteMODELFree A .universal B =
+      FreeUniversal A (MODEL→Model B)
+
+    private
+      ConcreteFreeMODELᴰ : (A : hSet L) (Aᴰ : ⟨ A ⟩ → hSet L) →
+        Categoryᴰ.ob[_] (MODELᴰ T L L) (ConcreteFreeMODEL A)
+      ConcreteFreeMODELᴰ A Aᴰ =
+        Modelᴰ→MODELᴰ (FreeModel A) (FreeModelᴰ A Aᴰ)
+
+      C = ModelCBPVWithFree T ConcreteMODELFree .fst
+      Cᴰ = ModelCBPVᴰWithFree T ConcreteMODELFree
+
+      η-lift : (A : hSet L) (Aᴰ : ⟨ A ⟩ → hSet L) →
+        CartesianLift (Cᴰ ^opᴰᴰ)
+          (FreeMODELη T ConcreteMODELFree A) Aᴰ
+      η-lift A Aᴰ = UniversalElementⱽ'.REPRⱽ ue
+        where
+        module Cᴰᶠ = Fibers (Cᴰ ^opᴰᴰ)
+        module Dᴰ = Fibers (MODELᴰ T L L)
+
+        ue : UniversalElementⱽ' (Cᴰ ^opᴰᴰ)
+          (𝒞 , ConcreteFreeMODEL A)
+          (CartesianLiftPshSpec
+            ((∫C (C ^opᴰ)) [-, (𝒱 , A) ])
+            (Cᴰ ^opᴰᴰ)
+            ((Cᴰ ^opᴰᴰ) [-][-, Aᴰ ])
+            (FreeMODELη T ConcreteMODELFree A))
+        ue .UniversalElementⱽ'.vertexⱽ = ConcreteFreeMODELᴰ A Aᴰ
+        ue .UniversalElementⱽ'.elementⱽ = ηᴰ A Aᴰ
+        ue .UniversalElementⱽ'.universalⱽ
+          ((𝒱 , Z) , Zᴰ , ()) .fst
+        ue .UniversalElementⱽ'.universalⱽ
+          ((𝒞 , Z) , Zᴰ , ϕ) .fst ıᴰ =
+            isEquivToIsIso _
+              (FreeUniversalᴰ A Aᴰ (ϕ .snd) (MODELᴰ→Modelᴰ Zᴰ))
+              .fst ıᴰ
+        ue .UniversalElementⱽ'.universalⱽ
+          ((𝒱 , Z) , Zᴰ , ()) .snd .fst
+        ue .UniversalElementⱽ'.universalⱽ
+          ((𝒞 , Z) , Zᴰ , ϕ) .snd .fst ıᴰ =
+            Cᴰᶠ.rectifyOut {e' = refl}
+              ( Cᴰᶠ.reind-filler⁻ _
+              ∙ Cᴰᶠ.≡in {pth = refl}
+                  (isEquivToIsIso _
+                    (FreeUniversalᴰ A Aᴰ
+                      (ϕ .snd) (MODELᴰ→Modelᴰ Zᴰ))
+                    .snd .fst ıᴰ))
+        ue .UniversalElementⱽ'.universalⱽ
+          ((𝒱 , Z) , Zᴰ , ()) .snd .snd
+        ue .UniversalElementⱽ'.universalⱽ
+          ((𝒞 , Z) , Zᴰ , ϕ) .snd .snd ϕᴰ =
+            cong (ue .UniversalElementⱽ'.universalⱽ
+              ((𝒞 , Z) , Zᴰ , ϕ) .fst)
+              (Cᴰᶠ.rectifyOut {e' = refl} (Cᴰᶠ.reind-filler⁻ _))
+            ∙ (Dᴰ.rectify $ Dᴰ.≡out $
+                Dᴰ.≡in {pth = refl}
+                  (isEquivToIsIso _
+                    (FreeUniversalᴰ A Aᴰ
+                      (ϕ .snd) (MODELᴰ→Modelᴰ Zᴰ))
+                    .snd .snd ϕᴰ))
+
+    ConcreteFreeMODELConstruction : FreeMODELConstruction T
+    ConcreteFreeMODELConstruction .fst = ConcreteMODELFree
+    ConcreteFreeMODELConstruction .snd = η-lift

--- a/Cubical/Categories/Displayed/CBPV/Unary/Instances/Model/Multiplicative.agda
+++ b/Cubical/Categories/Displayed/CBPV/Unary/Instances/Model/Multiplicative.agda
@@ -1,0 +1,576 @@
+{-# OPTIONS --prop --lossy-unification #-}
+module Cubical.Categories.Displayed.CBPV.Unary.Instances.Model.Multiplicative where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism
+open import Cubical.Foundations.Isomorphism.More
+open import Cubical.Foundations.More
+open import Cubical.Foundations.Structure
+
+open import Cubical.Data.Sigma
+open import Cubical.Data.Bool
+import Cubical.Data.Equality as Eq
+
+open import Cubical.Algebra.Theory.Base
+  hiding (ℓ; ℓᴰ; ℓᴰᴰ; ℓ'; ℓᴰ'; ℓᴰᴰ'; ℓ''; ℓᴰ''; ℓO; ℓA; ℓE)
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Adjoint.UniversalElements
+open import Cubical.Categories.Instances.Fiber
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.TotalCategory hiding (elim)
+open import Cubical.Categories.Instances.WalkingArrow
+  renaming (l to 𝒱; r to 𝒞)
+import Cubical.Categories.Instances.WalkingArrow as WA
+open import Cubical.Categories.Presheaf.Morphism.Alt
+open import Cubical.Categories.Presheaf.Representable
+
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Instances.Algebra.Model
+open import Cubical.Categories.Displayed.Instances.Algebra.DisplayedModel
+open import Cubical.Categories.Displayed.Instances.Opposite
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Fibration
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Representable
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Eq.Conversion.CartesianV
+import Cubical.Categories.Displayed.Presheaf.Uncurried.Eq.Base as EqPsh
+open import Cubical.Categories.Displayed.CBPV.Unary.Base
+open import Cubical.Categories.Displayed.CBPV.Unary.Instances.Model.Base
+
+private
+  variable
+    ℓX ℓO ℓA ℓE ℓEA : Level
+
+module _ (T : Theory ℓO ℓA ℓE ℓEA) where
+  open Theory T
+
+  private
+    L = ModelLevel T
+    C = ModelCBPV T .fst
+    Cᴰ = ModelCBPVᴰ T
+
+    MODELOb→Model : Category.ob (MODEL T L) → Model L
+    MODELOb→Model B .fst = ⟨ B .fst ⟩ , B .snd .fst
+    MODELOb→Model B .snd .fst = B .snd .snd
+    MODELOb→Model B .snd .snd = B .fst .snd
+
+    MODELᴰOb→Modelᴰ : ∀ {B : Category.ob (MODEL T L)}
+      → Categoryᴰ.ob[_] (MODELᴰ T L L) B
+      → Modelᴰ (MODELOb→Model B) L
+    MODELᴰOb→Modelᴰ Bᴰ .fst .fst b = ⟨ Bᴰ .fst b ⟩
+    MODELᴰOb→Modelᴰ Bᴰ .fst .snd = Bᴰ .snd .fst
+    MODELᴰOb→Modelᴰ Bᴰ .snd .fst = Bᴰ .snd .snd
+    MODELᴰOb→Modelᴰ Bᴰ .snd .snd b = Bᴰ .fst b .snd
+
+    CBPVIdR : EqPsh.EqIdR (∫C C)
+    CBPVIdR {x = 𝒱 , A} {y = 𝒱 , B} f = Eq.refl
+    CBPVIdR {x = 𝒱 , A} {y = 𝒞 , B} f =
+      Eq.pathToEq (Category.⋆IdR (∫C C) f)
+    CBPVIdR {x = 𝒞 , A} {y = 𝒱 , B} ()
+    CBPVIdR {x = 𝒞 , A} {y = 𝒞 , B} f = Eq.refl
+
+    CBPVAssoc : EqPsh.ReprEqAssoc (∫C C)
+    CBPVAssoc (𝒱 , A)
+      {c = 𝒱 , W} {c' = 𝒱 , X} {c'' = 𝒱 , Y}
+      _ _ _ _ Eq.refl = Eq.refl
+    CBPVAssoc (𝒞 , B)
+      {c = 𝒱 , W} {c' = 𝒱 , X} {c'' = 𝒱 , Y}
+      _ _ _ _ Eq.refl = Eq.refl
+    CBPVAssoc x f g p f⋆g e = Eq.pathToEq
+      (sym (D.⋆Assoc f g p) ∙ cong (λ fg → fg D.⋆ p) (Eq.eqToPath e))
+      where module D = Category (∫C C)
+
+  FreeMODELη : (Free : LeftAdjoint (MODELForget T)) (A : hSet L)
+    → ∫C (C ^opᴰ)
+        [ (WA.r , Free A .UniversalElement.vertex) , (WA.l , A) ]
+  FreeMODELη Free A = _ , Free A .UniversalElement.element
+
+  -- A chosen free-model adjunction together with the displayed universal
+  -- property of its unit.  The vertex of the lift is the chosen free
+  -- displayed model; no particular syntax for either free object is exposed.
+  FreeMODELConstruction : Type _
+  FreeMODELConstruction =
+    Σ[ Free ∈ LeftAdjoint (MODELForget T) ]
+      ((A : hSet L) (Aᴰ : ⟨ A ⟩ → hSet L) →
+        CartesianLift ((ModelCBPVᴰWithFree T Free) ^opᴰᴰ)
+          (FreeMODELη Free A) Aᴰ)
+
+  -- A possibly lower-universe presentation of a free model.  This separate
+  -- formulation lets canonicity return native carriers such as the usual
+  -- state, writer, or reader representation rather than a lifted generator.
+  FreeMODELPresentation : Type ℓX → Type _
+  FreeMODELPresentation X =
+    Σ[ FreeX ∈ Category.ob (MODEL T L) ]
+    Σ[ ηX ∈ (X → ⟨ FreeX .fst ⟩) ]
+      ((B : Category.ob (MODEL T L)) →
+        isEquiv (λ (ϕ : MODEL T L [ FreeX , B ]) →
+          ϕ .fst ∘ ηX))
+
+  FreeMODELPresentationFromAdjunction :
+    (Free : LeftAdjoint (MODELForget T)) (X : hSet L)
+    → FreeMODELPresentation ⟨ X ⟩
+  FreeMODELPresentationFromAdjunction Free X .fst =
+    Free X .UniversalElement.vertex
+  FreeMODELPresentationFromAdjunction Free X .snd .fst =
+    Free X .UniversalElement.element
+  FreeMODELPresentationFromAdjunction Free X .snd .snd =
+    Free X .UniversalElement.universal
+
+  BoolFreeMODELConstruction : Type _
+  BoolFreeMODELConstruction = FreeMODELPresentation Bool
+
+  ModelCBPV-Uⱽ : hasUⱽ Cᴰ
+  ModelCBPV-Uⱽ {A = A} {B = B} f Bᴰ =
+    EqCartesianLift→CartesianLift CBPVAssoc Cᴰ Bᴰ (𝒱 , A) (_ , f)
+      (EqPsh.UEⱽ→Reprⱽ _ CBPVIdR ue)
+    where
+    ue : EqPsh.CartesianLiftUE Cᴰ CBPVAssoc CBPVIdR (_ , f) Bᴰ
+    ue .EqPsh.UEⱽ.v x = Bᴰ .fst (f x)
+    ue .EqPsh.UEⱽ.e _ xᴰ = xᴰ
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , Z) , Zᴰ , g) .fst h = h
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , Z) , Zᴰ , ()) .fst
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , Z) , Zᴰ , g) .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , Z) , Zᴰ , ()) .snd .fst
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒱 , Z) , Zᴰ , g) .snd .snd _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      ((𝒞 , Z) , Zᴰ , ()) .snd .snd
+
+  private
+    FreeMODELᴰ : (A : hSet L) (Aᴰ : ⟨ A ⟩ → hSet L)
+      → Categoryᴰ.ob[_] (MODELᴰ T L L) (FreeMODEL T A)
+    FreeMODELᴰ A Aᴰ .fst t =
+      |FreeModelᴰ| ⟨ A ⟩ (λ x → ⟨ Aᴰ x ⟩) t ,
+      isSetFreeModelᴰ ⟨ A ⟩ (λ x → ⟨ Aᴰ x ⟩) t
+    FreeMODELᴰ A Aᴰ .snd .fst =
+      FreeModelᴰ ⟨ A ⟩ (λ x → ⟨ Aᴰ x ⟩) .fst .snd
+    FreeMODELᴰ A Aᴰ .snd .snd =
+      FreeModelᴰ ⟨ A ⟩ (λ x → ⟨ Aᴰ x ⟩) .snd .fst
+
+    η-base : (A : hSet L) → (∫C C) [ (𝒱 , A) , (𝒞 , FreeMODEL T A) ]
+    η-base A = _ , var
+
+    η-lift : (A : hSet L) (Aᴰ : ⟨ A ⟩ → hSet L)
+      → CartesianLift (Cᴰ ^opᴰᴰ) (η-base A) Aᴰ
+    η-lift A Aᴰ = UniversalElementⱽ'.REPRⱽ ue
+      where
+      module Cᴰᶠ = Fibers (Cᴰ ^opᴰᴰ)
+      module Dᴰ = Fibers (MODELᴰ T L L)
+
+      ue : UniversalElementⱽ' (Cᴰ ^opᴰᴰ)
+        (𝒞 , FreeMODEL T A)
+        (CartesianLiftPshSpec
+          ((∫C (C ^opᴰ)) [-, (𝒱 , A) ])
+          (Cᴰ ^opᴰᴰ)
+          ((Cᴰ ^opᴰᴰ) [-][-, Aᴰ ])
+          (η-base A))
+      ue .UniversalElementⱽ'.vertexⱽ = FreeMODELᴰ A Aᴰ
+      ue .UniversalElementⱽ'.elementⱽ x xᴰ = |FreeModelᴰ|.var xᴰ
+      ue .UniversalElementⱽ'.universalⱽ
+        ((𝒱 , Z) , Zᴰ , ()) .fst
+      ue .UniversalElementⱽ'.universalⱽ
+        ((𝒞 , Z) , Zᴰ , ϕ) .fst ıᴰ =
+          recFMᴰ ⟨ A ⟩ (λ x → ⟨ Aᴰ x ⟩) (ϕ .snd)
+            (MODELᴰOb→Modelᴰ Zᴰ) ıᴰ
+      ue .UniversalElementⱽ'.universalⱽ
+        ((𝒱 , Z) , Zᴰ , ()) .snd .fst
+      ue .UniversalElementⱽ'.universalⱽ
+        ((𝒞 , Z) , Zᴰ , ϕ) .snd .fst ıᴰ =
+          Cᴰᶠ.rectifyOut {e' = refl} $
+            Cᴰᶠ.reind-filler⁻ _
+            ∙ Cᴰᶠ.≡in {pth = refl} (funExt λ x → funExt λ xᴰ →
+              hSetReasoning.rectifyOut (Z .fst)
+                (λ z → ⟨ Zᴰ .fst z ⟩) refl)
+      ue .UniversalElementⱽ'.universalⱽ
+        ((𝒱 , Z) , Zᴰ , ()) .snd .snd
+      ue .UniversalElementⱽ'.universalⱽ
+        ((𝒞 , Z) , Zᴰ , ϕ) .snd .snd ϕᴰ =
+          cong (ue .UniversalElementⱽ'.universalⱽ
+            ((𝒞 , Z) , Zᴰ , ϕ) .fst)
+            (Cᴰᶠ.rectifyOut {e' = refl} (Cᴰᶠ.reind-filler⁻ _))
+          ∙ (Dᴰ.rectify $ Dᴰ.≡out $
+              Dᴰ.≡in {pth = refl}
+                (MODELᴰHomo≡ T _ _
+                  (sym (recFMᴰ-η ⟨ A ⟩ (λ x → ⟨ Aᴰ x ⟩)
+                    (ϕ .snd) (MODELᴰOb→Modelᴰ Zᴰ)
+                    (_ , ϕᴰ .snd)))))
+
+    module _ {B B' : Category.ob (MODEL T L)}
+      (ϕ : Homo (MODELOb→Model B .fst) (MODELOb→Model B' .fst))
+      (Bᴰ : Categoryᴰ.ob[_] (MODELᴰ T L L) B) where
+
+      private
+        BModelᴰ = MODELᴰOb→Modelᴰ Bᴰ
+
+      PushAlgebraᴰ : Algebraᴰ (MODELOb→Model B' .fst) L
+      PushAlgebraᴰ .fst b' =
+        Σ[ b ∈ ⟨ B .fst ⟩ ] (ϕ .fst b ≡ b') × ⟨ Bᴰ .fst b ⟩
+      PushAlgebraᴰ .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ =
+        B .snd .fst op (λ v → γᴰ v .fst) ,
+        (sym (ϕ .snd op (λ v → γᴰ v .fst) _ refl)
+          ∙ cong (B' .snd .fst op) (funExt λ v → γᴰ v .snd .fst)
+          ∙ op∘γ≡op⟨γ⟩) ,
+        Bᴰ .snd .fst op (λ v → γᴰ v .fst)
+          (λ v → γᴰ v .snd .snd) _ refl
+
+      private
+        PushTotal : Algebra L
+        PushTotal = ∫Algebra PushAlgebraᴰ
+
+        SourceTotal : Model L
+        SourceTotal = ∫Model BModelᴰ
+
+        forgetPush : PushTotal .fst → SourceTotal .fst .fst
+        forgetPush z = z .snd .fst , z .snd .snd .snd
+
+        forgetPushHomo : Homo PushTotal (SourceTotal .fst)
+        forgetPushHomo .fst = forgetPush
+        forgetPushHomo .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ i .fst =
+          op∘γ≡op⟨γ⟩ i .snd .fst
+        forgetPushHomo .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ i .snd =
+          op∘γ≡op⟨γ⟩ i .snd .snd .snd
+
+        sourceEquation : ∀ e
+          (ρ : EqArity e → ⟨ B' .fst ⟩)
+          (ρᴰ : (v : EqArity e) → PushAlgebraᴰ .fst (ρ v))
+          → Path (SourceTotal .fst .fst)
+              ( forgetPush
+                ( interp (MODELOb→Model B' .fst) ρ (lhs e)
+                , interpᴰ PushAlgebraᴰ ρ ρᴰ (lhs e)))
+              ( forgetPush
+                ( interp (MODELOb→Model B' .fst) ρ (rhs e)
+                , interpᴰ PushAlgebraᴰ ρ ρᴰ (rhs e)))
+        sourceEquation e ρ ρᴰ =
+          cong forgetPush
+            (sym (interp∫ {Aᴰ = PushAlgebraᴰ}
+              (λ v → ρ v , ρᴰ v) (lhs e)))
+          ∙ sym (interpHomo forgetPushHomo
+              (λ v → ρ v , ρᴰ v) (lhs e))
+          ∙ SourceTotal .snd .fst e
+              (λ v → ρᴰ v .fst , ρᴰ v .snd .snd)
+          ∙ interpHomo forgetPushHomo
+              (λ v → ρ v , ρᴰ v) (rhs e)
+          ∙ cong forgetPush
+            (interp∫ {Aᴰ = PushAlgebraᴰ}
+              (λ v → ρ v , ρᴰ v) (rhs e))
+
+      PushMODELInternalᴰ : Categoryᴰ.ob[_] (MODELᴰ T L L) B'
+      PushMODELInternalᴰ .fst b' .fst = PushAlgebraᴰ .fst b'
+      PushMODELInternalᴰ .fst b' .snd =
+        isSetΣ (B .fst .snd) λ b →
+          isSet× (isProp→isSet (B' .fst .snd _ _)) (Bᴰ .fst b .snd)
+      PushMODELInternalᴰ .snd .fst = PushAlgebraᴰ .snd
+      PushMODELInternalᴰ .snd .snd e ρ ρᴰ i .fst =
+        sourceEquation e ρ ρᴰ i .fst
+      PushMODELInternalᴰ .snd .snd e ρ ρᴰ i .snd .fst =
+        isProp→PathP
+          (λ j → B' .fst .snd
+            (ϕ .fst (sourceEquation e ρ ρᴰ j .fst))
+            (B' .snd .snd e ρ j))
+          (interpᴰ PushAlgebraᴰ ρ ρᴰ (lhs e) .snd .fst)
+          (interpᴰ PushAlgebraᴰ ρ ρᴰ (rhs e) .snd .fst) i
+      PushMODELInternalᴰ .snd .snd e ρ ρᴰ i .snd .snd =
+        sourceEquation e ρ ρᴰ i .snd
+
+      push-inᴰ : Categoryᴰ.Hom[_][_,_] (MODELᴰ T L L) ϕ Bᴰ PushMODELInternalᴰ
+      push-inᴰ .fst b bᴰ = b , refl , bᴰ
+      push-inᴰ .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩
+        op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ =
+          ΣPathP
+            ( op∘γ≡op⟨γ⟩
+            , ΣPathP
+                ( isProp→PathP
+                    (λ i → B' .fst .snd
+                      (ϕ .fst (op∘γ≡op⟨γ⟩ i))
+                      (ϕ .fst op⟨γ⟩)) _ _
+                , hSetReasoning.rectifyOut (B .fst)
+                    (λ b → ⟨ Bᴰ .fst b ⟩)
+                    {e' = op∘γ≡op⟨γ⟩}
+                    (hSetReasoning.≡in (B .fst)
+                      (λ b → ⟨ Bᴰ .fst b ⟩)
+                      (λ i → Bᴰ .snd .fst op γ γᴰ
+                        (op∘γ≡op⟨γ⟩ i)
+                        (λ j → op∘γ≡op⟨γ⟩ (i ∧ j)))
+                    ∙ hSetReasoning.≡in (B .fst)
+                        (λ b → ⟨ Bᴰ .fst b ⟩)
+                        op∘γᴰ≡op⟨γᴰ⟩)))
+
+      module _ {Z : Category.ob (MODEL T L)}
+        (ψ : Homo (MODELOb→Model B' .fst) (MODELOb→Model Z .fst))
+        (Zᴰ : Categoryᴰ.ob[_] (MODELᴰ T L L) Z)
+        (γᴰ : Categoryᴰ.Hom[_][_,_] (MODELᴰ T L L)
+          (ϕ ⋆H ψ) Bᴰ Zᴰ) where
+
+        private
+          module ZᴰR = hSetReasoning (Z .fst) (λ z → ⟨ Zᴰ .fst z ⟩)
+
+        recPush-fᴰ : ∀ b' → ⟨ PushMODELInternalᴰ .fst b' ⟩
+          → ⟨ Zᴰ .fst (ψ .fst b') ⟩
+        recPush-fᴰ b' (b , p , bᴰ) =
+          ZᴰR.reind (cong (ψ .fst) p) (γᴰ .fst b bᴰ)
+
+        private
+          op-filler : ∀ op δ δᴰ z (p : Z .snd .fst op δ ≡ z)
+            → (Z .snd .fst op δ , Zᴰ .snd .fst op δ δᴰ _ refl)
+              ≡ (z , Zᴰ .snd .fst op δ δᴰ z p)
+          op-filler op δ δᴰ z p i .fst = p i
+          op-filler op δ δᴰ z p i .snd =
+            Zᴰ .snd .fst op δ δᴰ (p i) (λ j → p (i ∧ j))
+
+          child-path : ∀ {b'} (x : ⟨ PushMODELInternalᴰ .fst b' ⟩) →
+            Path (Σ ⟨ Z .fst ⟩ (λ z → ⟨ Zᴰ .fst z ⟩))
+              (ψ .fst (ϕ .fst (x .fst)) ,
+                γᴰ .fst (x .fst) (x .snd .snd))
+              (ψ .fst b' , recPush-fᴰ b' x)
+          child-path (b , p , bᴰ) = ΣPathP
+            ( cong (ψ .fst) p
+            , ZᴰR.rectifyOut (ZᴰR.reind-filler (cong (ψ .fst) p)))
+
+        recPushᴰ : Categoryᴰ.Hom[_][_,_] (MODELᴰ T L L)
+          ψ PushMODELInternalᴰ Zᴰ
+        recPushᴰ .fst = recPush-fᴰ
+        recPushᴰ .snd op δ δᴰ op⟨δ⟩ op∘δ≡op⟨δ⟩
+          op⟨δᴰ⟩ op∘δᴰ≡op⟨δᴰ⟩ =
+            ZᴰR.rectifyOut $
+              sym (op-filler op (ψ .fst ∘ δ)
+                (λ v → recPush-fᴰ (δ v) (δᴰ v)) _
+                (ψ .snd op δ op⟨δ⟩ op∘δ≡op⟨δ⟩))
+              ∙ sym (cong (∫Algebra (_ , Zᴰ .snd .fst) .snd op)
+                  (funExt (λ v → child-path (δᴰ v))))
+              ∙ op-filler op
+                  (ψ .fst ∘ ϕ .fst ∘ (λ v → δᴰ v .fst))
+                  (λ v → γᴰ .fst (δᴰ v .fst) (δᴰ v .snd .snd))
+                  _ ((ϕ ⋆H ψ) .snd op
+                    (λ v → δᴰ v .fst) _ refl)
+              ∙ ZᴰR.≡in
+                  (γᴰ .snd op
+                    (λ v → δᴰ v .fst)
+                    (λ v → δᴰ v .snd .snd) _ refl _ refl)
+              ∙ ZᴰR.reind-filler
+                  (cong (ψ .fst)
+                    (PushMODELInternalᴰ .snd .fst op δ δᴰ op⟨δ⟩
+                      op∘δ≡op⟨δ⟩ .snd .fst))
+              ∙ ZᴰR.≡in
+                  (cong (recPush-fᴰ op⟨δ⟩)
+                    op∘δᴰ≡op⟨δᴰ⟩)
+
+      push-path : ∀ b bᴰ {b'} (p : ϕ .fst b ≡ b') →
+        Path (Σ ⟨ B' .fst ⟩ (λ b' → ⟨ PushMODELInternalᴰ .fst b' ⟩))
+          (ϕ .fst b , b , refl , bᴰ)
+          (b' , b , p , bᴰ)
+      push-path b bᴰ p = ΣPathP
+        ( p
+        , ΣPathP
+            ( refl
+            , ΣPathP
+                ( isProp→PathP
+                    (λ i → B' .fst .snd (ϕ .fst b) (p i)) _ _
+                , refl)))
+
+      canonical-homᴰ : ∀ {Z : Category.ob (MODEL T L)}
+        (ψ : Homo (MODELOb→Model B' .fst) (MODELOb→Model Z .fst))
+        (Zᴰ : Categoryᴰ.ob[_] (MODELᴰ T L L) Z)
+        (χᴰ : Categoryᴰ.Hom[_][_,_] (MODELᴰ T L L) ψ PushMODELInternalᴰ Zᴰ)
+        → Categoryᴰ.Hom[_][_,_] (MODELᴰ T L L) (ϕ ⋆H ψ) Bᴰ Zᴰ
+      canonical-homᴰ {Z = Z} ψ Zᴰ χᴰ =
+        _⋆Hᴰ_
+          {A = MODELOb→Model B .fst}
+          {B = MODELOb→Model B' .fst}
+          {C = MODELOb→Model Z .fst}
+          {Aᴰ = MODELᴰOb→Modelᴰ Bᴰ .fst}
+          {Bᴰ = MODELᴰOb→Modelᴰ PushMODELInternalᴰ .fst}
+          {Cᴰ = MODELᴰOb→Modelᴰ Zᴰ .fst}
+          {ϕ = ϕ} {ψ = ψ} (_ , push-inᴰ .snd) (_ , χᴰ .snd)
+
+      recPush-η-fᴰ : ∀ {Z : Category.ob (MODEL T L)}
+        (ψ : Homo (MODELOb→Model B' .fst) (MODELOb→Model Z .fst))
+        (Zᴰ : Categoryᴰ.ob[_] (MODELᴰ T L L) Z)
+        (χᴰ : Categoryᴰ.Hom[_][_,_] (MODELᴰ T L L) ψ PushMODELInternalᴰ Zᴰ)
+        b' (x : ⟨ PushMODELInternalᴰ .fst b' ⟩)
+        → recPush-fᴰ ψ Zᴰ (canonical-homᴰ ψ Zᴰ χᴰ) b' x
+          ≡ χᴰ .fst b' x
+      recPush-η-fᴰ {Z = Z} ψ Zᴰ χᴰ b' (b , p , bᴰ) =
+        ZᴰR.rectifyOut $
+          ZᴰR.reind-filler⁻ (cong (ψ .fst) p)
+          ∙ cong totalχ (push-path b bᴰ p)
+        where
+        module ZᴰR = hSetReasoning (Z .fst) (λ z → ⟨ Zᴰ .fst z ⟩)
+        totalχ : (Σ ⟨ B' .fst ⟩ (λ z → ⟨ PushMODELInternalᴰ .fst z ⟩))
+          → Σ ⟨ Z .fst ⟩ (λ z → ⟨ Zᴰ .fst z ⟩)
+        totalχ q = ψ .fst (q .fst) , χᴰ .fst (q .fst) (q .snd)
+
+      push-base : ∫C (C ^opᴰ)
+        [ (𝒞 , B') , (𝒞 , B) ]
+      push-base = _ , ϕ
+
+      push-lift : CartesianLift (Cᴰ ^opᴰᴰ) push-base Bᴰ
+      push-lift = UniversalElementⱽ'.REPRⱽ ue
+        where
+        module Cᴰᶠ = Fibers (Cᴰ ^opᴰᴰ)
+        module Dᴰ = Fibers (MODELᴰ T L L)
+
+        Homo≡ : ∀ {X Z : Category.ob (MODEL T L)}
+          (f g : Homo (MODELOb→Model X .fst) (MODELOb→Model Z .fst))
+          → f .fst ≡ g .fst → f ≡ g
+        Homo≡ {Z = Z} f g p i .fst = p i
+        Homo≡ {Z = Z} f g p i .snd =
+          isProp→PathP
+            {B = λ i → isHomoSimpl _ _ (p i)}
+            (λ _ → isPropΠ4 λ _ _ _ _ → Z .fst .snd _ _)
+            (f .snd) (g .snd) i
+
+        CBPVHomo≡ : ∀ {X Z : Category.ob (MODEL T L)}
+          (f g : ∫C (C ^opᴰ) [ (𝒞 , Z) , (𝒞 , X) ])
+          → f .snd .fst ≡ g .snd .fst → f ≡ g
+        CBPVHomo≡ f g p i .fst = f .fst
+        CBPVHomo≡ {X = X} {Z = Z} f g p i .snd =
+          Homo≡ {X = X} {Z = Z} (f .snd) (g .snd) p i
+
+        MODELᴰHomoP≡ : ∀ {X Z : Category.ob (MODEL T L)}
+          {Xᴰ : Categoryᴰ.ob[_] (MODELᴰ T L L) X}
+          {Zᴰ : Categoryᴰ.ob[_] (MODELᴰ T L L) Z}
+          {f g : Homo (MODELOb→Model X .fst) (MODELOb→Model Z .fst)}
+          (p : f ≡ g)
+          (fᴰ : Categoryᴰ.Hom[_][_,_] (MODELᴰ T L L) f Xᴰ Zᴰ)
+          (gᴰ : Categoryᴰ.Hom[_][_,_] (MODELᴰ T L L) g Xᴰ Zᴰ)
+          → PathP
+              (λ i → ∀ x → ⟨ Xᴰ .fst x ⟩ → ⟨ Zᴰ .fst (p i .fst x) ⟩)
+              (fᴰ .fst) (gᴰ .fst)
+          → PathP
+              (λ i → Categoryᴰ.Hom[_][_,_] (MODELᴰ T L L) (p i) Xᴰ Zᴰ)
+              fᴰ gᴰ
+        MODELᴰHomoP≡ p fᴰ gᴰ q i .fst = q i
+        MODELᴰHomoP≡ {Zᴰ = Zᴰ} p fᴰ gᴰ q i .snd =
+          isProp→PathP
+            {B = λ i → isHomoᴰSimpl (p i)
+              (_ , _) (_ , Zᴰ .snd .fst) (q i)}
+            (λ _ → isPropΠ6 λ _ _ _ _ _ _ →
+              isPropΠ λ _ → Zᴰ .fst _ .snd _ _)
+            (fᴰ .snd) (gᴰ .snd) i
+
+        ue : UniversalElementⱽ' (Cᴰ ^opᴰᴰ)
+          (𝒞 , B')
+          (CartesianLiftPshSpec
+            ((∫C (C ^opᴰ)) [-, (𝒞 , B) ])
+            (Cᴰ ^opᴰᴰ)
+            ((Cᴰ ^opᴰᴰ) [-][-, Bᴰ ])
+            push-base)
+        ue .UniversalElementⱽ'.vertexⱽ = PushMODELInternalᴰ
+        ue .UniversalElementⱽ'.elementⱽ .fst = push-inᴰ .fst
+        ue .UniversalElementⱽ'.elementⱽ .snd =
+          subst
+            (λ hϕ → isHomoᴰSimpl (ϕ .fst , hϕ)
+              (_ , Bᴰ .snd .fst) (_ , PushMODELInternalᴰ .snd .fst)
+              (push-inᴰ .fst))
+            (isProp→PathP
+              (λ _ → isPropΠ4 λ _ _ _ _ → B' .fst .snd _ _)
+              (ϕ .snd) _)
+            (push-inᴰ .snd)
+        ue .UniversalElementⱽ'.universalⱽ
+          ((𝒞 , Z) , Zᴰ , ψ) .fst γᴰ =
+            recPushᴰ (ψ .snd) Zᴰ γᴰ
+        ue .UniversalElementⱽ'.universalⱽ
+          ((𝒞 , Z) , Zᴰ , ψ) .snd .fst γᴰ =
+            Cᴰᶠ.rectifyOut {e' = refl} $
+              Cᴰᶠ.reind-filler⁻ _
+              ∙ Cᴰᶠ.≡in
+                  {pth = CBPVHomo≡ _ _ refl}
+                  (MODELᴰHomoP≡ {X = B} {Z = Z}
+                    (Homo≡ {X = B} {Z = Z} _ _ refl) _ _
+                    (funExt λ b → funExt λ bᴰ →
+                      hSetReasoning.rectifyOut (Z .fst)
+                        (λ z → ⟨ Zᴰ .fst z ⟩)
+                        (hSetReasoning.reind-filler⁻ (Z .fst)
+                          (λ z → ⟨ Zᴰ .fst z ⟩) refl)))
+        ue .UniversalElementⱽ'.universalⱽ
+          ((𝒞 , Z) , Zᴰ , ψ) .snd .snd χᴰ =
+            cong (ue .UniversalElementⱽ'.universalⱽ
+              ((𝒞 , Z) , Zᴰ , ψ) .fst)
+              (Cᴰᶠ.rectifyOut {e' = refl} $
+                Cᴰᶠ.reind-filler⁻ _
+                ∙ Cᴰᶠ.≡in
+                    {pth = CBPVHomo≡ _ _ refl}
+                    (MODELᴰHomoP≡ {X = B} {Z = Z}
+                      (Homo≡ {X = B} {Z = Z} _ _ refl) _ _ refl))
+            ∙ (Dᴰ.rectify {a = B'} {b = Z}
+                {aᴰ = PushMODELInternalᴰ} {bᴰ = Zᴰ} $
+                Dᴰ.≡out $ Dᴰ.≡in {a = B'} {b = Z}
+                  {aᴰ = PushMODELInternalᴰ} {bᴰ = Zᴰ}
+                  {p = recPushᴰ (ψ .snd) Zᴰ
+                    (canonical-homᴰ (ψ .snd) Zᴰ χᴰ)}
+                  {q = χᴰ}
+                  (MODELᴰHomo≡ T _ _
+                    (funExt λ b' → funExt λ x →
+                      recPush-η-fᴰ (ψ .snd) Zᴰ χᴰ b' x)))
+
+  PushMODELᴰ : ∀ {B B' : Category.ob (MODEL T L)}
+    (ϕ : MODEL T L [ B , B' ])
+    (Bᴰ : Categoryᴰ.ob[_] (MODELᴰ T L L) B)
+    → Categoryᴰ.ob[_] (MODELᴰ T L L) B'
+  PushMODELᴰ = PushMODELInternalᴰ
+
+  CanonicalFreeMODELConstruction : FreeMODELConstruction
+  CanonicalFreeMODELConstruction .fst = MODELFree T
+  CanonicalFreeMODELConstruction .snd = η-lift
+
+  CanonicalBoolFreeMODELConstruction : BoolFreeMODELConstruction
+  CanonicalBoolFreeMODELConstruction .fst .fst =
+    FreeModel Bool .fst .fst , FreeModel Bool .snd .snd
+  CanonicalBoolFreeMODELConstruction .fst .snd .fst =
+    FreeModel Bool .fst .snd
+  CanonicalBoolFreeMODELConstruction .fst .snd .snd =
+    FreeModel Bool .snd .fst
+  CanonicalBoolFreeMODELConstruction .snd .fst = var
+  CanonicalBoolFreeMODELConstruction .snd .snd B = isIsoToIsEquiv
+    ( recFM Bool (MODELOb→Model B)
+    , (λ _ → refl)
+    , (λ ϕ → Σ≡Prop
+        (λ _ → isPropΠ4 λ _ _ _ _ → B .fst .snd _ _)
+        (sym (recFM-uniq Bool (MODELOb→Model B) ϕ)))
+    )
+
+  ModelCBPV-FⱽWithFree : (Free : FreeMODELConstruction) → hasFⱽ Cᴰ
+  ModelCBPV-FⱽWithFree Free {A = A} {B = B} f Aᴰ =
+    transportCartesianLift (Cᴰ ^opᴰᴰ) factor≡f composite
+    where
+    module Cᵒᵖ = Category (∫C (C ^opᴰ))
+
+    recf : MODEL T L [ Free .fst A .UniversalElement.vertex , B ]
+    recf = isEquivToIsIso _
+      (Free .fst A .UniversalElement.universal B) .fst f
+
+    free-lift : CartesianLift (Cᴰ ^opᴰᴰ)
+      (FreeMODELη (Free .fst) A) Aᴰ
+    free-lift = Free .snd A Aᴰ
+
+    composite : CartesianLift (Cᴰ ^opᴰᴰ)
+      ((_ , recf) Cᵒᵖ.⋆ (FreeMODELη (Free .fst) A)) Aᴰ
+    composite = composeCartesianLifts (Cᴰ ^opᴰᴰ)
+      free-lift (push-lift recf (free-lift .fst))
+
+    factor≡f :
+      ((_ , recf) Cᵒᵖ.⋆ (FreeMODELη (Free .fst) A)) ≡ (_ , f)
+    factor≡f = ΣPathP
+      ( refl
+      , isEquivToIsIso _
+          (Free .fst A .UniversalElement.universal B) .snd .fst f)
+
+  ModelCBPV-Fⱽ : hasFⱽ Cᴰ
+  ModelCBPV-Fⱽ = ModelCBPV-FⱽWithFree CanonicalFreeMODELConstruction
+
+  ModelCBPVⱽWithFree : (Free : FreeMODELConstruction) →
+    MultCBPVCatⱽ (ModelCBPVWithFree T (Free .fst) .fst)
+      (ℓ-suc L) L
+  ModelCBPVⱽWithFree Free .fst = Cᴰ
+  ModelCBPVⱽWithFree Free .snd .fst = ModelCBPV-Uⱽ
+  ModelCBPVⱽWithFree Free .snd .snd = ModelCBPV-FⱽWithFree Free
+
+  ModelCBPVⱽ : MultCBPVCatⱽ (ModelCBPV T .fst)
+    (ℓ-suc L) L
+  ModelCBPVⱽ = ModelCBPVⱽWithFree CanonicalFreeMODELConstruction

--- a/Cubical/Categories/Displayed/CBPV/Unary/Instances/StateAlg/Base.agda
+++ b/Cubical/Categories/Displayed/CBPV/Unary/Instances/StateAlg/Base.agda
@@ -116,6 +116,7 @@ StateAlgForgetᴰ .Functorᴰ.F-idᴰ = refl
 StateAlgForgetᴰ .Functorᴰ.F-seqᴰ fᴰ gᴰ = refl
 
 module _ (X : Type ℓ) where
+  -- The Free State Algebra can be constructed as the state monad
   FreeStateAlg : StateAlg (Bool → Bool × X)
   FreeStateAlg .StateAlg.rd ft ff = if_then ft true else ff false
   FreeStateAlg .StateAlg.wt b f _ = f b
@@ -327,6 +328,12 @@ module _ {X : Type ℓ}{Xᴰ : X → Type ℓ'} where
   pack⁻ .snd .fst _ = refl
   pack⁻ .snd .snd _ = refl
 
+  pack⁻Homo :
+    Homo (pack⁻ .fst)
+      (FreeStateAlg (Σ X Xᴰ))
+      (StateAlgᴰ.∫ (FreeStateAlgᴰ X Xᴰ))
+  pack⁻Homo = invHomo pack pack⁻
+
   module _ {Y : Type ℓ'} {Yᴰ : Y → Type ℓᴰ'}
     {B : StateAlg Y} (Bᴰ : StateAlgᴰ B Yᴰ) where
     private
@@ -364,29 +371,20 @@ module _ {X : Type ℓ}{Xᴰ : X → Type ℓ'} where
         recFSA-β (Σ X Xᴰ) Bᴰ.∫
           (λ z → i (z .fst) , iᴰ (z .fst) (z .snd)) (x , xᴰ)
 
-recFSAᴰ-η :
-  ∀ {X : Type ℓ} (Xᴰ : X → Type ℓ')
-    {Y : Type ℓ'} {Yᴰ : Y → Type ℓᴰ'}
-    {B : StateAlg Y} (Bᴰ : StateAlgᴰ B Yᴰ)
-    {f : (Bool → Bool × X) → Y}
-    (fᴰ : ∀ s → (∀ b → Xᴰ (s b .snd)) → Yᴰ (f s))
-    (f-hom : Homo f (FreeStateAlg X) B)
-    (fᴰ-hom : Homoᴰ fᴰ f-hom (FreeStateAlgᴰ X Xᴰ) Bᴰ)
-    (isSetB : isSet Y) s sᴰ
-  → StateAlgᴰ._P≡[_]_ Bᴰ
-      (recFSAᴰ-f {Xᴰ = Xᴰ} Bᴰ (f ∘ η X)
-        (λ x xᴰ → fᴰ (η X x) (ηᴰ X Xᴰ x xᴰ)) isSetB s sᴰ)
-      (recFSA-η X B f-hom s) (fᴰ s sᴰ)
-recFSAᴰ-η Xᴰ {Y = Y} {Yᴰ = Yᴰ} Bᴰ {f = f}
-  fᴰ f-hom fᴰ-hom isSetB s sᴰ =
-  hSetReasoning.rectifyOut (_ , isSetB) _ $
-    cong₂ (StateAlg.rd (StateAlgᴰ.∫ Bᴰ))
-      (sym $ Homo.wt-hom' (Homoᴰ.∫ fᴰ-hom) _ _)
-      (sym $ Homo.wt-hom' (Homoᴰ.∫ fᴰ-hom) _ _)
-    ∙ (sym $ Homo.rd-hom' (Homoᴰ.∫ fᴰ-hom) _ _)
-    ∙ cong {B = λ _ → Σ Y Yᴰ}
-        (λ q → f (q .fst) , fᴰ (q .fst) (q .snd))
-        (sym $ StateAlg.rd-wt (StateAlgᴰ.∫ (FreeStateAlgᴰ _ Xᴰ)) (s , sᴰ))
+    module _ (isSetB : isSet Y) where
+      recFSAᴰ-η :
+          ∀ {f : (Bool → Bool × X) → Y}
+          (fᴰ : ∀ s → (∀ b → Xᴰ (s b .snd)) → Yᴰ (f s))
+          (f-hom : Homo f (FreeStateAlg X) B)
+          (fᴰ-hom : Homoᴰ fᴰ f-hom (FreeStateAlgᴰ X Xᴰ) Bᴰ)
+          s sᴰ
+        → recFSAᴰ-f (f ∘ η X) (λ x xᴰ → fᴰ _ (ηᴰ X Xᴰ x xᴰ)) isSetB s sᴰ
+            Bᴰ.P≡[ recFSA-η X B f-hom s ]
+          fᴰ s sᴰ
+      recFSAᴰ-η fᴰ f-hom fᴰ-hom s sᴰ =
+        hSetReasoning.rectifyOut (_ , isSetB) _ $
+        recFSA-η (Σ X Xᴰ) Bᴰ.∫
+          (pack⁻Homo ⋆Homo Homoᴰ.∫ fᴰ-hom) (pack-f (s , sᴰ))
 
 module _ {X : Type ℓ} {X' : Type ℓ'}
   {B : StateAlg X} {B' : StateAlg X'} {f : X → X'}
@@ -496,3 +494,9 @@ module _ {X : Type ℓ}(Xᴰ : X → Type ℓᴰ)
 
   FreeStateAlgⱽ : StateAlgᴰ B FreeStateAlgⱽ-Xᴰ
   FreeStateAlgⱽ = push (recFSA X B i) (FreeStateAlgᴰ X Xᴰ) isSetB
+
+  -- Q: it is technically unnecessary to provide an explicit
+  -- definition of FreeStateAlgᴰ, since we can define it using ⊤ⱽ and
+  -- push, in which case we could simplify this definition to just
+  --
+  -- FreeStateAlgⱽ = push (recFSA (Σ X Xᴰ) B (i ∘ fst)) ⊤ⱽ isSetB

--- a/Cubical/Categories/Displayed/CBPV/Unary/Instances/StateAlg/Vertical.agda
+++ b/Cubical/Categories/Displayed/CBPV/Unary/Instances/StateAlg/Vertical.agda
@@ -192,9 +192,9 @@ StateAlgCBPV-η-lift {ℓ = ℓ} {A = A} Aᴰ = UniversalElementⱽ'.REPRⱽ η-
           (ΣPathPProp
             (λ fᴰ → isPropHomoᴰ (λ z → Zᴰ .fst z .snd))
             (funExt λ s → funExt λ sᴰ →
-              recFSAᴰ-η (λ x → ⟨ Aᴰ x ⟩) (Zᴰ .snd)
-                (ψᴰ .fst) (ϕ .snd .snd) (ψᴰ .snd)
-                (Z .fst .snd) s sᴰ)))
+              recFSAᴰ-η {Xᴰ = λ x → ⟨ Aᴰ x ⟩} (Zᴰ .snd)
+                (Z .fst .snd) (ψᴰ .fst) (ϕ .snd .snd)
+                (ψᴰ .snd) s sᴰ)))
 
 module _ {B B' : StateAlgebra ℓ} (ϕ : StateAlgHom B B')
   (Bᴰ : Σ[ Xᴰ ∈ (⟨ B .fst ⟩ → hSet ℓ) ]

--- a/Cubical/Categories/Displayed/Instances/Algebra/Algebra.agda
+++ b/Cubical/Categories/Displayed/Instances/Algebra/Algebra.agda
@@ -25,7 +25,6 @@ open import Cubical.Categories.Profunctor.Relator
 
 open import Cubical.Categories.Displayed.Base
 open import Cubical.Categories.Displayed.HLevels
-open import Cubical.Categories.Displayed.Instances.StructureOver
 open import Cubical.Categories.Displayed.Limits.BinProduct
 open import Cubical.Categories.Displayed.Limits.Terminal
 open import Cubical.Categories.Displayed.Presheaf.Representable
@@ -34,11 +33,10 @@ open import Cubical.Algebra.Signature.Base
 
 private
   variable
-    ℓC ℓC' ℓD ℓD' ℓS : Level
+    ℓ ℓC ℓC' ℓD ℓD' ℓS : Level
 
 open Category
 open Categoryᴰ
-open StructureOver
 open Functor
 open UniversalElement
 open UniversalElementᴰ
@@ -60,13 +58,13 @@ module _ {ℓO ℓA}(Sig : Signature ℓO ℓA) where
   ALG : ∀ ℓ → Category _ _
   ALG ℓ = ∫C (ALGOver ℓ)
 
+  ALGForget : Functor (ALG ℓ) (SET ℓ)
+  ALGForget = TotalCat.Fst
+
   AlgebraLevel : Level
   AlgebraLevel = ℓ-max ℓO ℓA
 
   module _ (isSetOp : isSet Op) where
-    ALGForget : Functor (ALG AlgebraLevel) (SET AlgebraLevel)
-    ALGForget = TotalCat.Fst
-
     FreeALG : hSet AlgebraLevel → ALG AlgebraLevel .ob
     FreeALG X .fst = |FreeAlgebra| ⟨ X ⟩ , isSetFreeAlgebra isSetOp (X .snd)
     FreeALG X .snd = app

--- a/Cubical/Categories/Displayed/Instances/Algebra/Algebra.agda
+++ b/Cubical/Categories/Displayed/Instances/Algebra/Algebra.agda
@@ -1,0 +1,111 @@
+-- Algebras of a Signature, displayed over their carrier set
+module Cubical.Categories.Displayed.Instances.Algebra.Algebra where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Structure
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Equiv.Dependent
+open import Cubical.Foundations.Isomorphism
+
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit
+
+open import Cubical.Categories.Adjoint.UniversalElements
+open import Cubical.Categories.Bifunctor
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.Instances.BinProduct as BP
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.Sets.Properties
+open import Cubical.Categories.Instances.TotalCategory as TotalCat
+open import Cubical.Categories.Limits.BinProduct.More using (BinProducts)
+open import Cubical.Categories.Limits.Terminal.More using (Terminal')
+open import Cubical.Categories.Presheaf.Representable
+open import Cubical.Categories.Profunctor.Relator
+
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.HLevels
+open import Cubical.Categories.Displayed.Instances.StructureOver
+open import Cubical.Categories.Displayed.Limits.BinProduct
+open import Cubical.Categories.Displayed.Limits.Terminal
+open import Cubical.Categories.Displayed.Presheaf.Representable
+
+open import Cubical.Algebra.Signature.Base
+
+private
+  variable
+    ℓC ℓC' ℓD ℓD' ℓS : Level
+
+open Category
+open Categoryᴰ
+open StructureOver
+open Functor
+open UniversalElement
+open UniversalElementᴰ
+open isIsoOver
+
+module _ {ℓO ℓA}(Sig : Signature ℓO ℓA) where
+  open Signature Sig
+  ALGOver : ∀ ℓ → Categoryᴰ (SET ℓ) (ℓ-max (ℓ-max ℓO ℓA) ℓ) (ℓ-max (ℓ-max ℓO ℓA) ℓ)
+  ALGOver ℓ .ob[_] X = AlgebraWithCarrier ⟨ X ⟩
+  ALGOver ℓ .Hom[_][_,_] f A B = isHomoSimpl (_ , A)(_ , B) f
+  ALGOver ℓ .idᴰ = λ op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ → op∘γ≡op⟨γ⟩
+  ALGOver ℓ ._⋆ᴰ_ = λ z₁ z₂ op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ →
+                       z₂ op _ _ (z₁ op γ op⟨γ⟩ op∘γ≡op⟨γ⟩)
+  ALGOver ℓ .⋆IdLᴰ _ = refl
+  ALGOver ℓ .⋆IdRᴰ _ = refl
+  ALGOver ℓ .⋆Assocᴰ _ _ _ = refl
+  ALGOver ℓ .isSetHomᴰ {y = Y}= isSetΠ3 λ _ _ _ → isSetΠ (λ _ → isProp→isSet (Y .snd _ _))
+
+  ALG : ∀ ℓ → Category _ _
+  ALG ℓ = ∫C (ALGOver ℓ)
+
+  AlgebraLevel : Level
+  AlgebraLevel = ℓ-max ℓO ℓA
+
+  module _ (isSetOp : isSet Op) where
+    ALGForget : Functor (ALG AlgebraLevel) (SET AlgebraLevel)
+    ALGForget = TotalCat.Fst
+
+    FreeALG : hSet AlgebraLevel → ALG AlgebraLevel .ob
+    FreeALG X .fst = |FreeAlgebra| ⟨ X ⟩ , isSetFreeAlgebra isSetOp (X .snd)
+    FreeALG X .snd = app
+
+    ALGFree : LeftAdjoint ALGForget
+    ALGFree X .UniversalElement.vertex = FreeALG X
+    ALGFree X .UniversalElement.element = var
+    ALGFree X .UniversalElement.universal B = isIsoToIsEquiv
+      ( (recFA (_ , B .snd))
+      , (λ _ → refl)
+      , (λ ϕ → Σ≡Prop
+          (λ _ → isPropΠ4 λ _ _ _ _ → B .fst .snd _ _)
+          (sym (recFA-uniq (_ , B .snd) ϕ)))
+      )
+
+  module _ {ℓSET : Level} where
+    TerminalALGOver : Terminalᴰ (ALGOver ℓSET) TerminalSET
+    TerminalALGOver .vertexᴰ = ⊤*Algebra
+    TerminalALGOver .elementᴰ = tt
+    TerminalALGOver .universalᴰ .inv _ _ _ _ _ _ = refl
+    TerminalALGOver .universalᴰ .rightInv _ _ = refl
+    TerminalALGOver .universalᴰ .leftInv _ _ =
+      isProp→PathP
+        (λ _ → isPropΠ4 λ _ _ _ _ → isSetUnit* _ _)
+        _ _
+
+    BinProductsALGOver : BinProductsᴰ (ALGOver ℓSET) BinProductsSET
+    BinProductsALGOver {c12 = X , Y} (A , B) .vertexᴰ = ((_ , A) ×Alg (_ , B)) .snd
+    BinProductsALGOver {c12 = X , Y} (A , B) .elementᴰ .fst op γ op⟨γ⟩ p = cong fst p
+    BinProductsALGOver {c12 = X , Y} (A , B) .elementᴰ .snd op γ op⟨γ⟩ p = cong snd p
+    BinProductsALGOver {c12 = X , Y} (A , B) .universalᴰ .inv _ (fᴰ , gᴰ) op γ op⟨γ⟩ p i =
+        fᴰ op γ op⟨γ⟩ p i , gᴰ op γ op⟨γ⟩ p i
+    BinProductsALGOver {c12 = X , Y} (A , B) .universalᴰ .rightInv _ _ = refl
+    BinProductsALGOver {c12 = X , Y} (A , B) .universalᴰ .leftInv _ _ = refl
+
+    TerminalALG : Terminal' (ALG ℓSET)
+    TerminalALG = TerminalᴰNotation.∫term (ALGOver ℓSET) TerminalALGOver
+
+    BinProductsALG : BinProducts (ALG ℓSET)
+    BinProductsALG = BinProductsᴰNotation.∫bp BinProductsALGOver
+
+  -- TODO: ALGOver is an IsoFibration

--- a/Cubical/Categories/Displayed/Instances/Algebra/DisplayedAlgebra.agda
+++ b/Cubical/Categories/Displayed/Instances/Algebra/DisplayedAlgebra.agda
@@ -1,0 +1,128 @@
+{-# OPTIONS --lossy-unification #-}
+module Cubical.Categories.Displayed.Instances.Algebra.DisplayedAlgebra where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Structure
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.HLevels
+
+import Cubical.Data.Equality as Eq
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit
+
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.TotalCategory as TotalCat
+open import Cubical.Categories.Presheaf.Morphism.Alt
+
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Instances.Algebra.Algebra
+open import Cubical.Categories.Displayed.Instances.Reindex.Eq.Base
+open import Cubical.Categories.Displayed.Instances.Sets.Base
+open import Cubical.Categories.Displayed.Instances.TotalCategory
+import Cubical.Categories.Displayed.Presheaf.Uncurried.Eq.Base as EqPsh
+
+open import Cubical.Algebra.Signature.Base
+
+module _ {ℓO ℓA}(Sig : Signature ℓO ℓA) where
+  open Signature Sig
+  SETᴰOverALG : ∀ ℓ ℓᴰ → Categoryᴰ (ALG Sig ℓ) _ _
+  SETᴰOverALG ℓ ℓᴰ = (EqReindexWithLaws.reindex
+      (SETᴰ ℓ ℓᴰ)
+      (ALGForget Sig)
+      Eq.refl
+      (λ _ _ → Eq.refl)
+      (λ _ → refl)
+      (λ _ → refl)
+      (λ _ _ _ → refl))
+
+  ALG×SETᴰ : ∀ ℓ ℓᴰ → Category _ _
+  ALG×SETᴰ ℓ ℓᴰ = ∫C (SETᴰOverALG ℓ ℓᴰ)
+
+  ALGᴰOver : ∀ ℓ ℓᴰ → Categoryᴰ (ALG×SETᴰ ℓ ℓᴰ) _ _
+  ALGᴰOver ℓ ℓᴰ .Categoryᴰ.ob[_] XAXᴰ =
+    AlgebraᴰWithCarrier (_ , XAXᴰ .fst .snd) (⟨_⟩ ∘ XAXᴰ .snd)
+  ALGᴰOver ℓ ℓᴰ .Categoryᴰ.Hom[_][_,_] (ϕ , fᴰ) Aᴰ Bᴰ =
+    isHomoᴰSimpl ϕ (_ , Aᴰ) (_ , Bᴰ) fᴰ
+  ALGᴰOver ℓ ℓᴰ .Categoryᴰ.idᴰ = idHomoᴰ .snd
+  ALGᴰOver ℓ ℓᴰ .Categoryᴰ._⋆ᴰ_ {yᴰ = Bᴰ}{zᴰ = Cᴰ} ϕᴰ ψᴰ =
+    (_⋆Hᴰ_ {Cᴰ = _ , Cᴰ} (_ , ϕᴰ) (_ , ψᴰ)) .snd
+  ALGᴰOver ℓ ℓᴰ .Categoryᴰ.⋆IdLᴰ _ = refl
+  ALGᴰOver ℓ ℓᴰ .Categoryᴰ.⋆IdRᴰ _ = refl
+  ALGᴰOver ℓ ℓᴰ .Categoryᴰ.⋆Assocᴰ _ _ _ = refl
+  ALGᴰOver ℓ ℓᴰ .Categoryᴰ.isSetHomᴰ {y = (Y , B) , Yᴰ} =
+    isProp→isSet
+      (isPropΠ λ _ → isPropΠ6 λ _ _ _ _ _ _ → Yᴰ _ .snd _ _)
+
+  ALGᴰ : ∀ ℓ ℓᴰ → Categoryᴰ (ALG Sig ℓ) _ _
+  ALGᴰ ℓ ℓᴰ = ∫Cᴰ (SETᴰOverALG ℓ ℓᴰ) (ALGᴰOver ℓ ℓᴰ)
+
+  module _ {ℓ ℓᴰ} {X Y : ALG Sig ℓ .Category.ob}
+    {Xᴰ : Categoryᴰ.ob[_] (ALGᴰ ℓ ℓᴰ) X}
+    {Yᴰ : Categoryᴰ.ob[_] (ALGᴰ ℓ ℓᴰ) Y}
+    {f : ALG Sig ℓ [ X , Y ]}
+    (fᴰ gᴰ : Categoryᴰ.Hom[_][_,_] (ALGᴰ ℓ ℓᴰ) f Xᴰ Yᴰ) where
+    ALGᴰHomo≡ : fᴰ .fst ≡ gᴰ .fst → fᴰ ≡ gᴰ
+    ALGᴰHomo≡ fᴰ≡gᴰ i .fst = fᴰ≡gᴰ i
+    ALGᴰHomo≡ fᴰ≡gᴰ i .snd =
+      isProp→PathP
+        {B = λ i → Categoryᴰ.Hom[_][_,_] (ALGᴰOver ℓ ℓᴰ)
+          (f , fᴰ≡gᴰ i) (Xᴰ .snd) (Yᴰ .snd)}
+        (λ _ → isPropΠ6 λ _ _ _ _ _ _ →
+          isPropΠ λ _ → Yᴰ .fst _ .snd _ _)
+        (fᴰ .snd) (gᴰ .snd) i
+
+  private
+    ALGIdR : ∀ {ℓ} → EqPsh.EqIdR (ALG Sig ℓ)
+    ALGIdR _ = Eq.refl
+
+  TerminalsEqⱽALGᴰ : ∀ {ℓ ℓᴰ} → EqPsh.Terminalsⱽ (ALGᴰ ℓ ℓᴰ)
+  TerminalsEqⱽALGᴰ {ℓ = ℓ} {ℓᴰ = ℓᴰ} X =
+    EqPsh.UEⱽ→Reprⱽ _ ALGIdR ue
+    where
+    ue : EqPsh.UEⱽ
+      (EqPsh.UnitⱽPsh {Cᴰ = ALGᴰ ℓ ℓᴰ} {P = (ALG Sig ℓ) [-, X ]})
+      ALGIdR
+    ue .EqPsh.UEⱽ.v = (λ _ → Unit* , isSetUnit*) , ⊤*ⱽ .snd
+    ue .EqPsh.UEⱽ.e = tt
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      _ .fst _ .fst _ _ = tt*
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      _ .fst _ .snd _ _ _ _ _ _ _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      _ .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      _ .snd .snd h = ALGᴰHomo≡ _ h (funExt λ _ → funExt λ _ → refl)
+
+  BinProductsEqⱽALGᴰ : ∀ {ℓ ℓᴰ} → EqPsh.BinProductsⱽ (ALGᴰ ℓ ℓᴰ)
+  BinProductsEqⱽALGᴰ {ℓ = ℓ} {ℓᴰ = ℓᴰ} {x = X}
+    (Xᴰ , Aᴰ) (Yᴰ , Bᴰ) = EqPsh.UEⱽ→Reprⱽ _ ALGIdR ue
+    where
+    ue : EqPsh.UEⱽ
+      (((ALGᴰ ℓ ℓᴰ EqPsh.[-][-, Xᴰ , Aᴰ ]) EqPsh.×ⱽPsh
+        (ALGᴰ ℓ ℓᴰ EqPsh.[-][-, Yᴰ , Bᴰ ])))
+      ALGIdR
+    ue .EqPsh.UEⱽ.v =
+      (λ a → (⟨ Xᴰ a ⟩ × ⟨ Yᴰ a ⟩) , isSet× (Xᴰ a .snd) (Yᴰ a .snd)) ,
+      ((_ , Aᴰ) ×ⱽ (_ , Bᴰ)) .snd
+    ue .EqPsh.UEⱽ.e .fst .fst _ z = z .fst
+    ue .EqPsh.UEⱽ.e .fst .snd _ _ _ _ _ _ p = cong fst p
+    ue .EqPsh.UEⱽ.e .snd .fst _ z = z .snd
+    ue .EqPsh.UEⱽ.e .snd .snd _ _ _ _ _ _ p = cong snd p
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      _ .fst (ϕᴰ , ψᴰ) .fst a z = ϕᴰ .fst a z , ψᴰ .fst a z
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      _ .fst (ϕᴰ , ψᴰ) .snd
+      op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ i =
+        ϕᴰ .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ i ,
+        ψᴰ .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ i
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      _ .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      _ .snd .snd h = ALGᴰHomo≡ _ h refl
+
+  TerminalsⱽALGᴰ : ∀ {ℓ ℓᴰ} → EqPsh.Terminalsⱽ (ALGᴰ ℓ ℓᴰ)
+  TerminalsⱽALGᴰ = TerminalsEqⱽALGᴰ
+
+  BinProductsⱽALGᴰ : ∀ {ℓ ℓᴰ} → EqPsh.BinProductsⱽ (ALGᴰ ℓ ℓᴰ)
+  BinProductsⱽALGᴰ = BinProductsEqⱽALGᴰ

--- a/Cubical/Categories/Displayed/Instances/Algebra/DisplayedModel.agda
+++ b/Cubical/Categories/Displayed/Instances/Algebra/DisplayedModel.agda
@@ -1,0 +1,184 @@
+{-# OPTIONS --lossy-unification #-}
+module Cubical.Categories.Displayed.Instances.Algebra.DisplayedModel where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Structure
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.HLevels
+
+import Cubical.Data.Equality as Eq
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit
+
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.TotalCategory as TotalCat
+open import Cubical.Categories.Presheaf.Morphism.Alt
+
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Instances.Algebra.Model
+open import Cubical.Categories.Displayed.Instances.Reindex.Eq.Base
+open import Cubical.Categories.Displayed.Instances.Sets.Base
+open import Cubical.Categories.Displayed.Instances.TotalCategory
+import Cubical.Categories.Displayed.Presheaf.Uncurried.Eq.Base as EqPsh
+
+open import Cubical.Algebra.Theory.Base
+  hiding (ℓ; ℓᴰ; ℓᴰᴰ; ℓ'; ℓᴰ'; ℓᴰᴰ'; ℓ''; ℓᴰ''; ℓO; ℓA; ℓE)
+
+module _ {ℓO ℓA ℓE ℓEA} (T : Theory ℓO ℓA ℓE ℓEA) where
+  open Theory T
+
+  private
+    MODELOb→Model : ∀ {ℓ} → MODEL T ℓ .Category.ob → Model ℓ
+    MODELOb→Model M .fst = ⟨ M .fst ⟩ , M .snd .fst
+    MODELOb→Model M .snd .fst = M .snd .snd
+    MODELOb→Model M .snd .snd = M .fst .snd
+
+  SETᴰOverMODEL : ∀ ℓ ℓᴰ → Categoryᴰ (MODEL T ℓ) _ _
+  SETᴰOverMODEL ℓ ℓᴰ = EqReindexWithLaws.reindex
+    (SETᴰ ℓ ℓᴰ)
+    (MODELForget T)
+    Eq.refl
+    (λ _ _ → Eq.refl)
+    (λ _ → refl)
+    (λ _ → refl)
+    (λ _ _ _ → refl)
+
+  MODEL×SETᴰ : ∀ ℓ ℓᴰ → Category _ _
+  MODEL×SETᴰ ℓ ℓᴰ = ∫C (SETᴰOverMODEL ℓ ℓᴰ)
+
+  MODELᴰOver : ∀ ℓ ℓᴰ → Categoryᴰ (MODEL×SETᴰ ℓ ℓᴰ) _ _
+  MODELᴰOver ℓ ℓᴰ .Categoryᴰ.ob[_] XMXᴰ =
+    ModelᴰWithCarrier
+      (MODELOb→Model (XMXᴰ .fst))
+      (⟨_⟩ ∘ XMXᴰ .snd)
+  MODELᴰOver ℓ ℓᴰ .Categoryᴰ.Hom[_][_,_] (ϕ , fᴰ) Aᴰ Bᴰ =
+    isHomoᴰSimpl ϕ (_ , Aᴰ .fst) (_ , Bᴰ .fst) fᴰ
+  MODELᴰOver ℓ ℓᴰ .Categoryᴰ.idᴰ = idHomoᴰ .snd
+  MODELᴰOver ℓ ℓᴰ .Categoryᴰ._⋆ᴰ_ {yᴰ = Bᴰ} {zᴰ = Cᴰ} ϕᴰ ψᴰ =
+    (_⋆Hᴰ_ {Cᴰ = _ , Cᴰ .fst} (_ , ϕᴰ) (_ , ψᴰ)) .snd
+  MODELᴰOver ℓ ℓᴰ .Categoryᴰ.⋆IdLᴰ _ = refl
+  MODELᴰOver ℓ ℓᴰ .Categoryᴰ.⋆IdRᴰ _ = refl
+  MODELᴰOver ℓ ℓᴰ .Categoryᴰ.⋆Assocᴰ _ _ _ = refl
+  MODELᴰOver ℓ ℓᴰ .Categoryᴰ.isSetHomᴰ {y = (Y , B) , Yᴰ} =
+    isProp→isSet
+      (isPropΠ λ _ → isPropΠ6 λ _ _ _ _ _ _ → Yᴰ _ .snd _ _)
+
+  MODELᴰ : ∀ ℓ ℓᴰ → Categoryᴰ (MODEL T ℓ) _ _
+  MODELᴰ ℓ ℓᴰ = ∫Cᴰ (SETᴰOverMODEL ℓ ℓᴰ) (MODELᴰOver ℓ ℓᴰ)
+
+  module _ {ℓ ℓᴰ} {X Y : MODEL T ℓ .Category.ob}
+    {Xᴰ : Categoryᴰ.ob[_] (MODELᴰ ℓ ℓᴰ) X}
+    {Yᴰ : Categoryᴰ.ob[_] (MODELᴰ ℓ ℓᴰ) Y}
+    {f : MODEL T ℓ [ X , Y ]}
+    (fᴰ gᴰ : Categoryᴰ.Hom[_][_,_] (MODELᴰ ℓ ℓᴰ) f Xᴰ Yᴰ) where
+    MODELᴰHomo≡ : fᴰ .fst ≡ gᴰ .fst → fᴰ ≡ gᴰ
+    MODELᴰHomo≡ fᴰ≡gᴰ i .fst = fᴰ≡gᴰ i
+    MODELᴰHomo≡ fᴰ≡gᴰ i .snd =
+      isProp→PathP
+        {B = λ i → Categoryᴰ.Hom[_][_,_] (MODELᴰOver ℓ ℓᴰ)
+          (f , fᴰ≡gᴰ i) (Xᴰ .snd) (Yᴰ .snd)}
+        (λ _ → isPropΠ6 λ _ _ _ _ _ _ →
+          isPropΠ λ _ → Yᴰ .fst _ .snd _ _)
+        (fᴰ .snd) (gᴰ .snd) i
+
+  private
+    MODELIdR : ∀ {ℓ} → EqPsh.EqIdR (MODEL T ℓ)
+    MODELIdR _ = Eq.refl
+
+  TerminalsEqⱽMODELᴰ : ∀ {ℓ ℓᴰ} → EqPsh.Terminalsⱽ (MODELᴰ ℓ ℓᴰ)
+  TerminalsEqⱽMODELᴰ {ℓ = ℓ} {ℓᴰ = ℓᴰ} X =
+    EqPsh.UEⱽ→Reprⱽ _ MODELIdR ue
+    where
+    ue : EqPsh.UEⱽ
+      (EqPsh.UnitⱽPsh {Cᴰ = MODELᴰ ℓ ℓᴰ} {P = (MODEL T ℓ) [-, X ]})
+      MODELIdR
+    ue .EqPsh.UEⱽ.v =
+      (λ _ → Unit* , isSetUnit*) ,
+      (⊤*ⱽ .snd , λ _ _ _ → isProp→PathP (λ _ → isPropUnit*) _ _)
+    ue .EqPsh.UEⱽ.e = tt
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      _ .fst _ .fst _ _ = tt*
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      _ .fst _ .snd _ _ _ _ _ _ _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      _ .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      _ .snd .snd h = MODELᴰHomo≡ _ h (funExt λ _ → funExt λ _ → refl)
+
+  TerminalsⱽMODELᴰ : ∀ {ℓ ℓᴰ} → EqPsh.Terminalsⱽ (MODELᴰ ℓ ℓᴰ)
+  TerminalsⱽMODELᴰ = TerminalsEqⱽMODELᴰ
+
+  private
+    interpProductᴰ : ∀ {ℓ ℓᴰ ℓV} {M : MODEL T ℓ .Category.ob}
+      (Mᴰ Nᴰ : Categoryᴰ.ob[_] (MODELᴰ ℓ ℓᴰ) M)
+      {V : Type ℓV}
+      (ρ : V → ⟨ M .fst ⟩)
+      (ρᴰ : (v : V) → ⟨ Mᴰ .fst (ρ v) ⟩ × ⟨ Nᴰ .fst (ρ v) ⟩)
+      (t : |FreeAlgebra| V)
+      → interpᴰ
+          ((_ , Mᴰ .snd .fst) ×ⱽ (_ , Nᴰ .snd .fst))
+          ρ ρᴰ t
+        ≡ ( interpᴰ (_ , Mᴰ .snd .fst) ρ (λ v → ρᴰ v .fst) t
+          , interpᴰ (_ , Nᴰ .snd .fst) ρ (λ v → ρᴰ v .snd) t)
+    interpProductᴰ Mᴰ Nᴰ ρ ρᴰ (var v) = refl
+    interpProductᴰ {M = M} Mᴰ Nᴰ ρ ρᴰ (app op γ) =
+      cong₂ _,_
+        (cong
+          (λ γᴰ → Mᴰ .snd .fst op
+            (λ v → interp (MODELOb→Model M .fst) ρ (γ v)) γᴰ
+            (interp (MODELOb→Model M .fst) ρ (app op γ))
+            (recFA (MODELOb→Model M .fst) ρ .snd
+              op γ (app op γ) refl))
+          (funExt λ v →
+            cong fst (interpProductᴰ Mᴰ Nᴰ ρ ρᴰ (γ v))))
+        (cong
+          (λ γᴰ → Nᴰ .snd .fst op
+            (λ v → interp (MODELOb→Model M .fst) ρ (γ v)) γᴰ
+            (interp (MODELOb→Model M .fst) ρ (app op γ))
+            (recFA (MODELOb→Model M .fst) ρ .snd
+              op γ (app op γ) refl))
+          (funExt λ v →
+            cong snd (interpProductᴰ Mᴰ Nᴰ ρ ρᴰ (γ v))))
+
+  BinProductsEqⱽMODELᴰ : ∀ {ℓ ℓᴰ} →
+    EqPsh.BinProductsⱽ (MODELᴰ ℓ ℓᴰ)
+  BinProductsEqⱽMODELᴰ {ℓ = ℓ} {ℓᴰ = ℓᴰ} {x = X}
+    (Xᴰ , Aᴰ) (Yᴰ , Bᴰ) = EqPsh.UEⱽ→Reprⱽ _ MODELIdR ue
+    where
+    ue : EqPsh.UEⱽ
+      (((MODELᴰ ℓ ℓᴰ EqPsh.[-][-, Xᴰ , Aᴰ ]) EqPsh.×ⱽPsh
+        (MODELᴰ ℓ ℓᴰ EqPsh.[-][-, Yᴰ , Bᴰ ])))
+      MODELIdR
+    ue .EqPsh.UEⱽ.v =
+      (λ a →
+        (⟨ Xᴰ a ⟩ × ⟨ Yᴰ a ⟩) ,
+        isSet× (Xᴰ a .snd) (Yᴰ a .snd)) ,
+      ( ((_ , Aᴰ .fst) ×ⱽ (_ , Bᴰ .fst)) .snd
+      , λ e ρ ρᴰ →
+          interpProductᴰ (Xᴰ , Aᴰ) (Yᴰ , Bᴰ) ρ ρᴰ (lhs e)
+          ◁ (λ i →
+              Aᴰ .snd e ρ (λ v → ρᴰ v .fst) i ,
+              Bᴰ .snd e ρ (λ v → ρᴰ v .snd) i)
+          ▷ sym
+              (interpProductᴰ (Xᴰ , Aᴰ) (Yᴰ , Bᴰ) ρ ρᴰ (rhs e)))
+    ue .EqPsh.UEⱽ.e .fst .fst _ z = z .fst
+    ue .EqPsh.UEⱽ.e .fst .snd _ _ _ _ _ _ p = cong fst p
+    ue .EqPsh.UEⱽ.e .snd .fst _ z = z .snd
+    ue .EqPsh.UEⱽ.e .snd .snd _ _ _ _ _ _ p = cong snd p
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      _ .fst (ϕᴰ , ψᴰ) .fst a z = ϕᴰ .fst a z , ψᴰ .fst a z
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      _ .fst (ϕᴰ , ψᴰ) .snd
+      op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩ op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ i =
+        ϕᴰ .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩
+          op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ i ,
+        ψᴰ .snd op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩
+          op⟨γᴰ⟩ op∘γᴰ≡op⟨γᴰ⟩ i
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      _ .snd .fst _ = refl
+    ue .EqPsh.UEⱽ.universal .isPshIsoEq.nIso
+      _ .snd .snd h = MODELᴰHomo≡ _ h refl
+
+  BinProductsⱽMODELᴰ : ∀ {ℓ ℓᴰ} → EqPsh.BinProductsⱽ (MODELᴰ ℓ ℓᴰ)
+  BinProductsⱽMODELᴰ = BinProductsEqⱽMODELᴰ

--- a/Cubical/Categories/Displayed/Instances/Algebra/Model.agda
+++ b/Cubical/Categories/Displayed/Instances/Algebra/Model.agda
@@ -1,0 +1,134 @@
+-- Models of a Theory, displayed over their carrier set
+module Cubical.Categories.Displayed.Instances.Algebra.Model where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Structure
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Equiv.Dependent
+open import Cubical.Foundations.Isomorphism
+
+open import Cubical.Data.Sigma
+open import Cubical.Data.Unit
+
+open import Cubical.Categories.Adjoint.UniversalElements
+open import Cubical.Categories.Bifunctor
+open import Cubical.Categories.Category.Base
+open import Cubical.Categories.Functor.Base
+open import Cubical.Categories.Instances.BinProduct as BP
+open import Cubical.Categories.Instances.Sets
+open import Cubical.Categories.Instances.Sets.Properties
+open import Cubical.Categories.Instances.TotalCategory as TotalCat
+open import Cubical.Categories.Limits.BinProduct.More using (BinProducts)
+open import Cubical.Categories.Limits.Terminal.More using (Terminal')
+open import Cubical.Categories.Presheaf.Representable
+open import Cubical.Categories.Profunctor.Relator
+
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.HLevels
+open import Cubical.Categories.Displayed.Limits.BinProduct
+open import Cubical.Categories.Displayed.Limits.Terminal
+open import Cubical.Categories.Displayed.Presheaf.Representable
+
+open import Cubical.Algebra.Theory.Base
+  hiding (ℓ; ℓᴰ; ℓᴰᴰ; ℓ'; ℓᴰ'; ℓᴰᴰ'; ℓ''; ℓᴰ''; ℓO; ℓA; ℓE)
+
+private
+  variable
+    ℓ : Level
+
+open Category
+open Categoryᴰ
+open Functor
+open UniversalElement
+open UniversalElementᴰ
+open isIsoOver
+
+module _ {ℓO ℓA ℓE ℓEA} (T : Theory ℓO ℓA ℓE ℓEA) where
+  open Theory T
+
+  ModelLevel : Level
+  ModelLevel = ℓ-max (ℓ-max ℓO ℓA) (ℓ-max ℓE ℓEA)
+
+  MODELOver : ∀ ℓ →
+    Categoryᴰ (SET ℓ)
+      (ℓ-max ModelLevel ℓ)
+      (ℓ-max (ℓ-max ℓO ℓA) ℓ)
+  MODELOver ℓ .ob[_] X =
+    Σ[ A ∈ AlgebraWithCarrier ⟨ X ⟩ ] IsModel (⟨ X ⟩ , A)
+  MODELOver ℓ .Hom[_][_,_] f A B =
+    isHomoSimpl (_ , A .fst) (_ , B .fst) f
+  MODELOver ℓ .idᴰ =
+    λ op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ → op∘γ≡op⟨γ⟩
+  MODELOver ℓ ._⋆ᴰ_ =
+    λ z₁ z₂ op γ op⟨γ⟩ op∘γ≡op⟨γ⟩ →
+      z₂ op _ _ (z₁ op γ op⟨γ⟩ op∘γ≡op⟨γ⟩)
+  MODELOver ℓ .⋆IdLᴰ _ = refl
+  MODELOver ℓ .⋆IdRᴰ _ = refl
+  MODELOver ℓ .⋆Assocᴰ _ _ _ = refl
+  MODELOver ℓ .isSetHomᴰ {y = Y} =
+    isSetΠ3 λ _ _ _ → isSetΠ (λ _ → isProp→isSet (Y .snd _ _))
+
+  MODEL : ∀ ℓ → Category _ _
+  MODEL ℓ = ∫C (MODELOver ℓ)
+
+  MODELForget : Functor (MODEL ℓ) (SET ℓ)
+  MODELForget = TotalCat.Fst
+
+  private
+    MODELOb→Model : (X : hSet ℓ) → Categoryᴰ.ob[_] (MODELOver ℓ) X → Model ℓ
+    MODELOb→Model X A .fst = ⟨ X ⟩ , A .fst
+    MODELOb→Model X A .snd .fst = A .snd
+    MODELOb→Model X A .snd .snd = X .snd
+
+  FreeMODEL : hSet ModelLevel → MODEL ModelLevel .ob
+  FreeMODEL X .fst =
+    FreeModel ⟨ X ⟩ .fst .fst , FreeModel ⟨ X ⟩ .snd .snd
+  FreeMODEL X .snd .fst = FreeModel ⟨ X ⟩ .fst .snd
+  FreeMODEL X .snd .snd = FreeModel ⟨ X ⟩ .snd .fst
+
+  MODELFree : LeftAdjoint (MODELForget {ℓ = ModelLevel})
+  MODELFree X .UniversalElement.vertex = FreeMODEL X
+  MODELFree X .UniversalElement.element = var
+  MODELFree X .UniversalElement.universal B = isIsoToIsEquiv
+    ( recFM ⟨ X ⟩ (MODELOb→Model (B .fst) (B .snd))
+    , (λ _ → refl)
+    , (λ ϕ → Σ≡Prop
+        (λ _ → isPropΠ4 λ _ _ _ _ → B .fst .snd _ _)
+        (sym (recFM-uniq ⟨ X ⟩ (MODELOb→Model (B .fst) (B .snd)) ϕ)))
+    )
+
+  module _ {ℓSET : Level} where
+    TerminalMODELOver : Terminalᴰ (MODELOver ℓSET) TerminalSET
+    TerminalMODELOver .vertexᴰ =
+      ⊤*Model .fst .snd , ⊤*Model .snd .fst
+    TerminalMODELOver .elementᴰ = tt
+    TerminalMODELOver .universalᴰ .inv _ _ _ _ _ _ = refl
+    TerminalMODELOver .universalᴰ .rightInv _ _ = refl
+    TerminalMODELOver .universalᴰ .leftInv _ _ =
+      isProp→PathP
+        (λ _ → isPropΠ4 λ _ _ _ _ → isSetUnit* _ _)
+        _ _
+
+    TerminalMODEL : Terminal' (MODEL ℓSET)
+    TerminalMODEL =
+      TerminalᴰNotation.∫term (MODELOver ℓSET) TerminalMODELOver
+
+    BinProductsMODELOver : BinProductsᴰ (MODELOver ℓSET) BinProductsSET
+    BinProductsMODELOver {c12 = X , Y} (A , B) .vertexᴰ =
+      let M = MODELOb→Model X A
+          N = MODELOb→Model Y B
+      in (M ×Model N) .fst .snd , (M ×Model N) .snd .fst
+    BinProductsMODELOver {c12 = X , Y} (A , B) .elementᴰ .fst
+      op γ op⟨γ⟩ p = cong fst p
+    BinProductsMODELOver {c12 = X , Y} (A , B) .elementᴰ .snd
+      op γ op⟨γ⟩ p = cong snd p
+    BinProductsMODELOver {c12 = X , Y} (A , B) .universalᴰ .inv
+      _ (fᴰ , gᴰ) op γ op⟨γ⟩ p i =
+        fᴰ op γ op⟨γ⟩ p i , gᴰ op γ op⟨γ⟩ p i
+    BinProductsMODELOver {c12 = X , Y} (A , B) .universalᴰ .rightInv
+      _ _ = refl
+    BinProductsMODELOver {c12 = X , Y} (A , B) .universalᴰ .leftInv
+      _ _ = refl
+
+    BinProductsMODEL : BinProducts (MODEL ℓSET)
+    BinProductsMODEL = BinProductsᴰNotation.∫bp BinProductsMODELOver

--- a/Cubical/Categories/Displayed/Instances/Reindex/Cartesian.agda
+++ b/Cubical/Categories/Displayed/Instances/Reindex/Cartesian.agda
@@ -48,6 +48,7 @@ open import Cubical.Categories.Displayed.Limits.CartesianV'
 open import Cubical.Categories.Displayed.Presheaf.Uncurried.Base
 open import Cubical.Categories.Displayed.Presheaf.Uncurried.Constructions
 open import Cubical.Categories.Displayed.Presheaf.Uncurried.Constructions.Exponential
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Fibration
 open import Cubical.Categories.Displayed.Presheaf.Uncurried.Representable
 open import Cubical.Categories.Displayed.Presheaf.Uncurried.UniversalProperties
 
@@ -175,3 +176,54 @@ module _
       (TerminalsⱽReindex F Dᴰ.termⱽ)
       (BinProductsⱽReindex F Dᴰ.bpⱽ)
       (isFibrationReindex Dᴰ.Cᴰ F Dᴰ.cartesianLifts)
+
+-- Reindexing the opposite Dᴰ ^opᴰ along the (transport-free) opposite of
+-- F gives, fiberwise, the opposite of reindex Dᴰ F. So vertical
+-- universal properties of Dᴰ ^opᴰ (initial objects, coproducts,
+-- opcartesian lifts) reindex to (reindex Dᴰ F) ^opᴰ by retyping.
+module _ {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}
+  {Dᴰ : Categoryᴰ D ℓDᴰ ℓDᴰ'}
+  (F : Functor C D) where
+  private
+    module Dᴰ = Categoryᴰ Dᴰ
+
+    F^op : Functor (C ^op) (D ^op)
+    F^op .F-ob = F .F-ob
+    F^op .F-hom = F .F-hom
+    F^op .F-id = F .F-id
+    F^op .F-seq f g = F .F-seq g f
+
+  reindexInitialⱽ : ∀ x
+    → Terminalⱽ (Dᴰ ^opᴰ) (F ⟅ x ⟆)
+    → Terminalⱽ ((reindex Dᴰ F) ^opᴰ) x
+  reindexInitialⱽ x init =
+    init' .fst ,
+    pshiso
+      (pshhom (λ c → init' .snd .trans .N-ob c) (λ _ _ _ _ → refl))
+      (init' .snd .nIso)
+    where
+    init' = reindexTerminalⱽ {Dᴰ = Dᴰ ^opᴰ} F^op x init
+
+  reindexBinCoProductⱽ : ∀ {x} (Fxᴰ Fyᴰ : Dᴰ.ob[ F ⟅ x ⟆ ])
+    → BinProductⱽ (Dᴰ ^opᴰ) Fxᴰ Fyᴰ
+    → BinProductⱽ ((reindex Dᴰ F) ^opᴰ) Fxᴰ Fyᴰ
+  reindexBinCoProductⱽ Fxᴰ Fyᴰ bcp =
+    bcp' .fst ,
+    pshiso
+      (pshhom (λ c → bcp' .snd .trans .N-ob c)
+        (λ c c' g p → bcp' .snd .trans .N-hom c c' g p))
+      (bcp' .snd .nIso)
+    where
+    bcp' = reindexBinProductⱽ {Dᴰ = Dᴰ ^opᴰ} F^op Fxᴰ Fyᴰ bcp
+
+  reindexOpcartesianLift : ∀ {x y} (f : C [ y , x ]) (Fyᴰ : Dᴰ.ob[ F ⟅ y ⟆ ])
+    → CartesianLift (Dᴰ ^opᴰ) (F ⟪ f ⟫) Fyᴰ
+    → CartesianLift ((reindex Dᴰ F) ^opᴰ) f Fyᴰ
+  reindexOpcartesianLift f Fyᴰ f*Fyᴰ =
+    lift' .fst ,
+    pshiso
+      (pshhom (λ c → lift' .snd .trans .N-ob c)
+        (λ c c' g p → lift' .snd .trans .N-hom c c' g p))
+      (lift' .snd .nIso)
+    where
+    lift' = reindexCartesianLift (Dᴰ ^opᴰ) F^op f Fyᴰ f*Fyᴰ

--- a/Cubical/Categories/Displayed/Instances/Reindex/Eq/Base.agda
+++ b/Cubical/Categories/Displayed/Instances/Reindex/Eq/Base.agda
@@ -69,6 +69,67 @@ module _
     lem = sym (Eq.eqToPath
       ((Eq.transportPathToEq→transportPath Hom[_][ _ , _ ]) p fᴰ))
 
+module EqReindexWithLaws
+  {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}
+  (Dᴰ : Categoryᴰ D ℓDᴰ ℓDᴰ')
+  (F : Functor C D)
+  (F-id'  : {x : C .ob} → D .id {x = F .F-ob x} Eq.≡ F .F-hom (C .id))
+  (F-seq' : {x y z : C .ob} (f : C [ x , y ]) (g : C [ y , z ])
+          → (F .F-hom f) ⋆⟨ D ⟩ (F .F-hom g) Eq.≡ F .F-hom (f ⋆⟨ C ⟩ g))
+  where
+
+  private
+    module C = Category C
+    module Dᴰ = Categoryᴰ Dᴰ
+
+  idᴰ' : ∀ {x} {xᴰ : Dᴰ.ob[ F .F-ob x ]}
+    → Dᴰ.Hom[ F .F-hom C.id ][ xᴰ , xᴰ ]
+  idᴰ' = reind' Dᴰ F-id' Dᴰ.idᴰ
+
+  _⋆ᴰ'_ : ∀ {x y z} {f : C [ x , y ]} {g : C [ y , z ]}
+    {xᴰ : Dᴰ.ob[ F .F-ob x ]} {yᴰ : Dᴰ.ob[ F .F-ob y ]}
+    {zᴰ : Dᴰ.ob[ F .F-ob z ]}
+    → Dᴰ.Hom[ F .F-hom f ][ xᴰ , yᴰ ]
+    → Dᴰ.Hom[ F .F-hom g ][ yᴰ , zᴰ ]
+    → Dᴰ.Hom[ F .F-hom (f C.⋆ g) ][ xᴰ , zᴰ ]
+  _⋆ᴰ'_ {f = f} {g = g} fᴰ gᴰ =
+    reind' Dᴰ (F-seq' f g) (fᴰ Dᴰ.⋆ᴰ gᴰ)
+
+  reindex :
+    (⋆IdLᴰ' : ∀ {x y} {f : C [ x , y ]}
+      {xᴰ : Dᴰ.ob[ F .F-ob x ]} {yᴰ : Dᴰ.ob[ F .F-ob y ]}
+      (fᴰ : Dᴰ.Hom[ F .F-hom f ][ xᴰ , yᴰ ])
+      → PathP
+          (λ i → Dᴰ.Hom[ F .F-hom (C.⋆IdL f i) ][ xᴰ , yᴰ ])
+          (idᴰ' ⋆ᴰ' fᴰ) fᴰ)
+    (⋆IdRᴰ' : ∀ {x y} {f : C [ x , y ]}
+      {xᴰ : Dᴰ.ob[ F .F-ob x ]} {yᴰ : Dᴰ.ob[ F .F-ob y ]}
+      (fᴰ : Dᴰ.Hom[ F .F-hom f ][ xᴰ , yᴰ ])
+      → PathP
+          (λ i → Dᴰ.Hom[ F .F-hom (C.⋆IdR f i) ][ xᴰ , yᴰ ])
+          (fᴰ ⋆ᴰ' idᴰ') fᴰ)
+    (⋆Assocᴰ' : ∀ {w x y z}
+      {f : C [ w , x ]} {g : C [ x , y ]} {h : C [ y , z ]}
+      {wᴰ : Dᴰ.ob[ F .F-ob w ]} {xᴰ : Dᴰ.ob[ F .F-ob x ]}
+      {yᴰ : Dᴰ.ob[ F .F-ob y ]} {zᴰ : Dᴰ.ob[ F .F-ob z ]}
+      (fᴰ : Dᴰ.Hom[ F .F-hom f ][ wᴰ , xᴰ ])
+      (gᴰ : Dᴰ.Hom[ F .F-hom g ][ xᴰ , yᴰ ])
+      (hᴰ : Dᴰ.Hom[ F .F-hom h ][ yᴰ , zᴰ ])
+      → PathP
+          (λ i → Dᴰ.Hom[ F .F-hom (C.⋆Assoc f g h i) ][ wᴰ , zᴰ ])
+          ((fᴰ ⋆ᴰ' gᴰ) ⋆ᴰ' hᴰ) (fᴰ ⋆ᴰ' (gᴰ ⋆ᴰ' hᴰ)))
+    → Categoryᴰ C ℓDᴰ ℓDᴰ'
+  reindex ⋆IdLᴰ' ⋆IdRᴰ' ⋆Assocᴰ' .Categoryᴰ.ob[_] x =
+    Dᴰ.ob[ F .F-ob x ]
+  reindex ⋆IdLᴰ' ⋆IdRᴰ' ⋆Assocᴰ' .Categoryᴰ.Hom[_][_,_] f =
+    Dᴰ.Hom[ F .F-hom f ][_,_]
+  reindex ⋆IdLᴰ' ⋆IdRᴰ' ⋆Assocᴰ' .Categoryᴰ.idᴰ = idᴰ'
+  reindex ⋆IdLᴰ' ⋆IdRᴰ' ⋆Assocᴰ' .Categoryᴰ._⋆ᴰ_ = _⋆ᴰ'_
+  reindex ⋆IdLᴰ' ⋆IdRᴰ' ⋆Assocᴰ' .Categoryᴰ.⋆IdLᴰ = ⋆IdLᴰ'
+  reindex ⋆IdLᴰ' ⋆IdRᴰ' ⋆Assocᴰ' .Categoryᴰ.⋆IdRᴰ = ⋆IdRᴰ'
+  reindex ⋆IdLᴰ' ⋆IdRᴰ' ⋆Assocᴰ' .Categoryᴰ.⋆Assocᴰ = ⋆Assocᴰ'
+  reindex ⋆IdLᴰ' ⋆IdRᴰ' ⋆Assocᴰ' .Categoryᴰ.isSetHomᴰ = Dᴰ.isSetHomᴰ
+
 module EqReindex
   {C : Category ℓC ℓC'} {D : Category ℓD ℓD'}
   (Dᴰ : Categoryᴰ D ℓDᴰ ℓDᴰ')

--- a/Cubical/Categories/Displayed/Presheaf/Uncurried/Constructions.agda
+++ b/Cubical/Categories/Displayed/Presheaf/Uncurried/Constructions.agda
@@ -533,3 +533,28 @@ module _ {C : Category ℓC ℓC'}{Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}{Cᴰ�
           ≡ (fᴰᴰ Pᴰᴰ.⋆ᴰ pᴰᴰ , fᴰᴰ Qᴰᴰ.⋆ᴰ qᴰᴰ)
       test×ⱽᴰPsh p pᴰ qᴰ f fᴰ fᴰᴰ pᴰᴰ qᴰᴰ =
         refl
+
+    -- Pairing total-space paths componentwise. The two paths only agree
+    -- on the shared P-component up to isSetPsh, so the second is
+    -- rectified onto the first.
+    ×ⱽᴰPsh-∫≡ : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {Γᴰᴰ : Cᴰᴰ.ob[ Γ , Γᴰ ]}
+      {p p' : P.p[ Γ ]}
+      {pᴰ : Pᴰ.p[ p ][ Γᴰ ]} {pᴰ' : Pᴰ.p[ p' ][ Γᴰ ]}
+      {qᴰ : Qᴰ.p[ p ][ Γᴰ ]} {qᴰ' : Qᴰ.p[ p' ][ Γᴰ ]}
+      {pᴰᴰ : Pᴰᴰ.p[ p , pᴰ ][ Γᴰᴰ ]} {pᴰᴰ' : Pᴰᴰ.p[ p' , pᴰ' ][ Γᴰᴰ ]}
+      {qᴰᴰ : Qᴰᴰ.p[ p , qᴰ ][ Γᴰᴰ ]} {qᴰᴰ' : Qᴰᴰ.p[ p' , qᴰ' ][ Γᴰᴰ ]}
+      → pᴰᴰ Pᴰᴰ.∫≡ pᴰᴰ'
+      → qᴰᴰ Qᴰᴰ.∫≡ qᴰᴰ'
+      → Path (Σ[ s ∈ Pᴰ×Qᴰ.p[ Γ , Γᴰ ] ] Pᴰᴰ×Qᴰᴰ.p[ s ][ Γᴰᴰ ])
+          ((p , pᴰ , qᴰ) , pᴰᴰ , qᴰᴰ)
+          ((p' , pᴰ' , qᴰ') , pᴰᴰ' , qᴰᴰ')
+    ×ⱽᴰPsh-∫≡ {p = p} {p' = p'} {qᴰ = qᴰ} {qᴰ' = qᴰ'}
+      {qᴰᴰ = qᴰᴰ} {qᴰᴰ' = qᴰᴰ'} e₁ e₂ i =
+      (e₁ i .fst .fst , e₁ i .fst .snd , e₂' i .snd) , e₁ i .snd , e₂'' i
+      where
+      e₂' : Path (Σ[ q ∈ P.p[ _ ] ] Qᴰ.p[ q ][ _ ]) (p , qᴰ) (p' , qᴰ')
+      e₂' j =
+        e₁ j .fst .fst
+        , Qᴰ.rectifyOut {e' = λ k → e₁ k .fst .fst} (λ k → e₂ k .fst) j
+      e₂'' : PathP (λ j → Qᴰᴰ.p[ e₂' j ][ _ ]) qᴰᴰ qᴰᴰ'
+      e₂'' = Qᴰᴰ.rectifyOut {e' = e₂'} e₂

--- a/Cubical/Categories/Displayed/Presheaf/Uncurried/Fibration/Displayed.agda
+++ b/Cubical/Categories/Displayed/Presheaf/Uncurried/Fibration/Displayed.agda
@@ -117,3 +117,65 @@ module Liftsᴰ⁺ⱽ (K : Category ℓ ℓ') (C : Categoryᴰ K ℓᴰ ℓᴰ')
     Quadrableⱽ→ᴰ ≤*ⱽ Bᴰ .fst = ≤*ⱽ Bᴰ .fst
     Quadrableⱽ→ᴰ ≤*ⱽ Bᴰ .snd = FiberwisePshIsoᴰ→PshIsoᴰ $
       ≤*ⱽ Bᴰ .snd ⋆PshIso ≤*ᴰ-Specⱽ≅ᴰ (≤* _) Bᴰ
+
+    -- Notation for a displayed cartesian lift, mirroring
+    -- CartesianLiftNotation. The generic laws of RepresentableᴰNotation
+    -- live in the total space of ≤*ᴰ-Specᴰ Bᴰ; here they are converted
+    -- to paths in Cᴰ.Hom[ _ , _ ] so clients can rectify them along a
+    -- base path.
+    module CartesianLiftᴰNotation {B : C.ob[ k2 ]} {Bᴰ : Cᴰ.ob[ _ , B ]}
+      (≤*ᴰBᴰ : Representableᴰ Cᴰ (∫≤*-Spec B) (≤*ᴰ-Specᴰ Bᴰ) (∫≤* B))
+      where
+      private
+        module Spec = PresheafNotation (∫≤*-Spec B)
+        module Specᴰ = PresheafᴰNotation Cᴰ (∫≤*-Spec B) (≤*ᴰ-Specᴰ Bᴰ)
+        module R = RepresentableᴰNotation Cᴰ (∫≤*-Spec B) (≤*ᴰ-Specᴰ Bᴰ) ≤*ᴰBᴰ
+
+        toHom : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]}
+          → Σ[ p ∈ Spec.p[ Γ ] ] Specᴰ.p[ p ][ Γᴰ ]
+          → Cᴰ.Hom[ (Γ , Γᴰ) , (_ , Bᴰ) ]
+        toHom (p , pᴰ) = π≤k B .N-ob _ p , pᴰ
+
+      open R public using (vertexᴰ ; introᴰ ; cong-introᴰ)
+        renaming (_⋆elementᴰ to _⋆πⱽ)
+
+      πⱽ : Cᴰ [ K.id K.⋆ ≤ , ≤*-π (≤* B) ][ vertexᴰ , Bᴰ ]
+      πⱽ = R.elementᴰ
+
+      opaque
+        ⟨_⟩⋆πⱽ : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {g g'}
+          {gᴰ : Cᴰ [ g ][ Γᴰ , vertexᴰ ]} {gᴰ' : Cᴰ [ g' ][ Γᴰ , vertexᴰ ]}
+          → gᴰ Cᴰ.∫≡ gᴰ'
+          → (gᴰ ⋆πⱽ) Cᴰ.∫≡ (gᴰ' ⋆πⱽ)
+        ⟨ gᴰ≡gᴰ' ⟩⋆πⱽ = cong toHom R.⟨ gᴰ≡gᴰ' ⟩⋆elementᴰ
+
+        ⋆πⱽ-natural : ∀ {Δ Γ} {Δᴰ : Cᴰ.ob[ Δ ]} {Γᴰ : Cᴰ.ob[ Γ ]} {γ g}
+          (γᴰ : Cᴰ [ γ ][ Δᴰ , Γᴰ ]) (gᴰ : Cᴰ [ g ][ Γᴰ , vertexᴰ ])
+          → ((γᴰ Cᴰ.⋆ᴰ gᴰ) ⋆πⱽ) Cᴰ.∫≡ (γᴰ Cᴰ.⋆ᴰ (gᴰ ⋆πⱽ))
+        ⋆πⱽ-natural γᴰ gᴰ =
+          cong toHom (R.⋆elementᴰ-natural γᴰ gᴰ) ∙ Cᴰ.reind-filler⁻ _
+
+        ⋆πⱽ≡⋆ᴰπⱽ : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {g}
+          (gᴰ : Cᴰ [ g ][ Γᴰ , vertexᴰ ])
+          → (gᴰ ⋆πⱽ) Cᴰ.∫≡ (gᴰ Cᴰ.⋆ᴰ πⱽ)
+        ⋆πⱽ≡⋆ᴰπⱽ gᴰ =
+          cong toHom (R.⋆elementᴰ≡⋆ᴰelementᴰ gᴰ) ∙ Cᴰ.reind-filler⁻ _
+
+        βᴰ : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {p : Spec.p[ Γ ]}
+          (gfᴰ : Specᴰ.p[ p ][ Γᴰ ])
+          → (introᴰ gfᴰ ⋆πⱽ) Cᴰ.∫≡ gfᴰ
+        βᴰ gfᴰ = cong toHom (R.∫βᴰ gfᴰ)
+
+        βᴰ' : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {p : Spec.p[ Γ ]}
+          (gfᴰ : Specᴰ.p[ p ][ Γᴰ ])
+          → (introᴰ gfᴰ Cᴰ.⋆ᴰ πⱽ) Cᴰ.∫≡ gfᴰ
+        βᴰ' gfᴰ = sym (⋆πⱽ≡⋆ᴰπⱽ _) ∙ βᴰ gfᴰ
+
+        ηᴰ : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {g}
+          (gᴰ : Cᴰ [ g ][ Γᴰ , vertexᴰ ])
+          → gᴰ Cᴰ.∫≡ introᴰ (gᴰ ⋆πⱽ)
+        ηᴰ = R.∫ηᴰ
+
+    module QuadrableᴰNotation (≤*ᴰ : Quadrableᴰ)
+      {B : C.ob[ k2 ]} {Bᴰ : Cᴰ.ob[ _ , B ]} =
+      CartesianLiftᴰNotation (≤*ᴰ Bᴰ)

--- a/Cubical/Categories/Displayed/Presheaf/Uncurried/Representable.agda
+++ b/Cubical/Categories/Displayed/Presheaf/Uncurried/Representable.agda
@@ -153,6 +153,66 @@ module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ')
     REPRⱽ .fst = vertexⱽ
     REPRⱽ .snd = toPshIsoⱽ
 
+  -- Notation for a vertical representable: the vertical analogue of
+  -- RepresentableᴰNotation below, with the laws stated as paths in
+  -- the total spaces (Pⱽ.∫≡ / Cᴰ.∫≡).
+  module RepresentableⱽNotation (reprⱽ : Representableⱽ) where
+    vertexⱽ : Cᴰ.ob[ x ]
+    vertexⱽ = reprⱽ .fst
+
+    _⋆elementⱽ : ∀ {Γ Γᴰ} {f : C [ Γ , x ]}
+      → Cᴰ [ f ][ Γᴰ , vertexⱽ ] → Pⱽ.p[ f ][ Γᴰ ]
+    fᴰ ⋆elementⱽ = reprⱽ .snd .trans .N-ob (_ , _ , _) fᴰ
+
+    elementⱽ : Pⱽ.p[ C.id ][ vertexⱽ ]
+    elementⱽ = Cᴰ.idᴰ ⋆elementⱽ
+
+    introⱽ : ∀ {Γ Γᴰ} {f : C [ Γ , x ]}
+      → Pⱽ.p[ f ][ Γᴰ ] → Cᴰ [ f ][ Γᴰ , vertexⱽ ]
+    introⱽ = reprⱽ .snd .nIso (_ , _ , _) .fst
+
+    opaque
+      cong-introⱽ : ∀ {Γ Γᴰ} {f f' : C [ Γ , x ]}
+        {pᴰ : Pⱽ.p[ f ][ Γᴰ ]} {p'ᴰ : Pⱽ.p[ f' ][ Γᴰ ]}
+        → pᴰ Pⱽ.∫≡ p'ᴰ
+        → introⱽ pᴰ Cᴰ.∫≡ introⱽ p'ᴰ
+      cong-introⱽ pᴰ≡p'ᴰ i = pᴰ≡p'ᴰ i .fst , introⱽ (pᴰ≡p'ᴰ i .snd)
+
+      ⟨_⟩⋆elementⱽ : ∀ {Γ Γᴰ} {f f' : C [ Γ , x ]}
+        {fᴰ : Cᴰ [ f ][ Γᴰ , vertexⱽ ]} {f'ᴰ : Cᴰ [ f' ][ Γᴰ , vertexⱽ ]}
+        → fᴰ Cᴰ.∫≡ f'ᴰ
+        → (fᴰ ⋆elementⱽ) Pⱽ.∫≡ (f'ᴰ ⋆elementⱽ)
+      ⟨ fᴰ≡f'ᴰ ⟩⋆elementⱽ i = fᴰ≡f'ᴰ i .fst , (fᴰ≡f'ᴰ i .snd) ⋆elementⱽ
+
+      ⋆elementⱽ-natural : ∀ {Δ Γ Δᴰ Γᴰ} {γ : C [ Δ , Γ ]} {f : C [ Γ , x ]}
+        (γᴰ : Cᴰ [ γ ][ Δᴰ , Γᴰ ]) (fᴰ : Cᴰ [ f ][ Γᴰ , vertexⱽ ])
+        → ((γᴰ Cᴰ.⋆ᴰ fᴰ) ⋆elementⱽ) Pⱽ.∫≡ (γᴰ Pⱽ.⋆ᴰ (fᴰ ⋆elementⱽ))
+      ⋆elementⱽ-natural γᴰ fᴰ =
+        ⟨ Cᴰ.reind-filler _ ⟩⋆elementⱽ
+        ∙ Pⱽ.≡in (reprⱽ .snd .trans .N-hom _ _ (_ , γᴰ , refl) fᴰ)
+
+      ⋆elementⱽ≡⋆ᴰelementⱽ : ∀ {Γ Γᴰ} {f : C [ Γ , x ]}
+        (fᴰ : Cᴰ [ f ][ Γᴰ , vertexⱽ ])
+        → (fᴰ ⋆elementⱽ) Pⱽ.∫≡ (fᴰ Pⱽ.⋆ᴰ elementⱽ)
+      ⋆elementⱽ≡⋆ᴰelementⱽ fᴰ =
+        ⟨ sym $ Cᴰ.⋆IdR _ ⟩⋆elementⱽ ∙ ⋆elementⱽ-natural fᴰ Cᴰ.idᴰ
+
+      ∫βⱽ : ∀ {Γ Γᴰ} {f : C [ Γ , x ]} (pᴰ : Pⱽ.p[ f ][ Γᴰ ])
+        → (introⱽ pᴰ ⋆elementⱽ) Pⱽ.∫≡ pᴰ
+      ∫βⱽ pᴰ = Pⱽ.≡in $ reprⱽ .snd .nIso (_ , _ , _) .snd .fst pᴰ
+
+      ∫βⱽ' : ∀ {Γ Γᴰ} {f : C [ Γ , x ]} (pᴰ : Pⱽ.p[ f ][ Γᴰ ])
+        → (introⱽ pᴰ Pⱽ.⋆ᴰ elementⱽ) Pⱽ.∫≡ pᴰ
+      ∫βⱽ' pᴰ = sym (⋆elementⱽ≡⋆ᴰelementⱽ _) ∙ ∫βⱽ pᴰ
+
+      ∫ηⱽ : ∀ {Γ Γᴰ} {f : C [ Γ , x ]} (fᴰ : Cᴰ [ f ][ Γᴰ , vertexⱽ ])
+        → fᴰ Cᴰ.∫≡ introⱽ (fᴰ ⋆elementⱽ)
+      ∫ηⱽ fᴰ = Cᴰ.≡in $ sym $ reprⱽ .snd .nIso (_ , _ , _) .snd .snd fᴰ
+
+      ∫ηⱽ' : ∀ {Γ Γᴰ} {f : C [ Γ , x ]} (fᴰ : Cᴰ [ f ][ Γᴰ , vertexⱽ ])
+        → fᴰ Cᴰ.∫≡ introⱽ (fᴰ Pⱽ.⋆ᴰ elementⱽ)
+      ∫ηⱽ' fᴰ = ∫ηⱽ fᴰ ∙ cong-introⱽ (⋆elementⱽ≡⋆ᴰelementⱽ fᴰ)
+
 module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ')
          (P : Presheaf C ℓP) (Pᴰ : Presheafᴰ P Cᴰ ℓPᴰ) where
   private

--- a/Cubical/Categories/Displayed/Presheaf/Uncurried/Representable.agda
+++ b/Cubical/Categories/Displayed/Presheaf/Uncurried/Representable.agda
@@ -225,32 +225,91 @@ module _ {C : Category ℓC ℓC'} (Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ')
       )
     open UniversalElementNotation ∫ue
 
+  -- Notation for a displayed representable over an arbitrary base
+  -- representation. The displayed β/η laws are stated as paths in the
+  -- total spaces (Pᴰ.∫≡ / Cᴰ.∫≡) so that clients can rectify them
+  -- along whatever base path they are handed.
+  module RepresentableᴰNotation {x : C.ob} {yx≅P : PshIso (C [-, x ]) P}
+    (reprᴰ : Representableᴰ (x , yx≅P)) where
+    private
+      α = yx≅P .trans
+      ∫αᴰ = ∫PshHomᴰ {α = α} (reprᴰ .snd .fst)
+
+    vertexᴰ : Cᴰ.ob[ x ]
+    vertexᴰ = reprᴰ .fst
+
+    _⋆elementᴰ : ∀ {Γ Γᴰ} {f : C [ Γ , x ]}
+      → Cᴰ [ f ][ Γᴰ , vertexᴰ ]
+      → Pᴰ.p[ α .N-ob Γ f ][ Γᴰ ]
+    fᴰ ⋆elementᴰ = reprᴰ .snd .fst .N-ob (_ , _ , _) fᴰ
+
+    elementᴰ : Pᴰ.p[ α .N-ob x C.id ][ vertexᴰ ]
+    elementᴰ = Cᴰ.idᴰ ⋆elementᴰ
+
+    introᴰ : ∀ {Γ Γᴰ} {p : P.p[ Γ ]}
+      → Pᴰ.p[ p ][ Γᴰ ]
+      → Cᴰ [ yx≅P .nIso Γ .fst p ][ Γᴰ , vertexᴰ ]
+    introᴰ = reprᴰ .snd .snd _ _ .inv _
+
+    opaque
+      cong-introᴰ : ∀ {Γ Γᴰ} {p p' : P.p[ Γ ]}
+        {pᴰ : Pᴰ.p[ p ][ Γᴰ ]} {p'ᴰ : Pᴰ.p[ p' ][ Γᴰ ]}
+        → pᴰ Pᴰ.∫≡ p'ᴰ
+        → introᴰ pᴰ Cᴰ.∫≡ introᴰ p'ᴰ
+      cong-introᴰ pᴰ≡p'ᴰ i =
+        yx≅P .nIso _ .fst (pᴰ≡p'ᴰ i .fst)
+        , introᴰ {p = pᴰ≡p'ᴰ i .fst} (pᴰ≡p'ᴰ i .snd)
+
+      ⟨_⟩⋆elementᴰ : ∀ {Γ Γᴰ} {f f' : C [ Γ , x ]}
+        {fᴰ : Cᴰ [ f ][ Γᴰ , vertexᴰ ]} {f'ᴰ : Cᴰ [ f' ][ Γᴰ , vertexᴰ ]}
+        → fᴰ Cᴰ.∫≡ f'ᴰ
+        → (fᴰ ⋆elementᴰ) Pᴰ.∫≡ (f'ᴰ ⋆elementᴰ)
+      ⟨ fᴰ≡f'ᴰ ⟩⋆elementᴰ i =
+        α .N-ob _ (fᴰ≡f'ᴰ i .fst) , (fᴰ≡f'ᴰ i .snd) ⋆elementᴰ
+
+      ⋆elementᴰ-natural : ∀ {Δ Γ Δᴰ Γᴰ} {γ : C [ Δ , Γ ]} {f : C [ Γ , x ]}
+        (γᴰ : Cᴰ [ γ ][ Δᴰ , Γᴰ ]) (fᴰ : Cᴰ [ f ][ Γᴰ , vertexᴰ ])
+        → ((γᴰ Cᴰ.⋆ᴰ fᴰ) ⋆elementᴰ) Pᴰ.∫≡ (γᴰ Pᴰ.⋆ᴰ (fᴰ ⋆elementᴰ))
+      ⋆elementᴰ-natural γᴰ fᴰ =
+        ⟨ Cᴰ.reind-filler _ ⟩⋆elementᴰ
+        ∙ ∫αᴰ .N-hom _ _ (_ , γᴰ) (_ , fᴰ)
+
+      ⋆elementᴰ≡⋆ᴰelementᴰ : ∀ {Γ Γᴰ} {f : C [ Γ , x ]}
+        (fᴰ : Cᴰ [ f ][ Γᴰ , vertexᴰ ])
+        → (fᴰ ⋆elementᴰ) Pᴰ.∫≡ (fᴰ Pᴰ.⋆ᴰ elementᴰ)
+      ⋆elementᴰ≡⋆ᴰelementᴰ fᴰ =
+        ⟨ sym $ Cᴰ.⋆IdR _ ⟩⋆elementᴰ ∙ ⋆elementᴰ-natural fᴰ Cᴰ.idᴰ
+
+      ∫βᴰ : ∀ {Γ Γᴰ} {p : P.p[ Γ ]} (pᴰ : Pᴰ.p[ p ][ Γᴰ ])
+        → (introᴰ pᴰ ⋆elementᴰ) Pᴰ.∫≡ pᴰ
+      ∫βᴰ pᴰ = Pᴰ.≡in $ reprᴰ .snd .snd _ _ .rightInv _ pᴰ
+
+      ∫βᴰ' : ∀ {Γ Γᴰ} {p : P.p[ Γ ]} (pᴰ : Pᴰ.p[ p ][ Γᴰ ])
+        → (introᴰ pᴰ Pᴰ.⋆ᴰ elementᴰ) Pᴰ.∫≡ pᴰ
+      ∫βᴰ' pᴰ = sym (⋆elementᴰ≡⋆ᴰelementᴰ _) ∙ ∫βᴰ pᴰ
+
+      ∫ηᴰ : ∀ {Γ Γᴰ} {f : C [ Γ , x ]} (fᴰ : Cᴰ [ f ][ Γᴰ , vertexᴰ ])
+        → fᴰ Cᴰ.∫≡ introᴰ (fᴰ ⋆elementᴰ)
+      ∫ηᴰ fᴰ = Cᴰ.≡in $ symP $ reprᴰ .snd .snd _ _ .leftInv _ fᴰ
+
+      ∫ηᴰ' : ∀ {Γ Γᴰ} {f : C [ Γ , x ]} (fᴰ : Cᴰ [ f ][ Γᴰ , vertexᴰ ])
+        → fᴰ Cᴰ.∫≡ introᴰ (fᴰ Pᴰ.⋆ᴰ elementᴰ)
+      ∫ηᴰ' fᴰ = ∫ηᴰ fᴰ ∙ cong-introᴰ (⋆elementᴰ≡⋆ᴰelementᴰ fᴰ)
+
   -- Could be more compositional but too lazy
   Representableᴰ→UniversalElementᴰOverUE : (ue : UniversalElement C P)
     → Representableᴰ (ue .vertex , asPshIso ue)
     → UniversalElementᴰ ue
-  Representableᴰ→UniversalElementᴰOverUE ue yᴰxᴰ≅Pᴰ .fst = yᴰxᴰ≅Pᴰ .fst
-  Representableᴰ→UniversalElementᴰOverUE ue yᴰxᴰ≅Pᴰ .snd .fst =
-    Pᴰ.reind (P.⋆IdL (UniversalElement.element ue))
-             (yᴰxᴰ≅Pᴰ .snd .fst .N-ob
-               (UniversalElement.vertex ue , yᴰxᴰ≅Pᴰ .fst , C.id) Cᴰ.idᴰ)
-  Representableᴰ→UniversalElementᴰOverUE ue yᴰxᴰ≅Pᴰ .snd .snd Γ Γᴰ .inv =
-    yᴰxᴰ≅Pᴰ .snd .snd Γ Γᴰ .inv
-  Representableᴰ→UniversalElementᴰOverUE ue yᴰxᴰ≅Pᴰ .snd .snd Γ Γᴰ .rightInv =
-    λ p pᴰ → Pᴰ.rectify $ Pᴰ.≡out $
-        Pᴰ.⟨⟩⋆⟨ sym $ Pᴰ.reind-filler _ ⟩
-        ∙ sym (∫PshHomᴰ {α = yoRec P (UniversalElement.element ue)} (yᴰxᴰ≅Pᴰ .snd .fst) .N-hom _ _ _ _)
-        ∙ cong (∫PshHomᴰ {α = yoRec P (UniversalElement.element ue)} (yᴰxᴰ≅Pᴰ .snd .fst) .N-ob _)
-                 ((sym $ Cᴰ.reind-filler _) ∙ Cᴰ.⋆IdR _)
-        ∙ Pᴰ.≡in (yᴰxᴰ≅Pᴰ .snd .snd Γ Γᴰ .rightInv _ _)
-  Representableᴰ→UniversalElementᴰOverUE ue yᴰxᴰ≅Pᴰ .snd .snd Γ Γᴰ .leftInv =
-      λ f fᴰ → Cᴰ.rectify $ Cᴰ.≡out $
-        cong (invPshIso (∫PshIsoᴰ {α = yoRecIso {P = P} ue} (yᴰxᴰ≅Pᴰ .snd)) .trans .N-ob _)
-          (Pᴰ.⟨⟩⋆⟨ (sym $ Pᴰ.reind-filler _) ⟩
-                    ∙ sym (∫PshHomᴰ {α = yoRec P (UniversalElement.element ue)} (yᴰxᴰ≅Pᴰ .snd .fst) .N-hom _ _ _ _)
-          ∙ cong (∫PshHomᴰ {α = yoRec P (UniversalElement.element ue)} (yᴰxᴰ≅Pᴰ .snd .fst) .N-ob _)
-                   (sym (Cᴰ.reind-filler _) ∙ Cᴰ.⋆IdR _))
-          ∙ (Cᴰ.≡in $ yᴰxᴰ≅Pᴰ .snd .snd Γ Γᴰ .leftInv _ _)
+  Representableᴰ→UniversalElementᴰOverUE ue yᴰxᴰ≅Pᴰ =
+    vertexᴰ , Pᴰ.reind (P.⋆IdL _) elementᴰ , univ
+    where
+    open RepresentableᴰNotation yᴰxᴰ≅Pᴰ
+    univ : isUniversalᴰ ue (Pᴰ.reind (P.⋆IdL _) elementᴰ)
+    univ Γ Γᴰ .inv = yᴰxᴰ≅Pᴰ .snd .snd Γ Γᴰ .inv
+    univ Γ Γᴰ .rightInv p pᴰ = Pᴰ.rectify $ Pᴰ.≡out $
+      Pᴰ.⟨⟩⋆⟨ sym $ Pᴰ.reind-filler _ ⟩ ∙ ∫βᴰ' pᴰ
+    univ Γ Γᴰ .leftInv f fᴰ = Cᴰ.rectify $ Cᴰ.≡out $
+      cong-introᴰ (Pᴰ.⟨⟩⋆⟨ sym $ Pᴰ.reind-filler _ ⟩) ∙ sym (∫ηᴰ' fᴰ)
 
   Representableⱽ→UniversalElementᴰ : (ue : UniversalElement C P)
     → Representableⱽ Cᴰ (ue .vertex) (reindPshᴰNatTrans (yoRec P (ue .element)) Pᴰ)

--- a/Cubical/Categories/Displayed/Presheaf/Uncurried/UniversalProperties.agda
+++ b/Cubical/Categories/Displayed/Presheaf/Uncurried/UniversalProperties.agda
@@ -325,36 +325,23 @@ module _ {C : Category ℓC ℓC'}
     ⋆PshIso invPshIso (reindPsh× _ _ _)
     where
     module bp = BinProductⱽNotation Cᴰ bpⱽ
+    module bpR = RepresentableⱽNotation Cᴰ x (BinProductⱽSpec Cᴰ Aᴰ Bᴰ) bpⱽ
     π₁-natural : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {f : C [ Γ , x ]}
       (hᴰ : Cᴰ [ f ][ Γᴰ , bp.vert ])
       → Path (Σ[ g ∈ C [ Γ , x ] ] Cᴰ [ g ][ Γᴰ , Aᴰ ])
           (f C.⋆ C.id , hᴰ Cᴰ.⋆ᴰ bp.π₁)
           (f , bpⱽ .snd .trans .N-ob (Γ , Γᴰ , f) hᴰ .fst)
-    π₁-natural {Γ = Γ} {Γᴰ = Γᴰ} {f = f} hᴰ =
+    π₁-natural hᴰ =
       Cᴰ.reind-filler _
-      ∙ cong (f ,_) (sym (cong fst natural))
-      ∙ cong (λ z → f , bpⱽ .snd .trans .N-ob (Γ , Γᴰ , f) z .fst)
-          (Cᴰ.rectifyOut {e' = refl}
-            (Cᴰ.reind-filler⁻ _ ∙ Cᴰ.⋆IdR (f , hᴰ)))
-      where
-      natural = bpⱽ .snd .trans .N-hom
-        (Γ , Γᴰ , f) (x , bp.vert , C.id)
-        (f , hᴰ , C.⋆IdR f) Cᴰ.idᴰ
+      ∙ cong (λ (g , ab) → g , ab .fst) (sym (bpR.⋆elementⱽ≡⋆ᴰelementⱽ hᴰ))
     π₂-natural : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {f : C [ Γ , x ]}
       (hᴰ : Cᴰ [ f ][ Γᴰ , bp.vert ])
       → Path (Σ[ g ∈ C [ Γ , x ] ] Cᴰ [ g ][ Γᴰ , Bᴰ ])
           (f C.⋆ C.id , hᴰ Cᴰ.⋆ᴰ bp.π₂)
           (f , bpⱽ .snd .trans .N-ob (Γ , Γᴰ , f) hᴰ .snd)
-    π₂-natural {Γ = Γ} {Γᴰ = Γᴰ} {f = f} hᴰ =
+    π₂-natural hᴰ =
       Cᴰ.reind-filler _
-      ∙ cong (f ,_) (sym (cong snd natural))
-      ∙ cong (λ z → f , bpⱽ .snd .trans .N-ob (Γ , Γᴰ , f) z .snd)
-          (Cᴰ.rectifyOut {e' = refl}
-            (Cᴰ.reind-filler⁻ _ ∙ Cᴰ.⋆IdR (f , hᴰ)))
-      where
-      natural = bpⱽ .snd .trans .N-hom
-        (Γ , Γᴰ , f) (x , bp.vert , C.id)
-        (f , hᴰ , C.⋆IdR f) Cᴰ.idᴰ
+      ∙ cong (λ (g , ab) → g , ab .snd) (sym (bpR.⋆elementⱽ≡⋆ᴰelementⱽ hᴰ))
 
   BinProductⱽ+π*→ⱽᴰ : ∀ {x} {Aᴰ Bᴰ : Cᴰ.ob[ x ]}
     (bpⱽ : BinProductⱽ Cᴰ Aᴰ Bᴰ)

--- a/Cubical/Categories/Displayed/Presheaf/Uncurried/UniversalProperties.agda
+++ b/Cubical/Categories/Displayed/Presheaf/Uncurried/UniversalProperties.agda
@@ -4,7 +4,6 @@ module Cubical.Categories.Displayed.Presheaf.Uncurried.UniversalProperties where
 open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.Function
 open import Cubical.Foundations.Isomorphism
-open import Cubical.Foundations.Equiv.Dependent
 open import Cubical.Foundations.More
 
 open import Cubical.Data.Sigma
@@ -253,50 +252,34 @@ module _ {C : Category ℓC ℓC'}
   module TerminalⱽᴰNotation {x} (termⱽ : Terminalⱽ Cᴰ x)
     (termⱽᴰ : Terminalⱽᴰ termⱽ) where
     private
-      term-reprᴰ : RepresentationPshIso
-        (PresheafᴰNotation.∫ Cᴰᴰ _ UnitPshᴰ)
-      term-reprᴰ =
-        ((x , termⱽ .fst) , termⱽᴰ .fst) ,
-        (invPshIso (∫Repr-iso Cᴰᴰ) ⋆PshIso ∫PshIsoᴰ (termⱽᴰ .snd))
-      term-ueᴰ = RepresentationPshIso→UniversalElement _ term-reprᴰ
-      module termᴰ = UniversalElementNotation term-ueᴰ
+      module R = RepresentableᴰNotation Cᴰᴰ _ UnitPshᴰ termⱽᴰ
 
-    vertexᴰ : Cᴰᴰ.ob[ x , termⱽ .fst ]
-    vertexᴰ = termⱽᴰ .fst
+      !ⱽ : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} (f : C [ Γ , x ])
+        → Cᴰ [ f ][ Γᴰ , termⱽ .fst ]
+      !ⱽ f = termⱽ .snd .nIso (_ , _ , f) .fst tt
+
+    open R public using (vertexᴰ)
 
     !ⱽᴰ : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {Γᴰᴰ : Cᴰᴰ.ob[ Γ , Γᴰ ]}
       {f : C [ Γ , x ]}
-      → Cᴰᴰ [ f , termᴰ.intro {c = ( (Γ , Γᴰ) , Γᴰᴰ )}
-          ((f , tt) , tt) .fst .snd ][ Γᴰᴰ , vertexᴰ ]
-    !ⱽᴰ {Γ = Γ} {Γᴰ = Γᴰ} {Γᴰᴰ = Γᴰᴰ} {f = f} =
-      termᴰ.intro {c = ( (Γ , Γᴰ) , Γᴰᴰ )} ((f , tt) , tt) .snd
+      → Cᴰᴰ [ f , !ⱽ f ][ Γᴰᴰ , vertexᴰ ]
+    !ⱽᴰ = R.introᴰ tt
 
-    private
-      !η-genericᴰ : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {Γᴰᴰ : Cᴰᴰ.ob[ Γ , Γᴰ ]}
+    opaque
+      !ηⱽᴰ : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {Γᴰᴰ : Cᴰᴰ.ob[ Γ , Γᴰ ]}
+        {f : C [ Γ , x ]} {fᴰ : Cᴰ [ f ][ Γᴰ , termⱽ .fst ]}
+        (fᴰᴰ : Cᴰᴰ [ f , fᴰ ][ Γᴰᴰ , vertexᴰ ])
+        → fᴰᴰ Cᴰᴰ.∫≡ !ⱽᴰ {f = f}
+      !ηⱽᴰ fᴰᴰ = R.∫ηᴰ fᴰᴰ
+
+      -- rectified along a caller-supplied base path
+      !ηⱽᴰ-on : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {Γᴰᴰ : Cᴰᴰ.ob[ Γ , Γᴰ ]}
         {f : C [ Γ , x ]} {fᴰ : Cᴰ [ f ][ Γᴰ , termⱽ .fst ]}
         (η : Path ∫Cᴰ.Hom[ (Γ , Γᴰ) , (x , termⱽ .fst) ]
-          (f , fᴰ)
-          (termᴰ.intro {c = ((Γ , Γᴰ) , Γᴰᴰ)} ((f , tt) , tt) .fst))
+          (f , fᴰ) (f , !ⱽ f))
         (fᴰᴰ : Cᴰᴰ [ f , fᴰ ][ Γᴰᴰ , vertexᴰ ])
-        → PathP (λ i → Cᴰᴰ [ η i ][ Γᴰᴰ , vertexᴰ ]) fᴰᴰ !ⱽᴰ
-      !η-genericᴰ {Γ = Γ} {Γᴰ = Γᴰ} {f = f} {fᴰ = fᴰ} η fᴰᴰ =
-        symP $ Cᴰᴰ.rectify {e' = sym η} $
-          termⱽᴰ .snd .snd (Γ , Γᴰ) _ .isIsoOver.leftInv (f , fᴰ) fᴰᴰ
-
-    !ηⱽᴰ : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {Γᴰᴰ : Cᴰᴰ.ob[ Γ , Γᴰ ]}
-      {f : C [ Γ , x ]} {fᴰ : Cᴰ [ f ][ Γᴰ , termⱽ .fst ]}
-      {g : ∫Cᴰ.Hom[ (Γ , Γᴰ) , (x , termⱽ .fst) ]}
-      (intro≡g : Path ∫Cᴰ.Hom[ (Γ , Γᴰ) , (x , termⱽ .fst) ]
-        (termᴰ.intro {c = ((Γ , Γᴰ) , Γᴰᴰ)} ((f , tt) , tt) .fst) g)
-      (η : Path ∫Cᴰ.Hom[ (Γ , Γᴰ) , (x , termⱽ .fst) ] (f , fᴰ) g)
-      (fᴰᴰ : Cᴰᴰ [ f , fᴰ ][ Γᴰᴰ , vertexᴰ ])
-      → PathP (λ i → Cᴰᴰ [ η i ][ Γᴰᴰ , vertexᴰ ])
-          fᴰᴰ (Cᴰᴰ.reind intro≡g !ⱽᴰ)
-    !ηⱽᴰ {Γ = Γ} {Γᴰ = Γᴰ} {f = f} {fᴰ = fᴰ} intro≡g η fᴰᴰ =
-      Cᴰᴰ.rectify {e' = η}
-        (Cᴰᴰ.≡out
-          ((Cᴰᴰ.≡in (!η-genericᴰ (η ∙ sym intro≡g) fᴰᴰ))
-          ∙ Cᴰᴰ.reind-filler {p = !ⱽᴰ} intro≡g))
+        → PathP (λ i → Cᴰᴰ [ η i ][ Γᴰᴰ , vertexᴰ ]) fᴰᴰ (!ⱽᴰ {f = f})
+      !ηⱽᴰ-on η fᴰᴰ = Cᴰᴰ.rectify {e' = η} $ Cᴰᴰ.≡out $ !ηⱽᴰ fᴰᴰ
 
   BinProductⱽᴰSpec : ∀ {x} {Aᴰ Bᴰ : Cᴰ.ob[ x ]}
     (bpⱽ : BinProductⱽ Cᴰ Aᴰ Bᴰ)
@@ -396,24 +379,34 @@ module _ {C : Category ℓC ℓC'}
     (bpⱽᴰ : BinProductⱽᴰ bpⱽ Aᴰᴰ Bᴰᴰ) where
     private
       module bpⱽ = BinProductⱽNotation Cᴰ bpⱽ
-      bp-reprᴰ : RepresentationPshIso
-        (PresheafᴰNotation.∫ Cᴰᴰ _ (BinProductⱽᴰSpec bpⱽ Aᴰᴰ Bᴰᴰ))
-      bp-reprᴰ =
-        ((x , bpⱽ.vert) , bpⱽᴰ .fst) ,
-        (invPshIso (∫Repr-iso Cᴰᴰ) ⋆PshIso ∫PshIsoᴰ (bpⱽᴰ .snd))
-      bp-ueᴰ = RepresentationPshIso→UniversalElement _ bp-reprᴰ
-      module bpᴰ = UniversalElementNotation bp-ueᴰ
-      module specᴰ = PresheafNotation
-        (PresheafᴰNotation.∫ Cᴰᴰ _ (BinProductⱽᴰSpec bpⱽ Aᴰᴰ Bᴰᴰ))
+      module R = RepresentableᴰNotation Cᴰᴰ _
+        (BinProductⱽᴰSpec bpⱽ Aᴰᴰ Bᴰᴰ) bpⱽᴰ
+      module Spec = PresheafNotation
+        (PresheafᴰNotation.∫ Cᴰ (C [-, x ]) (BinProductⱽSpec Cᴰ Aᴰ Bᴰ))
+      module Specᴰ = PresheafᴰNotation Cᴰᴰ _
+        (BinProductⱽᴰSpec bpⱽ Aᴰᴰ Bᴰᴰ)
 
-    vertexᴰ : Cᴰᴰ.ob[ x , bpⱽ.vert ]
-    vertexᴰ = bpⱽᴰ .fst
+      Aᴰᴰ-spec = reindPshᴰNatTrans (∫Repr-iso Cᴰ .trans) (Cᴰᴰ [-][-, Aᴰᴰ ])
+      Bᴰᴰ-spec = reindPshᴰNatTrans (∫Repr-iso Cᴰ .trans) (Cᴰᴰ [-][-, Bᴰᴰ ])
+
+      -- the two projections out of the total space of the spec
+      ∫π₁ : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {Γᴰᴰ : Cᴰᴰ.ob[ Γ , Γᴰ ]}
+        → Σ[ s ∈ Spec.p[ Γ , Γᴰ ] ] Specᴰ.p[ s ][ Γᴰᴰ ]
+        → Cᴰᴰ.Hom[ ((Γ , Γᴰ) , Γᴰᴰ) , ((x , Aᴰ) , Aᴰᴰ) ]
+      ∫π₁ ((f , fᴰ , gᴰ) , fᴰᴰ , gᴰᴰ) = (f , fᴰ) , fᴰᴰ
+
+      ∫π₂ : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {Γᴰᴰ : Cᴰᴰ.ob[ Γ , Γᴰ ]}
+        → Σ[ s ∈ Spec.p[ Γ , Γᴰ ] ] Specᴰ.p[ s ][ Γᴰᴰ ]
+        → Cᴰᴰ.Hom[ ((Γ , Γᴰ) , Γᴰᴰ) , ((x , Bᴰ) , Bᴰᴰ) ]
+      ∫π₂ ((f , fᴰ , gᴰ) , fᴰᴰ , gᴰᴰ) = (f , gᴰ) , gᴰᴰ
+
+    open R public using (vertexᴰ)
 
     πᴰ₁ : Cᴰᴰ [ C.id , bpⱽ.π₁ ][ vertexᴰ , Aᴰᴰ ]
-    πᴰ₁ = bpᴰ.element .snd .fst
+    πᴰ₁ = R.elementᴰ .fst
 
     πᴰ₂ : Cᴰᴰ [ C.id , bpⱽ.π₂ ][ vertexᴰ , Bᴰᴰ ]
-    πᴰ₂ = bpᴰ.element .snd .snd
+    πᴰ₂ = R.elementᴰ .snd
 
     infixr 4 _,ⱽᴰ_
     _,ⱽᴰ_ : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {Γᴰᴰ : Cᴰᴰ.ob[ Γ , Γᴰ ]}
@@ -421,156 +414,86 @@ module _ {C : Category ℓC ℓC'}
       {fᴰ : Cᴰ [ f ][ Γᴰ , Aᴰ ]} {gᴰ : Cᴰ [ f ][ Γᴰ , Bᴰ ]}
       → Cᴰᴰ [ f , fᴰ ][ Γᴰᴰ , Aᴰᴰ ] → Cᴰᴰ [ f , gᴰ ][ Γᴰᴰ , Bᴰᴰ ]
       → Cᴰᴰ [ f , (fᴰ bpⱽ.,ⱽ gᴰ) ][ Γᴰᴰ , vertexᴰ ]
-    _,ⱽᴰ_ {f = f} {fᴰ = fᴰ} {gᴰ = gᴰ} fᴰᴰ gᴰᴰ =
-      bpᴰ.intro ((f , fᴰ , gᴰ) , fᴰᴰ , gᴰᴰ) .snd
+    fᴰᴰ ,ⱽᴰ gᴰᴰ = R.introᴰ (fᴰᴰ , gᴰᴰ)
 
-    ×βⱽᴰ₁ : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {Γᴰᴰ : Cᴰᴰ.ob[ Γ , Γᴰ ]}
-      {f : C [ Γ , x ]}
-      {fᴰ : Cᴰ [ f ][ Γᴰ , Aᴰ ]} {gᴰ : Cᴰ [ f ][ Γᴰ , Bᴰ ]}
-      (fᴰᴰ : Cᴰᴰ [ f , fᴰ ][ Γᴰᴰ , Aᴰᴰ ]) (gᴰᴰ : Cᴰᴰ [ f , gᴰ ][ Γᴰᴰ , Bᴰᴰ ])
-      → ((fᴰᴰ ,ⱽᴰ gᴰᴰ) Cᴰᴰ.⋆ᴰ πᴰ₁)
-        Cᴰᴰ.≡[ Cᴰ.≡in bpⱽ.×βⱽ₁ ] fᴰᴰ
-    ×βⱽᴰ₁ fᴰᴰ gᴰᴰ = Cᴰᴰ.rectify $ Cᴰᴰ.≡out $
-      Cᴰᴰ.reind-filler _ ∙
-      (Cᴰᴰ.≡in $ PathPΣ (PathPΣ bpᴰ.β .snd) .fst)
+    opaque
+      ×βⱽᴰ₁ : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {Γᴰᴰ : Cᴰᴰ.ob[ Γ , Γᴰ ]}
+        {f : C [ Γ , x ]}
+        {fᴰ : Cᴰ [ f ][ Γᴰ , Aᴰ ]} {gᴰ : Cᴰ [ f ][ Γᴰ , Bᴰ ]}
+        (fᴰᴰ : Cᴰᴰ [ f , fᴰ ][ Γᴰᴰ , Aᴰᴰ ]) (gᴰᴰ : Cᴰᴰ [ f , gᴰ ][ Γᴰᴰ , Bᴰᴰ ])
+        → ((fᴰᴰ ,ⱽᴰ gᴰᴰ) Cᴰᴰ.⋆ᴰ πᴰ₁) Cᴰᴰ.∫≡ fᴰᴰ
+      ×βⱽᴰ₁ fᴰᴰ gᴰᴰ =
+        Cᴰᴰ.reind-filler _ ∙ cong ∫π₁ (R.∫βᴰ' (fᴰᴰ , gᴰᴰ))
 
-    ×βⱽᴰ₂ : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {Γᴰᴰ : Cᴰᴰ.ob[ Γ , Γᴰ ]}
-      {f : C [ Γ , x ]}
-      {fᴰ : Cᴰ [ f ][ Γᴰ , Aᴰ ]} {gᴰ : Cᴰ [ f ][ Γᴰ , Bᴰ ]}
-      (fᴰᴰ : Cᴰᴰ [ f , fᴰ ][ Γᴰᴰ , Aᴰᴰ ]) (gᴰᴰ : Cᴰᴰ [ f , gᴰ ][ Γᴰᴰ , Bᴰᴰ ])
-      → ((fᴰᴰ ,ⱽᴰ gᴰᴰ) Cᴰᴰ.⋆ᴰ πᴰ₂)
-        Cᴰᴰ.≡[ Cᴰ.≡in bpⱽ.×βⱽ₂ ] gᴰᴰ
-    ×βⱽᴰ₂ fᴰᴰ gᴰᴰ = Cᴰᴰ.rectify $ Cᴰᴰ.≡out $
-      Cᴰᴰ.reind-filler _ ∙
-      (Cᴰᴰ.≡in $ PathPΣ (PathPΣ bpᴰ.β .snd) .snd)
+      ×βⱽᴰ₂ : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {Γᴰᴰ : Cᴰᴰ.ob[ Γ , Γᴰ ]}
+        {f : C [ Γ , x ]}
+        {fᴰ : Cᴰ [ f ][ Γᴰ , Aᴰ ]} {gᴰ : Cᴰ [ f ][ Γᴰ , Bᴰ ]}
+        (fᴰᴰ : Cᴰᴰ [ f , fᴰ ][ Γᴰᴰ , Aᴰᴰ ]) (gᴰᴰ : Cᴰᴰ [ f , gᴰ ][ Γᴰᴰ , Bᴰᴰ ])
+        → ((fᴰᴰ ,ⱽᴰ gᴰᴰ) Cᴰᴰ.⋆ᴰ πᴰ₂) Cᴰᴰ.∫≡ gᴰᴰ
+      ×βⱽᴰ₂ fᴰᴰ gᴰᴰ =
+        Cᴰᴰ.reind-filler _ ∙ cong ∫π₂ (R.∫βᴰ' (fᴰᴰ , gᴰᴰ))
 
-    ×βⱽᴰ₁-on : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {Γᴰᴰ : Cᴰᴰ.ob[ Γ , Γᴰ ]}
-      {f : C [ Γ , x ]}
-      {fᴰ : Cᴰ [ f ][ Γᴰ , Aᴰ ]} {gᴰ : Cᴰ [ f ][ Γᴰ , Bᴰ ]}
-      {π' : ∫Cᴰ.Hom[ (x , bpⱽ.vert) , (x , Aᴰ) ]}
-      (π≡π' : Path ∫Cᴰ.Hom[ (x , bpⱽ.vert) , (x , Aᴰ) ]
-        (C.id , bpⱽ.π₁) π')
-      (β' : Path ∫Cᴰ.Hom[ (Γ , Γᴰ) , (x , Aᴰ) ]
-        ((f , fᴰ bpⱽ.,ⱽ gᴰ) ∫Cᴰ.⋆ π') (f , fᴰ))
-      (fᴰᴰ : Cᴰᴰ [ f , fᴰ ][ Γᴰᴰ , Aᴰᴰ ])
-      (gᴰᴰ : Cᴰᴰ [ f , gᴰ ][ Γᴰᴰ , Bᴰᴰ ])
-      → PathP (λ i → Cᴰᴰ [ β' i ][ Γᴰᴰ , Aᴰᴰ ])
-          ((Cᴰᴰ.reind (ΣPathP (refl , refl)) (fᴰᴰ ,ⱽᴰ gᴰᴰ))
-            Cᴰᴰ.⋆ᴰ Cᴰᴰ.reind π≡π' πᴰ₁) fᴰᴰ
-    ×βⱽᴰ₁-on π≡π' β' fᴰᴰ gᴰᴰ = Cᴰᴰ.rectify {e' = β'} $ Cᴰᴰ.≡out $
-      Cᴰᴰ.⟨ Cᴰᴰ.reind-filler⁻ (ΣPathP (refl , refl)) ⟩⋆⟨⟩
-      ∙ Cᴰᴰ.⟨⟩⋆⟨ Cᴰᴰ.reind-filler⁻ π≡π' ⟩
-      ∙ Cᴰᴰ.≡in (×βⱽᴰ₁ fᴰᴰ gᴰᴰ)
+      ×ηⱽᴰ : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {Γᴰᴰ : Cᴰᴰ.ob[ Γ , Γᴰ ]}
+        {f : C [ Γ , x ]} {hᴰ : Cᴰ [ f ][ Γᴰ , bpⱽ.vert ]}
+        (hᴰᴰ : Cᴰᴰ [ f , hᴰ ][ Γᴰᴰ , vertexᴰ ])
+        → hᴰᴰ Cᴰᴰ.∫≡ ((hᴰᴰ Cᴰᴰ.⋆ᴰ πᴰ₁) ,ⱽᴰ (hᴰᴰ Cᴰᴰ.⋆ᴰ πᴰ₂))
+      ×ηⱽᴰ hᴰᴰ =
+        R.∫ηᴰ hᴰᴰ
+        ∙ R.cong-introᴰ
+            (R.⋆elementᴰ≡⋆ᴰelementᴰ hᴰᴰ
+            ∙ ×ⱽᴰPsh-∫≡ Aᴰᴰ-spec Bᴰᴰ-spec
+                (Cᴰᴰ.reind-filler⁻ _) (Cᴰᴰ.reind-filler⁻ _))
 
-    ×βⱽᴰ₂-on : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {Γᴰᴰ : Cᴰᴰ.ob[ Γ , Γᴰ ]}
-      {f : C [ Γ , x ]}
-      {fᴰ : Cᴰ [ f ][ Γᴰ , Aᴰ ]} {gᴰ : Cᴰ [ f ][ Γᴰ , Bᴰ ]}
-      {π' : ∫Cᴰ.Hom[ (x , bpⱽ.vert) , (x , Bᴰ) ]}
-      (π≡π' : Path ∫Cᴰ.Hom[ (x , bpⱽ.vert) , (x , Bᴰ) ]
-        (C.id , bpⱽ.π₂) π')
-      (β' : Path ∫Cᴰ.Hom[ (Γ , Γᴰ) , (x , Bᴰ) ]
-        ((f , fᴰ bpⱽ.,ⱽ gᴰ) ∫Cᴰ.⋆ π') (f , gᴰ))
-      (fᴰᴰ : Cᴰᴰ [ f , fᴰ ][ Γᴰᴰ , Aᴰᴰ ])
-      (gᴰᴰ : Cᴰᴰ [ f , gᴰ ][ Γᴰᴰ , Bᴰᴰ ])
-      → PathP (λ i → Cᴰᴰ [ β' i ][ Γᴰᴰ , Bᴰᴰ ])
-          ((Cᴰᴰ.reind (ΣPathP (refl , refl)) (fᴰᴰ ,ⱽᴰ gᴰᴰ))
-            Cᴰᴰ.⋆ᴰ Cᴰᴰ.reind π≡π' πᴰ₂) gᴰᴰ
-    ×βⱽᴰ₂-on π≡π' β' fᴰᴰ gᴰᴰ = Cᴰᴰ.rectify {e' = β'} $ Cᴰᴰ.≡out $
-      Cᴰᴰ.⟨ Cᴰᴰ.reind-filler⁻ (ΣPathP (refl , refl)) ⟩⋆⟨⟩
-      ∙ Cᴰᴰ.⟨⟩⋆⟨ Cᴰᴰ.reind-filler⁻ π≡π' ⟩
-      ∙ Cᴰᴰ.≡in (×βⱽᴰ₂ fᴰᴰ gᴰᴰ)
+      -- The laws rectified along caller-supplied paths for the
+      -- projections and for the base β/η.
+      ×βⱽᴰ₁-on : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {Γᴰᴰ : Cᴰᴰ.ob[ Γ , Γᴰ ]}
+        {f : C [ Γ , x ]}
+        {fᴰ : Cᴰ [ f ][ Γᴰ , Aᴰ ]} {gᴰ : Cᴰ [ f ][ Γᴰ , Bᴰ ]}
+        {π' : ∫Cᴰ.Hom[ (x , bpⱽ.vert) , (x , Aᴰ) ]}
+        (π≡π' : Path ∫Cᴰ.Hom[ (x , bpⱽ.vert) , (x , Aᴰ) ]
+          (C.id , bpⱽ.π₁) π')
+        (β' : Path ∫Cᴰ.Hom[ (Γ , Γᴰ) , (x , Aᴰ) ]
+          ((f , fᴰ bpⱽ.,ⱽ gᴰ) ∫Cᴰ.⋆ π') (f , fᴰ))
+        (fᴰᴰ : Cᴰᴰ [ f , fᴰ ][ Γᴰᴰ , Aᴰᴰ ])
+        (gᴰᴰ : Cᴰᴰ [ f , gᴰ ][ Γᴰᴰ , Bᴰᴰ ])
+        → PathP (λ i → Cᴰᴰ [ β' i ][ Γᴰᴰ , Aᴰᴰ ])
+            ((fᴰᴰ ,ⱽᴰ gᴰᴰ) Cᴰᴰ.⋆ᴰ Cᴰᴰ.reind π≡π' πᴰ₁) fᴰᴰ
+      ×βⱽᴰ₁-on π≡π' β' fᴰᴰ gᴰᴰ = Cᴰᴰ.rectify {e' = β'} $ Cᴰᴰ.≡out $
+        Cᴰᴰ.⟨⟩⋆⟨ Cᴰᴰ.reind-filler⁻ π≡π' ⟩ ∙ ×βⱽᴰ₁ fᴰᴰ gᴰᴰ
 
-    ×ηⱽᴰ : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {Γᴰᴰ : Cᴰᴰ.ob[ Γ , Γᴰ ]}
-      {f : C [ Γ , x ]} {hᴰ : Cᴰ [ f ][ Γᴰ , bpⱽ.vert ]}
-      (hᴰᴰ : Cᴰᴰ [ f , hᴰ ][ Γᴰᴰ , vertexᴰ ])
-      → hᴰᴰ Cᴰᴰ.≡[ Cᴰ.≡in bpⱽ.×ηⱽ ]
-          (bpᴰ.intro (((f , hᴰ) , hᴰᴰ) specᴰ.⋆ bpᴰ.element) .snd)
-    ×ηⱽᴰ hᴰᴰ = subst
-      (λ p → hᴰᴰ Cᴰᴰ.≡[ p ]
-        (bpᴰ.intro ((_ , hᴰᴰ) specᴰ.⋆ bpᴰ.element) .snd))
-      (Cᴰ.isSetHom _ _ (cong fst bpᴰ.η) (Cᴰ.≡in bpⱽ.×ηⱽ))
-      (PathPΣ bpᴰ.η .snd)
+      ×βⱽᴰ₂-on : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {Γᴰᴰ : Cᴰᴰ.ob[ Γ , Γᴰ ]}
+        {f : C [ Γ , x ]}
+        {fᴰ : Cᴰ [ f ][ Γᴰ , Aᴰ ]} {gᴰ : Cᴰ [ f ][ Γᴰ , Bᴰ ]}
+        {π' : ∫Cᴰ.Hom[ (x , bpⱽ.vert) , (x , Bᴰ) ]}
+        (π≡π' : Path ∫Cᴰ.Hom[ (x , bpⱽ.vert) , (x , Bᴰ) ]
+          (C.id , bpⱽ.π₂) π')
+        (β' : Path ∫Cᴰ.Hom[ (Γ , Γᴰ) , (x , Bᴰ) ]
+          ((f , fᴰ bpⱽ.,ⱽ gᴰ) ∫Cᴰ.⋆ π') (f , gᴰ))
+        (fᴰᴰ : Cᴰᴰ [ f , fᴰ ][ Γᴰᴰ , Aᴰᴰ ])
+        (gᴰᴰ : Cᴰᴰ [ f , gᴰ ][ Γᴰᴰ , Bᴰᴰ ])
+        → PathP (λ i → Cᴰᴰ [ β' i ][ Γᴰᴰ , Bᴰᴰ ])
+            ((fᴰᴰ ,ⱽᴰ gᴰᴰ) Cᴰᴰ.⋆ᴰ Cᴰᴰ.reind π≡π' πᴰ₂) gᴰᴰ
+      ×βⱽᴰ₂-on π≡π' β' fᴰᴰ gᴰᴰ = Cᴰᴰ.rectify {e' = β'} $ Cᴰᴰ.≡out $
+        Cᴰᴰ.⟨⟩⋆⟨ Cᴰᴰ.reind-filler⁻ π≡π' ⟩ ∙ ×βⱽᴰ₂ fᴰᴰ gᴰᴰ
 
-    ×ηⱽᴰ-on : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {Γᴰᴰ : Cᴰᴰ.ob[ Γ , Γᴰ ]}
-      {f : C [ Γ , x ]} {hᴰ : Cᴰ [ f ][ Γᴰ , bpⱽ.vert ]}
-      {π₁' : Cᴰ [ C.id ][ bpⱽ.vert , Aᴰ ]}
-      {π₂' : Cᴰ [ C.id ][ bpⱽ.vert , Bᴰ ]}
-      (π₁≡π₁' : bpⱽ.π₁ ≡ π₁')
-      (π₂≡π₂' : bpⱽ.π₂ ≡ π₂')
-      (η' : Path ∫Cᴰ.Hom[ (Γ , Γᴰ) , (x , bpⱽ.vert) ]
-        (f , hᴰ)
-        (f C.⋆ C.id , (hᴰ Cᴰ.⋆ᴰ π₁') bpⱽ.,ⱽ (hᴰ Cᴰ.⋆ᴰ π₂')))
-      (hᴰᴰ : Cᴰᴰ [ f , hᴰ ][ Γᴰᴰ , vertexᴰ ])
-      → PathP (λ i → Cᴰᴰ [ η' i ][ Γᴰᴰ , vertexᴰ ]) hᴰᴰ
-          (Cᴰᴰ.reind (ΣPathP (refl , refl))
+      ×ηⱽᴰ-on : ∀ {Γ} {Γᴰ : Cᴰ.ob[ Γ ]} {Γᴰᴰ : Cᴰᴰ.ob[ Γ , Γᴰ ]}
+        {f : C [ Γ , x ]} {hᴰ : Cᴰ [ f ][ Γᴰ , bpⱽ.vert ]}
+        {π₁' : Cᴰ [ C.id ][ bpⱽ.vert , Aᴰ ]}
+        {π₂' : Cᴰ [ C.id ][ bpⱽ.vert , Bᴰ ]}
+        (π₁≡π₁' : bpⱽ.π₁ ≡ π₁')
+        (π₂≡π₂' : bpⱽ.π₂ ≡ π₂')
+        (η' : Path ∫Cᴰ.Hom[ (Γ , Γᴰ) , (x , bpⱽ.vert) ]
+          (f , hᴰ)
+          (f C.⋆ C.id , (hᴰ Cᴰ.⋆ᴰ π₁') bpⱽ.,ⱽ (hᴰ Cᴰ.⋆ᴰ π₂')))
+        (hᴰᴰ : Cᴰᴰ [ f , hᴰ ][ Γᴰᴰ , vertexᴰ ])
+        → PathP (λ i → Cᴰᴰ [ η' i ][ Γᴰᴰ , vertexᴰ ]) hᴰᴰ
             ((hᴰᴰ Cᴰᴰ.⋆ᴰ Cᴰᴰ.reind (ΣPathP (refl , π₁≡π₁')) πᴰ₁) ,ⱽᴰ
-             (hᴰᴰ Cᴰᴰ.⋆ᴰ Cᴰᴰ.reind (ΣPathP (refl , π₂≡π₂')) πᴰ₂)))
-    ×ηⱽᴰ-on {Γ = Γ} {Γᴰ = Γᴰ} {Γᴰᴰ = Γᴰᴰ} {f = f} {hᴰ = hᴰ}
-      {π₁' = π₁'} {π₂' = π₂'} π₁≡π₁' π₂≡π₂' η' hᴰᴰ = Cᴰᴰ.rectify {e' = η'} $ Cᴰᴰ.≡out $
-      Cᴰᴰ.≡in (×ηⱽᴰ hᴰᴰ)
-      ∙ cong bpᴰ.intro (normalize-ηᴰ ∙ align-ηᴰ)
-      ∙ Cᴰᴰ.reind-filler (ΣPathP (refl , refl))
-      where
-      normalize-ηᴰ :
-        Path (Σ[ z ∈ (Σ[ g ∈ C [ Γ , x ] ]
-          (Cᴰ [ g ][ Γᴰ , Aᴰ ] × Cᴰ [ g ][ Γᴰ , Bᴰ ])) ]
-          (Cᴰᴰ [ z .fst , z .snd .fst ][ Γᴰᴰ , Aᴰᴰ ] ×
-           Cᴰᴰ [ z .fst , z .snd .snd ][ Γᴰᴰ , Bᴰᴰ ]))
-          ((((f , hᴰ) , hᴰᴰ) specᴰ.⋆ bpᴰ.element))
-          ((f C.⋆ C.id , (hᴰ Cᴰ.⋆ᴰ bpⱽ.π₁) , (hᴰ Cᴰ.⋆ᴰ bpⱽ.π₂)) ,
-           (hᴰᴰ Cᴰᴰ.⋆ᴰ πᴰ₁) , (hᴰᴰ Cᴰᴰ.⋆ᴰ πᴰ₂))
-      q₁ :
-        let s = (((f , hᴰ) , hᴰᴰ) specᴰ.⋆ bpᴰ.element)
-        in Path (Σ[ ga ∈ (Σ[ g ∈ C [ Γ , x ] ] Cᴰ [ g ][ Γᴰ , Aᴰ ]) ]
-             Cᴰᴰ [ ga .fst , ga .snd ][ Γᴰᴰ , Aᴰᴰ ])
-             ((s .fst .fst , s .fst .snd .fst) , s .snd .fst)
-             ((f C.⋆ C.id , hᴰ Cᴰ.⋆ᴰ bpⱽ.π₁) , hᴰᴰ Cᴰᴰ.⋆ᴰ πᴰ₁)
-      q₁ = sym (Cᴰᴰ.reind-filler _)
-      q₂ :
-        let s = (((f , hᴰ) , hᴰᴰ) specᴰ.⋆ bpᴰ.element)
-        in Path (Σ[ gb ∈ (Σ[ g ∈ C [ Γ , x ] ] Cᴰ [ g ][ Γᴰ , Bᴰ ]) ]
-             Cᴰᴰ [ gb .fst , gb .snd ][ Γᴰᴰ , Bᴰᴰ ])
-             ((s .fst .fst , s .fst .snd .snd) , s .snd .snd)
-             ((f C.⋆ C.id , hᴰ Cᴰ.⋆ᴰ bpⱽ.π₂) , hᴰᴰ Cᴰᴰ.⋆ᴰ πᴰ₂)
-      q₂ = sym (Cᴰᴰ.reind-filler _)
-      normalize-ηᴰ i =
-        let e₁ = cong fst q₁
-            e₂ = cong fst q₂
-            e₂' = λ j → e₁ j .fst , Cᴰ.rectifyOut {e' = cong fst e₁} e₂ j
-            p₁ = Cᴰᴰ.rectifyOut {e' = e₁} q₁
-            p₂ = Cᴰᴰ.rectifyOut {e' = e₂'} q₂
-        in ((e₁ i .fst , e₁ i .snd , e₂' i .snd) , p₁ i , p₂ i)
-      align-ηᴰ :
-        Path (Σ[ z ∈ (Σ[ g ∈ C [ Γ , x ] ]
-          (Cᴰ [ g ][ Γᴰ , Aᴰ ] × Cᴰ [ g ][ Γᴰ , Bᴰ ])) ]
-          (Cᴰᴰ [ z .fst , z .snd .fst ][ Γᴰᴰ , Aᴰᴰ ] ×
-           Cᴰᴰ [ z .fst , z .snd .snd ][ Γᴰᴰ , Bᴰᴰ ]))
-          ((f C.⋆ C.id , (hᴰ Cᴰ.⋆ᴰ bpⱽ.π₁) , (hᴰ Cᴰ.⋆ᴰ bpⱽ.π₂)) ,
-           (hᴰᴰ Cᴰᴰ.⋆ᴰ πᴰ₁) , (hᴰᴰ Cᴰᴰ.⋆ᴰ πᴰ₂))
-          ((f C.⋆ C.id , (hᴰ Cᴰ.⋆ᴰ π₁') , (hᴰ Cᴰ.⋆ᴰ π₂')) ,
-           (hᴰᴰ Cᴰᴰ.⋆ᴰ Cᴰᴰ.reind (ΣPathP (refl , π₁≡π₁')) πᴰ₁) ,
-           (hᴰᴰ Cᴰᴰ.⋆ᴰ Cᴰᴰ.reind (ΣPathP (refl , π₂≡π₂')) πᴰ₂))
-      r₁ : Path
-        (Σ[ ga ∈ (Σ[ g ∈ C [ Γ , x ] ] Cᴰ [ g ][ Γᴰ , Aᴰ ]) ]
-          Cᴰᴰ [ ga .fst , ga .snd ][ Γᴰᴰ , Aᴰᴰ ])
-        ((f C.⋆ C.id , hᴰ Cᴰ.⋆ᴰ bpⱽ.π₁) , hᴰᴰ Cᴰᴰ.⋆ᴰ πᴰ₁)
-        ((f C.⋆ C.id , hᴰ Cᴰ.⋆ᴰ π₁') ,
-          hᴰᴰ Cᴰᴰ.⋆ᴰ Cᴰᴰ.reind (ΣPathP (refl , π₁≡π₁')) πᴰ₁)
-      r₁ = Cᴰᴰ.⟨⟩⋆⟨ Cᴰᴰ.reind-filler (ΣPathP (refl , π₁≡π₁')) ⟩
-      r₂ : Path
-        (Σ[ gb ∈ (Σ[ g ∈ C [ Γ , x ] ] Cᴰ [ g ][ Γᴰ , Bᴰ ]) ]
-          Cᴰᴰ [ gb .fst , gb .snd ][ Γᴰᴰ , Bᴰᴰ ])
-        ((f C.⋆ C.id , hᴰ Cᴰ.⋆ᴰ bpⱽ.π₂) , hᴰᴰ Cᴰᴰ.⋆ᴰ πᴰ₂)
-        ((f C.⋆ C.id , hᴰ Cᴰ.⋆ᴰ π₂') ,
-          hᴰᴰ Cᴰᴰ.⋆ᴰ Cᴰᴰ.reind (ΣPathP (refl , π₂≡π₂')) πᴰ₂)
-      r₂ = Cᴰᴰ.⟨⟩⋆⟨ Cᴰᴰ.reind-filler (ΣPathP (refl , π₂≡π₂')) ⟩
-      align-ηᴰ i =
-            let e₁ = cong fst r₁
-                e₂ = cong fst r₂
-                e₂' = λ j → e₁ j .fst , Cᴰ.rectifyOut {e' = cong fst e₁} e₂ j
-                p₁ = Cᴰᴰ.rectifyOut {e' = e₁} r₁
-                p₂ = Cᴰᴰ.rectifyOut {e' = e₂'} r₂
-            in ((e₁ i .fst , e₁ i .snd , e₂' i .snd) , p₁ i , p₂ i)
+             (hᴰᴰ Cᴰᴰ.⋆ᴰ Cᴰᴰ.reind (ΣPathP (refl , π₂≡π₂')) πᴰ₂))
+      ×ηⱽᴰ-on π₁≡π₁' π₂≡π₂' η' hᴰᴰ = Cᴰᴰ.rectify {e' = η'} $ Cᴰᴰ.≡out $
+        ×ηⱽᴰ hᴰᴰ
+        ∙ R.cong-introᴰ (×ⱽᴰPsh-∫≡ Aᴰᴰ-spec Bᴰᴰ-spec
+            Cᴰᴰ.⟨⟩⋆⟨ Cᴰᴰ.reind-filler (ΣPathP (refl , π₁≡π₁')) ⟩
+            Cᴰᴰ.⟨⟩⋆⟨ Cᴰᴰ.reind-filler (ΣPathP (refl , π₂≡π₂')) ⟩)
 
 module _ {C : Category ℓC ℓC'}
   {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
@@ -582,7 +505,7 @@ module _ {C : Category ℓC ℓC'}
   module InitialⱽᴰNotation {x} (initⱽ : Terminalⱽ (Cᴰ ^opᴰ) x)
     (initⱽᴰ : Initialⱽᴰ initⱽ) =
     TerminalⱽᴰNotation (Cᴰᴰ ^opᴰᴰ) initⱽ initⱽᴰ renaming
-      (!ⱽᴰ to ¡ⱽᴰ ; !ηⱽᴰ to ¡ηⱽᴰ)
+      (!ⱽᴰ to ¡ⱽᴰ ; !ηⱽᴰ to ¡ηⱽᴰ ; !ηⱽᴰ-on to ¡ηⱽᴰ-on)
 
   BinCoProductⱽᴰ : ∀ {x} {Aᴰ Bᴰ : Categoryᴰ.ob[_] Cᴰ x}
     (bcpⱽ : BinProductⱽ (Cᴰ ^opᴰ) Aᴰ Bᴰ)

--- a/Cubical/Categories/Displayed/Presheaf/Uncurried/UniversalProperties.agda
+++ b/Cubical/Categories/Displayed/Presheaf/Uncurried/UniversalProperties.agda
@@ -499,6 +499,46 @@ module _ {C : Category ℓC ℓC'}
   {Cᴰ : Categoryᴰ C ℓCᴰ ℓCᴰ'}
   (Cᴰᴰ : Categoryᴰ (∫C Cᴰ) ℓCᴰᴰ ℓCᴰᴰ') where
 
+  private
+    module Cᴰ = Fibers Cᴰ
+    module Cᴰᴰ = Fibers Cᴰᴰ
+    module ∫Cᴰ = Category (∫C Cᴰ)
+
+  -- The doubly displayed opposite Cᴰᴰ ^opᴰᴰ is the direct opposite
+  -- Cᴰᴰ ^opᴰ reindexed along the strict isomorphism of base categories
+  -- ∫C (Cᴰ ^opᴰ) ≅ (∫C Cᴰ) ^op, so the fibers agree definitionally and
+  -- vertical universal properties transfer by retyping their data.
+  Terminalⱽ^opᴰ→^opᴰᴰ : ∀ {x} {xᴰ : Cᴰ.ob[ x ]}
+    → Terminalⱽ (Cᴰᴰ ^opᴰ) (x , xᴰ)
+    → Terminalⱽ (Cᴰᴰ ^opᴰᴰ) (x , xᴰ)
+  Terminalⱽ^opᴰ→^opᴰᴰ term .fst = term .fst
+  Terminalⱽ^opᴰ→^opᴰᴰ term .snd =
+    pshiso
+      (pshhom (λ c → term .snd .trans .N-ob c) (λ _ _ _ _ → refl))
+      (term .snd .nIso)
+
+  CartesianLift^opᴰ→^opᴰᴰ : ∀ {x y : ∫Cᴰ.ob} {f : ∫Cᴰ.Hom[ y , x ]}
+    {yᴰᴰ : Cᴰᴰ.ob[ y ]}
+    → CartesianLift (Cᴰᴰ ^opᴰ) f yᴰᴰ
+    → CartesianLift (Cᴰᴰ ^opᴰᴰ) f yᴰᴰ
+  CartesianLift^opᴰ→^opᴰᴰ f*yᴰᴰ .fst = f*yᴰᴰ .fst
+  CartesianLift^opᴰ→^opᴰᴰ f*yᴰᴰ .snd =
+    pshiso
+      (pshhom (λ c → f*yᴰᴰ .snd .trans .N-ob c)
+        (λ c c' g p → f*yᴰᴰ .snd .trans .N-hom c c' g p))
+      (f*yᴰᴰ .snd .nIso)
+
+  BinProductⱽ^opᴰ→^opᴰᴰ : ∀ {x} {xᴰ : Cᴰ.ob[ x ]}
+    {Aᴰᴰ Bᴰᴰ : Cᴰᴰ.ob[ x , xᴰ ]}
+    → BinProductⱽ (Cᴰᴰ ^opᴰ) Aᴰᴰ Bᴰᴰ
+    → BinProductⱽ (Cᴰᴰ ^opᴰᴰ) Aᴰᴰ Bᴰᴰ
+  BinProductⱽ^opᴰ→^opᴰᴰ bp .fst = bp .fst
+  BinProductⱽ^opᴰ→^opᴰᴰ bp .snd =
+    pshiso
+      (pshhom (λ c → bp .snd .trans .N-ob c)
+        (λ c c' g p → bp .snd .trans .N-hom c c' g p))
+      (bp .snd .nIso)
+
   Initialⱽᴰ : ∀ {x} → (initⱽ : Terminalⱽ (Cᴰ ^opᴰ) x) → Type _
   Initialⱽᴰ = Terminalⱽᴰ (Cᴰᴰ ^opᴰᴰ)
 

--- a/Cubical/Foundations/Equiv/More.agda
+++ b/Cubical/Foundations/Equiv/More.agda
@@ -1,0 +1,20 @@
+module Cubical.Foundations.Equiv.More where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.Isomorphism
+
+private
+  variable
+    ℓ ℓ' : Level
+    A : Type ℓ
+    B : A → Type ℓ'
+
+explicitΠEquiv : ({x : A} → B x) ≃ ((x : A) → B x)
+explicitΠEquiv = isoToEquiv explicitΠIso
+  where
+  explicitΠIso : Iso ({x : A} → B x) ((x : A) → B x)
+  explicitΠIso .Iso.fun f x = f {x}
+  explicitΠIso .Iso.inv f {x} = f x
+  explicitΠIso .Iso.sec f = refl
+  explicitΠIso .Iso.ret f = refl

--- a/Cubical/Foundations/HLevels/More.agda
+++ b/Cubical/Foundations/HLevels/More.agda
@@ -4,6 +4,7 @@ open import Cubical.Foundations.Prelude
 open import Cubical.Foundations.HLevels
 open import Cubical.Foundations.Equiv
 open import Cubical.Foundations.Isomorphism
+import Cubical.Data.Nat.Base as ℕ
 
 private
   variable
@@ -14,6 +15,42 @@ isPropIso f = isPropRetract (f .Iso.fun) (Iso.inv f) (Iso.ret f)
 
 isSetIso : {A : Type ℓ}{B : Type ℓ'} → Iso A B → isSet B → isSet A
 isSetIso f = isSetRetract (f .Iso.fun) (Iso.inv f) (Iso.ret f)
+
+isOfHLevelᴰ : (n : HLevel) {A : Type ℓ}
+  → isOfHLevel n A → (A → Type ℓ') → Type (ℓ-max ℓ ℓ')
+isOfHLevelᴰ 0 {A = A} Acontr B =
+  Σ[ b ∈ B (Acontr .fst) ]
+    ({a : A} (b' : B a) →
+      PathP (λ i → B (Acontr .snd a i)) b b')
+isOfHLevelᴰ 1 {A = A} Aprop B =
+  {a₀ a₁ : A} (b₀ : B a₀) (b₁ : B a₁) →
+    PathP (λ i → B (Aprop a₀ a₁ i)) b₀ b₁
+isOfHLevelᴰ (ℕ.suc (ℕ.suc n)) {A = A} Alevel B =
+  {a₀ a₁ : A} (b₀ : B a₀) (b₁ : B a₁) →
+    isOfHLevelᴰ (ℕ.suc n) (Alevel a₀ a₁)
+      (λ p → PathP (λ i → B (p i)) b₀ b₁)
+
+isPropᴰ : {A : Type ℓ} → isProp A → (A → Type ℓ') → Type _
+isPropᴰ = isOfHLevelᴰ 1
+
+isSetᴰ : {A : Type ℓ} → isSet A → (A → Type ℓ') → Type _
+isSetᴰ = isOfHLevelᴰ 2
+
+isOfHLevelᴰ→isOfHLevel : (n : HLevel) {A : Type ℓ}
+  (Alevel : isOfHLevel n A) {B : A → Type ℓ'}
+  → isOfHLevelᴰ n Alevel B
+  → (a : A) → isOfHLevel n (B a)
+isOfHLevelᴰ→isOfHLevel 0 Acontr {B = B} Bcontr a =
+  transport (λ i → B (Acontr .snd a i)) (Bcontr .fst)
+  , λ b → fromPathP (Bcontr .snd b)
+isOfHLevelᴰ→isOfHLevel 1 Aprop {B = B} Bprop a b₀ b₁ =
+  subst
+    (λ p → PathP (λ i → B (p i)) b₀ b₁)
+    (isProp→isSet Aprop a a (Aprop a a) refl)
+    (Bprop b₀ b₁)
+isOfHLevelᴰ→isOfHLevel (ℕ.suc (ℕ.suc n)) Alevel Blevel a b₀ b₁ =
+  isOfHLevelᴰ→isOfHLevel (ℕ.suc n)
+    (Alevel a a) (Blevel b₀ b₁) refl
 
 isPropLift :
   {ℓ ℓ' : Level} →

--- a/Gluing/CBPV/Algebra/Additive.agda
+++ b/Gluing/CBPV/Algebra/Additive.agda
@@ -1,0 +1,250 @@
+{-# OPTIONS --prop --lossy-unification #-}
+module Gluing.CBPV.Algebra.Additive where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Structure
+
+open import Cubical.Prop
+
+open import Cubical.Data.Bool as Bool hiding (elim)
+open import Cubical.Data.Sigma
+open import Cubical.Data.Sum as Sum
+open import Cubical.Data.Unit
+
+open import Cubical.Algebra.Signature.Base
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Instances.TotalCategory hiding (elim)
+open import Cubical.Categories.Instances.WalkingArrow
+  renaming (WalkingArrow to KIND; Vertex to Kind; l to 𝒱; r to 𝒞;
+    ≤Vertex to ≤Kind)
+
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Displayed.Section.Base
+  renaming (Section to DisplayedSection)
+open import Cubical.Categories.Displayed.Instances.Opposite
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Fibration
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.UniversalProperties
+open import Cubical.Categories.Displayed.CBPV.Unary.Base
+open import Cubical.Categories.Displayed.CBPV.Unary.Enrichment.Algebra
+open import Cubical.Categories.Displayed.CBPV.Unary.Instances.Algebra.Base
+open import Cubical.Categories.Displayed.CBPV.Unary.Instances.Algebra.Additive
+open import Cubical.Categories.Displayed.CBPV.Unary.Instances.Free.AlgEnriched.Additive
+open import Cubical.Categories.Displayed.Instances.Algebra.Algebra
+
+open Category
+open Functor
+open Functorᴰ
+open DisplayedSection
+
+private
+  variable
+    ℓO ℓA : Level
+
+module AlgebraGluing
+  (Sig : Signature ℓO ℓA)
+  (isSetOp : isSet (Signature.Op Sig))
+  (BaseTy : Kind → Type (AlgebraLevel Sig))
+  (Fun : ∀ {k₁ k₂} → ≤Kind k₁ k₂
+    → CBPV.Ob Sig BaseTy k₁ → CBPV.Ob Sig BaseTy k₂
+    → Type (AlgebraLevel Sig))
+  (I : CBPV.Ob Sig BaseTy 𝒱)
+  where
+  open CBPV Sig BaseTy
+  open Terms Fun
+
+  pts : Functorⱽ (AddCBPV .fst .fst)
+    (AlgebraAddCBPV Sig isSetOp .fst .fst)
+  pts = points Sig isSetOp (AddCBPV .fst .fst) CBPVAlg I
+
+  ptsPreservesAlgebra : PreservesAlgebraEnrichment Sig pts
+    CBPVAlg (AlgebraCBPVAlg Sig isSetOp)
+  ptsPreservesAlgebra =
+    pointsPreservesAlgebra Sig isSetOp (AddCBPV .fst .fst) CBPVAlg I
+
+module BoolAlgebraSyntax
+  (Sig : Signature ℓO ℓA)
+  (isSetOp : isSet (Signature.Op Sig))
+  where
+  open Signature Sig
+
+  private
+    L = AlgebraLevel Sig
+
+  data BaseTy (k : Kind) : Type L where
+
+  open CBPV Sig BaseTy
+
+  data FUN : ∀ {k₁ k₂} → ≤Kind k₁ k₂
+    → Ob k₁ → Ob k₂ → Type L where
+
+  open Terms FUN public
+
+  UnitTy BoolTy : VTy
+  UnitTy = [1]
+  BoolTy = UnitTy [+] UnitTy
+
+  private
+    inl' inr' : Tm tt UnitTy BoolTy
+    inl' = [+I1]
+    inr' = [+I2]
+
+  tru fls : Tm tt UnitTy BoolTy
+  tru = inl'
+  fls = inr'
+
+  quoteBool : Bool → Tm tt UnitTy BoolTy
+  quoteBool false = fls
+  quoteBool true = tru
+
+  module G = AlgebraGluing Sig isSetOp BaseTy FUN UnitTy
+
+  module Fundamental = LocalElim
+    G.pts
+    (AlgebraAddCBPVⱽ Sig isSetOp)
+    (AlgebraCBPVAlg Sig isSetOp)
+    G.ptsPreservesAlgebra
+    (AlgebraCBPVAlgᴰ Sig isSetOp)
+
+  baseObject : ∀ {k} (X : BaseTy k)
+    → Categoryᴰ.ob[_] (AlgebraAddCBPVⱽ Sig isSetOp .fst .fst)
+        (k , G.pts .F-obᴰ (gen X))
+  baseObject ()
+
+  fundamentalLemma :
+    DisplayedSection (∫F G.pts) (AlgebraAddCBPVⱽ Sig isSetOp .fst .fst)
+  fundamentalLemma = Fundamental.localElim baseObject λ ()
+
+  LogicalRelation : ∀ {k} (Γ : Ob k)
+    → Tm tt UnitTy Γ → hSet L
+  LogicalRelation {k = 𝒱} Γ = Fundamental.local-obᴰ baseObject Γ
+  LogicalRelation {k = 𝒞} Γ = Fundamental.local-obᴰ baseObject Γ .fst
+
+  fundamentalAt : ∀ {k} {Γ : Ob k} (M : Tm tt UnitTy Γ)
+    → ⟨ LogicalRelation Γ M ⟩
+  fundamentalAt {k = 𝒱} {Γ = Γ} M = subst
+    (λ N → ⟨ LogicalRelation Γ N ⟩)
+    (IdLS M) $
+    fundamentalLemma .F-homᴰ (_ , M) idS tt*
+  fundamentalAt {k = 𝒞} {Γ = Γ} M = subst
+    (λ N → ⟨ LogicalRelation Γ N ⟩)
+    (IdLS M) $
+    fundamentalLemma .F-homᴰ (_ , M) idS tt*
+
+  private
+    [ret]' : Tm tt BoolTy ([F] BoolTy)
+    [ret]' = CartesianLiftNotation.πⱽ (CBPV ^opᴰ)
+      (MultCBPV .snd .snd BoolTy)
+
+    [ret]'≡ret : [ret]' ≡ [ret]
+    [ret]'≡ret = cong snd
+      (Cop.reind-filler⁻ _
+      ∙ Cop.≡in {pth = refl} (IdRS [ret]))
+
+    value-σ₁≡[+I1] :
+      BinProductⱽNotation.π₁ (CBPV ^opᴰ)
+        (value-coproductⱽ UnitTy UnitTy) ≡ [+I1]
+    value-σ₁≡[+I1] = Cop.rectifyOut {e' = refl}
+      (Cop.reind-filler⁻ (Category.⋆IdR (KIND ^op) _)
+      ∙ Cop.≡in {pth = refl} (IdRS [+I1]))
+
+    value-σ₂≡[+I2] :
+      BinProductⱽNotation.π₂ (CBPV ^opᴰ)
+        (value-coproductⱽ UnitTy UnitTy) ≡ [+I2]
+    value-σ₂≡[+I2] = Cop.rectifyOut {e' = refl}
+      (Cop.reind-filler⁻ (Category.⋆IdR (KIND ^op) _)
+      ∙ Cop.≡in {pth = refl} (IdRS [+I2]))
+
+    CanonicalBool : Tm tt UnitTy BoolTy → Type L
+    CanonicalBool V =
+      fiber (λ (V₁ : Tm tt UnitTy UnitTy) → seqS V₁ inl') V
+      ⊎ fiber (λ (V₂ : Tm tt UnitTy UnitTy) → seqS V₂ inr') V
+
+    inspect-Bool : ∀ V → ⟨ LogicalRelation BoolTy V ⟩ → CanonicalBool V
+    inspect-Bool V (inl (V₁ , p , _)) =
+      inl (V₁ , sym (cong (seqS V₁) value-σ₁≡[+I1]) ∙ p)
+    inspect-Bool V (inr (V₂ , p , _)) =
+      inr (V₂ , sym (cong (seqS V₂) value-σ₂≡[+I2]) ∙ p)
+
+    canonicalBool : ∀ V → ⟨ LogicalRelation BoolTy V ⟩
+      → Σ[ b ∈ Bool ] V ≡ quoteBool b
+    canonicalBool V related = Sum.rec
+      (λ (V₁ , V₁-inl≡V) → true ,
+        sym V₁-inl≡V
+        ∙ cong (λ W → seqS W inl') ([1η] V₁ ∙ sym ([1η] idS))
+        ∙ IdLS inl')
+      (λ (V₂ , V₂-inr≡V) → false ,
+        sym V₂-inr≡V
+        ∙ cong (λ W → seqS W inr') ([1η] V₂ ∙ sym ([1η] idS))
+        ∙ IdLS inr')
+      (inspect-Bool V related)
+
+  RawFBool : Tm tt UnitTy ([F] BoolTy) → Type L
+  RawFBool M = ⟨ LogicalRelation ([F] BoolTy) M ⟩
+
+  raw-FBool : ∀ M → RawFBool M
+  raw-FBool = fundamentalAt
+
+  interpretFreeBool :
+    FreeAlgebra Bool .fst → Tm tt UnitTy ([F] BoolTy)
+  interpretFreeBool = recFA
+    (_ , AlgebraEff UnitTy ([F] BoolTy))
+    (λ b → seqS (quoteBool b) [ret]) .fst
+
+  private
+    rawTerm : ∀ {M} → RawFBool M
+      → |FreeAlgebra| (Tm tt UnitTy BoolTy)
+    rawTerm raw = raw .fst
+
+    rawRelated : ∀ {M} (raw : RawFBool M)
+      → |FreeAlgebraᴰ|
+          (λ V → ⟨ LogicalRelation BoolTy V ⟩)
+          (rawTerm raw)
+    rawRelated raw = raw .snd .snd
+
+    rawEquation : ∀ {M} (raw : RawFBool M)
+      → recFA (_ , AlgebraEff UnitTy ([F] BoolTy))
+          (λ V → seqS V [ret]') .fst (rawTerm raw) ≡ M
+    rawEquation raw = raw .snd .fst
+
+    rawRec : Homo
+      (FreeAlgebra (Tm tt UnitTy BoolTy))
+      (_ , AlgebraEff UnitTy ([F] BoolTy))
+    rawRec = recFA (_ , AlgebraEff UnitTy ([F] BoolTy))
+      (λ V → seqS V [ret]')
+
+    realizeTree : ∀ {t}
+      → |FreeAlgebraᴰ| (λ V → ⟨ LogicalRelation BoolTy V ⟩) t
+      → fiber interpretFreeBool (rawRec .fst t)
+    realizeTree (|FreeAlgebraᴰ|.var {x = V} Vᴰ) .fst =
+      |FreeAlgebra|.var (canonicalBool V Vᴰ .fst)
+    realizeTree (|FreeAlgebraᴰ|.var {x = V} Vᴰ) .snd =
+      cong₂ seqS
+        (sym (canonicalBool V Vᴰ .snd))
+        (sym [ret]'≡ret)
+    realizeTree
+      (|FreeAlgebraᴰ|.app op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩) .fst =
+        |FreeAlgebra|.app op (λ v → realizeTree (γᴰ v) .fst)
+    realizeTree
+      (|FreeAlgebraᴰ|.app op γ γᴰ op⟨γ⟩ op∘γ≡op⟨γ⟩) .snd =
+        cong ([op] op) (funExt λ v → realizeTree (γᴰ v) .snd)
+        ∙ rawRec .snd op γ op⟨γ⟩ op∘γ≡op⟨γ⟩
+
+    realizeRaw : ∀ {M} (raw : RawFBool M)
+      → fiber interpretFreeBool M
+    realizeRaw raw .fst = realizeTree (rawRelated raw) .fst
+    realizeRaw raw .snd =
+      realizeTree (rawRelated raw) .snd ∙ rawEquation raw
+
+  closed-FBool-surjective : ∀ M → fiber interpretFreeBool M
+  closed-FBool-surjective M = realizeRaw (raw-FBool M)
+
+  unquote-FBool : Tm tt UnitTy ([F] BoolTy) → FreeAlgebra Bool .fst
+  unquote-FBool M = closed-FBool-surjective M .fst
+
+open BoolAlgebraSyntax public

--- a/Gluing/CBPV/Model/Additive.agda
+++ b/Gluing/CBPV/Model/Additive.agda
@@ -1,0 +1,380 @@
+{-# OPTIONS --prop --lossy-unification #-}
+module Gluing.CBPV.Model.Additive where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.Function
+open import Cubical.Foundations.Equiv
+open import Cubical.Foundations.HLevels
+open import Cubical.Foundations.Isomorphism.More
+open import Cubical.Foundations.Structure
+
+open import Cubical.Prop
+
+open import Cubical.Data.Bool as Bool hiding (elim)
+open import Cubical.Data.Sigma
+open import Cubical.Data.Sum as Sum
+open import Cubical.Data.Unit
+
+open import Cubical.Algebra.Theory.Base
+  hiding (ℓ; ℓᴰ; ℓᴰᴰ; ℓ'; ℓᴰ'; ℓᴰᴰ'; ℓ''; ℓᴰ''; ℓO; ℓA; ℓE)
+
+open import Cubical.Categories.Category
+open import Cubical.Categories.Functor
+open import Cubical.Categories.Instances.TotalCategory hiding (elim)
+open import Cubical.Categories.Instances.WalkingArrow
+  renaming (WalkingArrow to KIND; Vertex to Kind; l to 𝒱; r to 𝒞;
+    ≤Vertex to ≤Kind)
+open import Cubical.Categories.Presheaf.Representable
+
+open import Cubical.Categories.Displayed.Base
+open import Cubical.Categories.Displayed.Functor
+open import Cubical.Categories.Displayed.Section.Base
+  renaming (Section to DisplayedSection)
+open import Cubical.Categories.Displayed.Instances.Opposite
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.Fibration
+open import Cubical.Categories.Displayed.Presheaf.Uncurried.UniversalProperties
+open import Cubical.Categories.Displayed.CBPV.Unary.Base
+open import Cubical.Categories.Displayed.CBPV.Unary.Enrichment.Model
+open import Cubical.Categories.Displayed.CBPV.Unary.Instances.Model.Base
+open import Cubical.Categories.Displayed.CBPV.Unary.Instances.Model.Multiplicative
+open import Cubical.Categories.Displayed.CBPV.Unary.Instances.Model.Additive
+open import Cubical.Categories.Displayed.CBPV.Unary.Instances.Free.ModelEnriched.Additive
+open import Cubical.Categories.Displayed.Instances.Algebra.Model
+open import Cubical.Categories.Displayed.Instances.Algebra.DisplayedModel
+
+open Category
+open Functor
+open Functorᴰ
+open DisplayedSection
+
+private
+  variable
+    ℓO ℓA ℓE ℓEA : Level
+
+-- The logical-relations model is parameterized by the ordinary and displayed
+-- free-model universal properties used to interpret F.
+module ModelGluingWithFree
+  (T : Theory ℓO ℓA ℓE ℓEA)
+  (Free : FreeMODELConstruction T)
+  (BaseTy : Kind → Type (ModelLevel T))
+  (Fun : ∀ {k₁ k₂} → ≤Kind k₁ k₂
+    → CBPV.Ob T BaseTy k₁ → CBPV.Ob T BaseTy k₂
+    → Type (ModelLevel T))
+  (I : CBPV.Ob T BaseTy 𝒱)
+  where
+  open CBPV T BaseTy
+  open Terms Fun
+
+  pts : Functorⱽ (AddCBPV .fst .fst)
+    (ModelAddCBPVWithFree T (Free .fst) .fst .fst)
+  pts = points T (AddCBPV .fst .fst) CBPVModel I
+
+  ptsPreservesModel : PreservesModelEnrichment T pts
+    CBPVModel (ModelCBPVModel T)
+  ptsPreservesModel =
+    pointsPreservesModel T (AddCBPV .fst .fst) CBPVModel I
+
+-- The Boolean canonicity theorem additionally chooses the desired concrete
+-- presentation of the free model on Bool.  It need not be the same datatype
+-- used internally by the free adjunction above.
+module BoolModelSyntaxWithFree
+  (T : Theory ℓO ℓA ℓE ℓEA)
+  (Free : FreeMODELConstruction T)
+  (FreeBool : BoolFreeMODELConstruction T)
+  where
+  open Theory T
+
+  private
+    L = ModelLevel T
+
+  data BaseTy (k : Kind) : Type L where
+
+  open CBPV T BaseTy
+
+  data FUN : ∀ {k₁ k₂} → ≤Kind k₁ k₂
+    → Ob k₁ → Ob k₂ → Type L where
+
+  open Terms FUN public
+
+  UnitTy BoolTy : VTy
+  UnitTy = [1]
+  BoolTy = UnitTy [+] UnitTy
+
+  private
+    inl' inr' : Tm tt UnitTy BoolTy
+    inl' = [+I1]
+    inr' = [+I2]
+
+  tru fls : Tm tt UnitTy BoolTy
+  tru = inl'
+  fls = inr'
+
+  quoteBool : Bool → Tm tt UnitTy BoolTy
+  quoteBool false = fls
+  quoteBool true = tru
+
+  module G = ModelGluingWithFree T Free BaseTy FUN UnitTy
+
+  module Fundamental = LocalElim
+    G.pts
+    (ModelAddCBPVⱽWithFree T Free)
+    (ModelCBPVModel T)
+    G.ptsPreservesModel
+    (ModelCBPVModelᴰ T)
+
+  baseObject : ∀ {k} (X : BaseTy k)
+    → Categoryᴰ.ob[_] (ModelAddCBPVⱽWithFree T Free .fst .fst)
+        (k , G.pts .F-obᴰ (gen X))
+  baseObject ()
+
+  fundamentalLemma :
+    DisplayedSection (∫F G.pts)
+      (ModelAddCBPVⱽWithFree T Free .fst .fst)
+  fundamentalLemma = Fundamental.localElim baseObject λ ()
+
+  LogicalRelation : ∀ {k} (Γ : Ob k)
+    → Tm tt UnitTy Γ → hSet L
+  LogicalRelation {k = 𝒱} Γ = Fundamental.local-obᴰ baseObject Γ
+  LogicalRelation {k = 𝒞} Γ = Fundamental.local-obᴰ baseObject Γ .fst
+
+  fundamentalAt : ∀ {k} {Γ : Ob k} (M : Tm tt UnitTy Γ)
+    → ⟨ LogicalRelation Γ M ⟩
+  fundamentalAt {k = 𝒱} {Γ = Γ} M = subst
+    (λ N → ⟨ LogicalRelation Γ N ⟩)
+    (IdLS M) $
+    fundamentalLemma .F-homᴰ (_ , M) idS tt*
+  fundamentalAt {k = 𝒞} {Γ = Γ} M = subst
+    (λ N → ⟨ LogicalRelation Γ N ⟩)
+    (IdLS M) $
+    fundamentalLemma .F-homᴰ (_ , M) idS tt*
+
+  private
+    [ret]' : Tm tt BoolTy ([F] BoolTy)
+    [ret]' = CartesianLiftNotation.πⱽ (CBPV ^opᴰ)
+      (MultCBPV .snd .snd BoolTy)
+
+    [ret]'≡ret : [ret]' ≡ [ret]
+    [ret]'≡ret = cong snd
+      (Cop.reind-filler⁻ _
+      ∙ Cop.≡in {pth = refl} (IdRS [ret]))
+
+    value-σ₁≡[+I1] :
+      BinProductⱽNotation.π₁ (CBPV ^opᴰ)
+        (value-coproductⱽ UnitTy UnitTy) ≡ [+I1]
+    value-σ₁≡[+I1] = Cop.rectifyOut {e' = refl}
+      (Cop.reind-filler⁻ (Category.⋆IdR (KIND ^op) _)
+      ∙ Cop.≡in {pth = refl} (IdRS [+I1]))
+
+    value-σ₂≡[+I2] :
+      BinProductⱽNotation.π₂ (CBPV ^opᴰ)
+        (value-coproductⱽ UnitTy UnitTy) ≡ [+I2]
+    value-σ₂≡[+I2] = Cop.rectifyOut {e' = refl}
+      (Cop.reind-filler⁻ (Category.⋆IdR (KIND ^op) _)
+      ∙ Cop.≡in {pth = refl} (IdRS [+I2]))
+
+    CanonicalBool : Tm tt UnitTy BoolTy → Type L
+    CanonicalBool V =
+      fiber (λ (V₁ : Tm tt UnitTy UnitTy) → seqS V₁ inl') V
+      ⊎ fiber (λ (V₂ : Tm tt UnitTy UnitTy) → seqS V₂ inr') V
+
+    inspect-Bool : ∀ V → ⟨ LogicalRelation BoolTy V ⟩ → CanonicalBool V
+    inspect-Bool V (inl (V₁ , p , _)) =
+      inl (V₁ , sym (cong (seqS V₁) value-σ₁≡[+I1]) ∙ p)
+    inspect-Bool V (inr (V₂ , p , _)) =
+      inr (V₂ , sym (cong (seqS V₂) value-σ₂≡[+I2]) ∙ p)
+
+    canonicalBool : ∀ V → ⟨ LogicalRelation BoolTy V ⟩
+      → Σ[ b ∈ Bool ] V ≡ quoteBool b
+    canonicalBool V related = Sum.rec
+      (λ (V₁ , V₁-inl≡V) → true ,
+        sym V₁-inl≡V
+        ∙ cong (λ W → seqS W inl') ([1η] V₁ ∙ sym ([1η] idS))
+        ∙ IdLS inl')
+      (λ (V₂ , V₂-inr≡V) → false ,
+        sym V₂-inr≡V
+        ∙ cong (λ W → seqS W inr') ([1η] V₂ ∙ sym ([1η] idS))
+        ∙ IdLS inr')
+      (inspect-Bool V related)
+
+  RawFBool : Tm tt UnitTy ([F] BoolTy) → Type L
+  RawFBool M = ⟨ LogicalRelation ([F] BoolTy) M ⟩
+
+  raw-FBool : ∀ M → RawFBool M
+  raw-FBool = fundamentalAt
+
+  private
+    SyntaxModel : Model L
+    SyntaxModel =
+      ModelEnrichmentModel CBPV T CBPVModel UnitTy ([F] BoolTy)
+
+    SyntaxMODEL : Category.ob (MODEL T L)
+    SyntaxMODEL .fst = SyntaxModel .fst .fst , SyntaxModel .snd .snd
+    SyntaxMODEL .snd .fst = SyntaxModel .fst .snd
+    SyntaxMODEL .snd .snd = SyntaxModel .snd .fst
+
+    SyntaxBoolSET : hSet L
+    SyntaxBoolSET = G.pts .F-obᴰ BoolTy
+
+    SyntaxBoolRelation : ⟨ SyntaxBoolSET ⟩ → hSet L
+    SyntaxBoolRelation = LogicalRelation BoolTy
+
+    RawFreeMODEL : Category.ob (MODEL T L)
+    RawFreeMODEL = Free .fst SyntaxBoolSET .UniversalElement.vertex
+
+    RawFreeLift : CartesianLift
+      ((ModelCBPVᴰWithFree T (Free .fst)) ^opᴰᴰ)
+      (FreeMODELη T (Free .fst) SyntaxBoolSET) SyntaxBoolRelation
+    RawFreeLift = Free .snd SyntaxBoolSET SyntaxBoolRelation
+
+    RawFreeMODELᴰ : Categoryᴰ.ob[_] (MODELᴰ T L L) RawFreeMODEL
+    RawFreeMODELᴰ = RawFreeLift .fst
+
+    rawRec : MODEL T L [ RawFreeMODEL , SyntaxMODEL ]
+    rawRec = isEquivToIsIso _
+      (Free .fst SyntaxBoolSET .UniversalElement.universal SyntaxMODEL)
+      .fst (λ V → seqS V [ret]')
+
+    rawβ :
+      (λ V → rawRec .fst
+        (Free .fst SyntaxBoolSET .UniversalElement.element V))
+      ≡ (λ V → seqS V [ret]')
+    rawβ = isEquivToIsIso _
+      (Free .fst SyntaxBoolSET .UniversalElement.universal SyntaxMODEL)
+      .snd .fst (λ V → seqS V [ret]')
+
+    FreeBoolMODEL : Category.ob (MODEL T L)
+    FreeBoolMODEL = FreeBool .fst
+
+    ηBool : Bool → ⟨ FreeBoolMODEL .fst ⟩
+    ηBool = FreeBool .snd .fst
+
+    interpretFreeBoolHomo : MODEL T L [ FreeBoolMODEL , SyntaxMODEL ]
+    interpretFreeBoolHomo = isEquivToIsIso _
+      (FreeBool .snd .snd SyntaxMODEL) .fst
+      (λ b → seqS (quoteBool b) [ret])
+
+    interpretβ : (λ b → interpretFreeBoolHomo .fst (ηBool b))
+      ≡ (λ b → seqS (quoteBool b) [ret])
+    interpretβ = isEquivToIsIso _
+      (FreeBool .snd .snd SyntaxMODEL) .snd .fst
+      (λ b → seqS (quoteBool b) [ret])
+
+  interpretFreeBool :
+    ⟨ FreeBoolMODEL .fst ⟩ → Tm tt UnitTy ([F] BoolTy)
+  interpretFreeBool = interpretFreeBoolHomo .fst
+
+  private
+    rawTerm : ∀ {M} → RawFBool M
+      → ⟨ RawFreeMODEL .fst ⟩
+    rawTerm raw = raw .fst
+
+    rawRelated : ∀ {M} (raw : RawFBool M)
+      → ⟨ RawFreeMODELᴰ .fst (rawTerm raw) ⟩
+    rawRelated raw = raw .snd .snd
+
+    rawEquation : ∀ {M} (raw : RawFBool M)
+      → rawRec .fst (rawTerm raw) ≡ M
+    rawEquation raw = raw .snd .fst
+
+    UnitFreeBoolMODELᴰ :
+      Categoryᴰ.ob[_] (MODELᴰ T L L) FreeBoolMODEL
+    UnitFreeBoolMODELᴰ = TerminalsⱽMODELᴰ T FreeBoolMODEL .fst
+
+    RealizerMODELᴰ : Categoryᴰ.ob[_] (MODELᴰ T L L) SyntaxMODEL
+    RealizerMODELᴰ =
+      PushMODELᴰ T interpretFreeBoolHomo UnitFreeBoolMODELᴰ
+
+    RealizerModelᴰ : Modelᴰ SyntaxModel L
+    RealizerModelᴰ .fst .fst M = ⟨ RealizerMODELᴰ .fst M ⟩
+    RealizerModelᴰ .fst .snd = RealizerMODELᴰ .snd .fst
+    RealizerModelᴰ .snd .fst = RealizerMODELᴰ .snd .snd
+    RealizerModelᴰ .snd .snd M = RealizerMODELᴰ .fst M .snd
+
+    realizeVar : ∀ V → ⟨ LogicalRelation BoolTy V ⟩
+      → RealizerModelᴰ .fst .fst
+          (rawRec .fst
+            (Free .fst SyntaxBoolSET .UniversalElement.element V))
+    realizeVar V Vᴰ .fst =
+      ηBool (canonicalBool V Vᴰ .fst)
+    realizeVar V Vᴰ .snd .fst =
+      funExt⁻ interpretβ (canonicalBool V Vᴰ .fst)
+      ∙ cong₂ seqS
+          (sym (canonicalBool V Vᴰ .snd))
+          (sym [ret]'≡ret)
+      ∙ sym (funExt⁻ rawβ V)
+    realizeVar V Vᴰ .snd .snd = tt*
+
+    module ModelCop = Category
+      (∫C (ModelCBPVWithFree T (Free .fst) .fst ^opᴰ))
+
+    rawRecᵒᵖ : ∫C (ModelCBPVWithFree T (Free .fst) .fst ^opᴰ)
+      [ (Kind.r , SyntaxMODEL) , (Kind.r , RawFreeMODEL) ]
+    rawRecᵒᵖ = _ , rawRec
+
+    rawFactor : ∫C (ModelCBPVWithFree T (Free .fst) .fst ^opᴰ)
+      [ (Kind.r , SyntaxMODEL) , (Kind.l , SyntaxBoolSET) ]
+    rawFactor = rawRecᵒᵖ ModelCop.⋆
+      FreeMODELη T (Free .fst) SyntaxBoolSET
+
+    realizeGenerator : Categoryᴰ.Hom[_][_,_]
+      ((ModelCBPVᴰWithFree T (Free .fst)) ^opᴰᴰ)
+      rawFactor RealizerMODELᴰ SyntaxBoolRelation
+    realizeGenerator = realizeVar
+
+    -- Use the displayed free-model universal property to extend the
+    -- generator realization.  This is the only recursion over the chosen
+    -- free displayed model, so the proof never inspects its constructors.
+    realizeFreeᴰᵒᵖ : Categoryᴰ.Hom[_][_,_]
+      ((ModelCBPVᴰWithFree T (Free .fst)) ^opᴰᴰ)
+      rawRecᵒᵖ RealizerMODELᴰ RawFreeMODELᴰ
+    realizeFreeᴰᵒᵖ =
+      CartesianLiftNotation.introᴰ
+        ((ModelCBPVᴰWithFree T (Free .fst)) ^opᴰᴰ)
+        RawFreeLift
+        {Γ = (Kind.r , SyntaxMODEL)}
+        {Γᴰ = RealizerMODELᴰ}
+        {g = rawRecᵒᵖ}
+        realizeGenerator
+
+    realizeTreeᴰ : ∀ {t} → ⟨ RawFreeMODELᴰ .fst t ⟩
+      → RealizerModelᴰ .fst .fst (rawRec .fst t)
+    realizeTreeᴰ {t = t} tᴰ = realizeFreeᴰᵒᵖ .fst t tᴰ
+
+    realizeTree : ∀ {t}
+      → ⟨ RawFreeMODELᴰ .fst t ⟩
+      → fiber interpretFreeBool (rawRec .fst t)
+    realizeTree tᴰ .fst = realizeTreeᴰ tᴰ .fst
+    realizeTree tᴰ .snd = realizeTreeᴰ tᴰ .snd .fst
+
+    realizeRaw : ∀ {M} (raw : RawFBool M)
+      → fiber interpretFreeBool M
+    realizeRaw raw .fst = realizeTree (rawRelated raw) .fst
+    realizeRaw raw .snd =
+      realizeTree (rawRelated raw) .snd ∙ rawEquation raw
+
+  closed-FBool-surjective : ∀ M → fiber interpretFreeBool M
+  closed-FBool-surjective M = realizeRaw (raw-FBool M)
+
+  unquote-FBool : Tm tt UnitTy ([F] BoolTy)
+    → ⟨ FreeBool .fst .fst ⟩
+  unquote-FBool M = closed-FBool-surjective M .fst
+
+module ModelGluing
+  {ℓO ℓA ℓE ℓEA : Level}
+  (T : Theory ℓO ℓA ℓE ℓEA)
+  (BaseTy : Kind → Type (ModelLevel T))
+  (Fun : ∀ {k₁ k₂} → ≤Kind k₁ k₂
+    → CBPV.Ob T BaseTy k₁ → CBPV.Ob T BaseTy k₂
+    → Type (ModelLevel T))
+  (I : CBPV.Ob T BaseTy Kind.l) =
+  ModelGluingWithFree T (CanonicalFreeMODELConstruction T)
+    BaseTy Fun I
+
+module BoolModelSyntax
+  {ℓO ℓA ℓE ℓEA : Level}
+  (T : Theory ℓO ℓA ℓE ℓEA) =
+  BoolModelSyntaxWithFree T
+    (CanonicalFreeMODELConstruction T)
+    (CanonicalBoolFreeMODELConstruction T)
+
+open BoolModelSyntax public

--- a/Gluing/CBPV/Model/Concrete.agda
+++ b/Gluing/CBPV/Model/Concrete.agda
@@ -10,6 +10,7 @@ open import Cubical.Algebra.Monoid.Base
 import Cubical.Algebra.Theory.Instances.Reader as Reader
 import Cubical.Algebra.Theory.Instances.State as State
 import Cubical.Algebra.Theory.Instances.Writer as Writer
+import Cubical.Algebra.Theory.Instances.Monoid as FreeMonoid
 
 open import Cubical.Categories.Displayed.CBPV.Unary.Instances.Model.Multiplicative
 import Cubical.Categories.Displayed.CBPV.Unary.Instances.Model.ConcreteFree as Concrete
@@ -108,3 +109,33 @@ module StateBoolModelSyntax {ℓS : Level} (Store : hSet ℓS) =
     (State.StateTheory (Store .fst))
     (StateFreeMODELConstruction Store)
     (StateBoolFreeMODELConstruction Store)
+
+MonoidFreeMODELConstruction :
+  FreeMODELConstruction FreeMonoid.MonoidTheory
+MonoidFreeMODELConstruction =
+  Concrete.ConcreteFreeMODELConstruction
+    FreeMonoid.MonoidTheory
+    (λ A → FreeMonoid.ListFreeModel A)
+    (λ A → FreeMonoid.ListFreeModelη A)
+    (λ A B → FreeMonoid.ListFreeModelUniversal A B)
+    (λ A Aᴰ → FreeMonoid.ListFreeModelᴰ A Aᴰ)
+    (λ A Aᴰ → FreeMonoid.ListFreeModelηᴰ A Aᴰ)
+    (λ A Aᴰ {B} ϕ Bᴰ →
+      FreeMonoid.ListFreeModelUniversalOverᴰ A Aᴰ ϕ Bᴰ)
+
+MonoidBoolFreeMODELConstruction :
+  BoolFreeMODELConstruction FreeMonoid.MonoidTheory
+MonoidBoolFreeMODELConstruction .fst =
+  Concrete.Model→MODEL FreeMonoid.MonoidTheory
+    (FreeMonoid.ListFreeModel (Bool , isSetBool))
+MonoidBoolFreeMODELConstruction .snd .fst =
+  FreeMonoid.ListFreeModelη (Bool , isSetBool)
+MonoidBoolFreeMODELConstruction .snd .snd B =
+  FreeMonoid.ListFreeModelUniversal (Bool , isSetBool)
+    (Concrete.MODEL→Model FreeMonoid.MonoidTheory B)
+
+module MonoidBoolModelSyntax =
+  Generic.BoolModelSyntaxWithFree
+    FreeMonoid.MonoidTheory
+    MonoidFreeMODELConstruction
+    MonoidBoolFreeMODELConstruction

--- a/Gluing/CBPV/Model/Concrete.agda
+++ b/Gluing/CBPV/Model/Concrete.agda
@@ -1,0 +1,110 @@
+{-# OPTIONS --prop --lossy-unification #-}
+module Gluing.CBPV.Model.Concrete where
+
+open import Cubical.Foundations.Prelude
+open import Cubical.Foundations.HLevels
+
+open import Cubical.Data.Bool
+
+open import Cubical.Algebra.Monoid.Base
+import Cubical.Algebra.Theory.Instances.Reader as Reader
+import Cubical.Algebra.Theory.Instances.State as State
+import Cubical.Algebra.Theory.Instances.Writer as Writer
+
+open import Cubical.Categories.Displayed.CBPV.Unary.Instances.Model.Multiplicative
+import Cubical.Categories.Displayed.CBPV.Unary.Instances.Model.ConcreteFree as Concrete
+import Gluing.CBPV.Model.Additive as Generic
+
+private
+  variable
+    ℓR ℓS ℓW : Level
+
+ReaderFreeMODELConstruction : (Env : Type ℓR) →
+  FreeMODELConstruction (Reader.ReaderTheory Env)
+ReaderFreeMODELConstruction Env =
+  Concrete.ConcreteFreeMODELConstruction
+    (Reader.ReaderTheory Env)
+    (λ A → Reader.ReaderFreeModel Env A)
+    (λ A → Reader.ReaderFreeModelη Env A)
+    (λ A B → Reader.ReaderFreeModelUniversal Env A B)
+    (λ A Aᴰ → Reader.ReaderFreeModelᴰ Env A Aᴰ)
+    (λ A Aᴰ → Reader.ReaderFreeModelηᴰ Env A Aᴰ)
+    (λ A Aᴰ {B} ϕ Bᴰ →
+      Reader.ReaderFreeModelUniversalOverᴰ Env A Aᴰ ϕ Bᴰ)
+
+ReaderBoolFreeMODELConstruction : (Env : Type ℓR) →
+  BoolFreeMODELConstruction (Reader.ReaderTheory Env)
+ReaderBoolFreeMODELConstruction Env .fst =
+  Concrete.Model→MODEL (Reader.ReaderTheory Env)
+    (Reader.ReaderFreeModel Env (Bool , isSetBool))
+ReaderBoolFreeMODELConstruction Env .snd .fst =
+  Reader.ReaderFreeModelη Env (Bool , isSetBool)
+ReaderBoolFreeMODELConstruction Env .snd .snd B =
+  Reader.ReaderFreeModelUniversal Env (Bool , isSetBool)
+    (Concrete.MODEL→Model (Reader.ReaderTheory Env) B)
+
+module ReaderBoolModelSyntax {ℓR : Level} (Env : Type ℓR) =
+  Generic.BoolModelSyntaxWithFree
+    (Reader.ReaderTheory Env)
+    (ReaderFreeMODELConstruction Env)
+    (ReaderBoolFreeMODELConstruction Env)
+
+WriterFreeMODELConstruction : (W : Monoid ℓW) →
+  FreeMODELConstruction (Writer.WriterTheory W)
+WriterFreeMODELConstruction W =
+  Concrete.ConcreteFreeMODELConstruction
+    (Writer.WriterTheory W)
+    (λ A → Writer.WriterFreeModel W A)
+    (λ A → Writer.WriterFreeModelη W A)
+    (λ A B → Writer.WriterFreeModelUniversal W A B)
+    (λ A Aᴰ → Writer.WriterFreeModelᴰ W A Aᴰ)
+    (λ A Aᴰ → Writer.WriterFreeModelηᴰ W A Aᴰ)
+    (λ A Aᴰ {B} ϕ Bᴰ →
+      Writer.WriterFreeModelUniversalOverᴰ W A Aᴰ ϕ Bᴰ)
+
+WriterBoolFreeMODELConstruction : (W : Monoid ℓW) →
+  BoolFreeMODELConstruction (Writer.WriterTheory W)
+WriterBoolFreeMODELConstruction W .fst =
+  Concrete.Model→MODEL (Writer.WriterTheory W)
+    (Writer.WriterFreeModel W (Bool , isSetBool))
+WriterBoolFreeMODELConstruction W .snd .fst =
+  Writer.WriterFreeModelη W (Bool , isSetBool)
+WriterBoolFreeMODELConstruction W .snd .snd B =
+  Writer.WriterFreeModelUniversal W (Bool , isSetBool)
+    (Concrete.MODEL→Model (Writer.WriterTheory W) B)
+
+module WriterBoolModelSyntax {ℓW : Level} (W : Monoid ℓW) =
+  Generic.BoolModelSyntaxWithFree
+    (Writer.WriterTheory W)
+    (WriterFreeMODELConstruction W)
+    (WriterBoolFreeMODELConstruction W)
+
+StateFreeMODELConstruction : (Store : hSet ℓS) →
+  FreeMODELConstruction (State.StateTheory (Store .fst))
+StateFreeMODELConstruction Store =
+  Concrete.ConcreteFreeMODELConstruction
+    (State.StateTheory (Store .fst))
+    (λ A → State.StateFreeModel Store A)
+    (λ A → State.StateFreeModelη Store A)
+    (λ A B → State.StateFreeModelUniversal Store A B)
+    (λ A Aᴰ → State.StateFreeModelᴰ Store A Aᴰ)
+    (λ A Aᴰ → State.StateFreeModelηᴰ Store A Aᴰ)
+    (λ A Aᴰ {B} ϕ Bᴰ →
+      State.StateFreeModelUniversalOverᴰ Store A Aᴰ ϕ Bᴰ)
+
+StateBoolFreeMODELConstruction : (Store : hSet ℓS) →
+  BoolFreeMODELConstruction (State.StateTheory (Store .fst))
+StateBoolFreeMODELConstruction Store .fst =
+  Concrete.Model→MODEL (State.StateTheory (Store .fst))
+    (State.StateFreeModel Store (Bool , isSetBool))
+StateBoolFreeMODELConstruction Store .snd .fst =
+  State.StateFreeModelη Store (Bool , isSetBool)
+StateBoolFreeMODELConstruction Store .snd .snd B =
+  State.StateFreeModelUniversal Store (Bool , isSetBool)
+    (Concrete.MODEL→Model (State.StateTheory (Store .fst)) B)
+
+module StateBoolModelSyntax {ℓS : Level} (Store : hSet ℓS) =
+  Generic.BoolModelSyntaxWithFree
+    (State.StateTheory (Store .fst))
+    (StateFreeMODELConstruction Store)
+    (StateBoolFreeMODELConstruction Store)


### PR DESCRIPTION
This PR abstracts the concrete state-algebra enrichment to enrichment in models of arbitrary algebraic theories. Includes nice definitions (i.e., strictly assoc/unital) of algebras, models, homomorphisms, etc. I made some attempt to unify sections and homomorphisms but couldn't quite get all the way there: there seems to be a pretty fundamental obstruction to unifying sections and displayed homomorphisms.

Gives also a parameterized CBPV syntax for enrichment in algebras/models and a generic gluing theorem for it. We can instantiate this gluing theorem with a concrete construction of free algebras and displayed free algebras to get out the concrete CBPV canonicity theorems we want.

There's some duplication in the definition and metatheory of enrichment. I'm working on fixing that in a followup PR so I'm just going to keep it temporarily for this one.